### PR TITLE
Implemented interfaces for Frame, Hand, Finger, Bone and Arm,  along …

### DIFF
--- a/Assets/LeapC/Arm.cs
+++ b/Assets/LeapC/Arm.cs
@@ -15,7 +15,7 @@ using System.Runtime.InteropServices;
    *
    */
 
-public class Arm : Bone {
+public class Arm : Bone, IArm {
 
    /**
     * Constructs an invalid Arm object.
@@ -46,13 +46,19 @@ public class Arm : Bone {
                             type,
                             basis){}
 
-        public new Arm TransformedCopy(Matrix trs){
+        public new IArm TransformedShallowCopy(ref Matrix trs)
+        {
+            return new TransformedArm(ref trs, this);
+        }
+
+        public new IArm TransformedCopy(ref Matrix trs)
+        {
             float dScale = trs.zBasis.Magnitude;
             float hScale = trs.xBasis.Magnitude;
             return new Arm(trs.TransformPoint(PrevJoint),
                 trs.TransformPoint(NextJoint),
                 trs.TransformPoint(Center),
-                trs.TransformDirection(Direction),
+                trs.TransformDirection(Direction).Normalized,
                 Length * dScale,
                 Width * hScale,
                 Type,
@@ -69,8 +75,8 @@ public class Arm : Bone {
     * exact same physical arm in the same frame and both Arm objects are valid.
     * @since 2.0.3
     */
-  public bool Equals(Arm other) {
-    return base.Equals(other as Bone);
+  public bool Equals(IArm other) {
+    return base.Equals(other as IBone);
   }
 
    /**
@@ -138,9 +144,11 @@ public class Arm : Bone {
      * @returns The invalid Arm instance.
      * @since 2.0.3
      */  
-      new  public static Arm Invalid {
+        private static IArm invalidArm = new InvalidArm();
+
+      new  public static IArm Invalid {
     get {
-      return new Arm();
+        return invalidArm;
     } 
   }
 

--- a/Assets/LeapC/Asserter.cs
+++ b/Assets/LeapC/Asserter.cs
@@ -1,0 +1,176 @@
+﻿using UnityEngine;
+using UnityEngine.Assertions;
+using System.Collections;
+
+namespace Leap
+{
+    public class Asserter
+    {
+        public static void CompareAllValues(IFrame reference, IFrame previousFrame, IFrame value, IFrame previousValueFrame)
+        {
+            Assert.AreEqual(value.IsValid, reference.IsValid);
+
+            //if (value.IsValid == false)
+            //    return;
+
+            Assert.AreEqual(value.Id, reference.Id);
+            Assert.AreEqual(reference.CurrentFramesPerSecond, value.CurrentFramesPerSecond);
+
+            Assert.AreEqual(reference.RotationAngle(previousFrame), value.RotationAngle(previousValueFrame));
+            Assert.AreEqual(reference.RotationAngle(previousFrame, Vector.Forward), value.RotationAngle(previousValueFrame, Vector.Forward));
+            Assert.AreEqual(reference.RotationAngle(previousFrame, Vector.Backward), value.RotationAngle(previousValueFrame, Vector.Backward));
+            Assert.AreEqual(reference.RotationAngle(previousFrame, Vector.Left), value.RotationAngle(previousValueFrame, Vector.Left));
+            Assert.AreEqual(reference.RotationAngle(previousFrame, Vector.Right), value.RotationAngle(previousValueFrame, Vector.Right));
+            Assert.AreEqual(reference.RotationAngle(previousFrame, Vector.Up), value.RotationAngle(previousValueFrame, Vector.Up));
+            Assert.AreEqual(reference.RotationAngle(previousFrame, Vector.Down), value.RotationAngle(previousValueFrame, Vector.Down));
+
+            Assert.AreEqual(reference.RotationAxis(previousFrame), value.RotationAxis(previousValueFrame));
+            Assert.AreEqual(reference.RotationMatrix(previousFrame), value.RotationMatrix(previousValueFrame));
+            Assert.AreEqual(reference.RotationProbability(previousFrame), value.RotationProbability(previousValueFrame));
+            Assert.AreEqual(reference.ScaleFactor(previousFrame), value.ScaleFactor(previousValueFrame));
+            Assert.AreEqual(reference.ScaleProbability(previousFrame), value.ScaleProbability(previousValueFrame));
+
+            Assert.AreEqual(reference.Translation(previousFrame), value.Translation(previousValueFrame));
+            Assert.AreEqual(reference.TranslationProbability(previousFrame), value.TranslationProbability(previousValueFrame));
+
+            Assert.AreEqual(reference.Timestamp, value.Timestamp);
+
+            Assert.AreEqual(reference.Hands.Count, value.Hands.Count);
+
+            for (int i = 0; i < reference.Hands.Count; i++)
+            {
+                CompareAllValues(reference.Hands[i], previousFrame, value.Hands[i], previousValueFrame);
+            }
+        }
+
+        public static void CompareAllValues(IHand value, IFrame previousFrame, IHand reference, IFrame previousValueFrame)
+        {
+            Assert.AreEqual(value.IsValid, reference.IsValid);
+
+            //if (value.IsValid == false)
+            //    return;
+
+            CompareAllValues(value.Arm, reference.Arm);
+
+            // The original Basis calculation should generate a left-handed
+            // basis for the left hand, and a right-handed base for the
+            // right hand, but there's a bug in it.
+            //Debug.Log("IsLeft? " + value.IsLeft);
+            //Assert.AreEqual(value.Basis, reference.Basis);
+
+            Assert.AreEqual(value.Confidence, reference.Confidence);
+            Assert.AreEqual(value.Direction, reference.Direction);
+
+            Assert.AreEqual(value.FrameId, reference.FrameId);
+            Assert.AreEqual(value.GrabAngle, reference.GrabAngle);
+
+            Assert.AreEqual(value.GrabStrength, reference.GrabStrength);
+
+            Assert.AreEqual(value.Id, reference.Id);
+            Assert.AreEqual(value.IsLeft, reference.IsLeft);
+            Assert.AreEqual(value.IsRight, reference.IsRight);
+
+            Assert.AreEqual(value.PalmNormal, reference.PalmNormal);
+            Assert.AreEqual(value.PalmPosition, reference.PalmPosition);
+            Assert.AreEqual(value.PalmVelocity, reference.PalmVelocity);
+            Assert.AreEqual(value.PalmWidth, reference.PalmWidth);
+
+            Assert.AreEqual(value.PinchDistance, reference.PinchDistance);
+            Assert.AreEqual(value.PinchStrength, reference.PinchStrength);
+
+            Assert.AreEqual(value.RotationAngle(previousFrame), reference.RotationAngle(previousValueFrame));
+            Assert.AreEqual(value.RotationAxis(previousFrame), reference.RotationAxis(previousValueFrame));
+            Assert.AreEqual(value.RotationMatrix(previousFrame), reference.RotationMatrix(previousValueFrame));
+            Assert.AreEqual(value.RotationProbability(previousFrame), reference.RotationProbability(previousValueFrame));
+
+            Assert.AreEqual(value.ScaleFactor(previousFrame), reference.ScaleFactor(previousValueFrame));
+            Assert.AreEqual(value.ScaleProbability(previousFrame), reference.ScaleProbability(previousValueFrame));
+
+            // There are known issues calculating the SphereCenter: it doesn't
+            // scale the minimum and maximum sphere radii. Will be removed next update anyway
+            // Assert.AreEqual(value.SphereCenter ,  reference.SphereCenter);
+            // Assert.AreEqual(value.SphereRadius ,  reference.SphereRadius);
+
+            Assert.AreEqual(value.StabilizedPalmPosition, reference.StabilizedPalmPosition);
+            Assert.AreEqual(value.TimeVisible, reference.TimeVisible);
+
+            Assert.AreEqual(value.Translation(previousFrame), reference.Translation(previousValueFrame));
+            Assert.AreEqual(value.TranslationProbability(previousFrame), reference.TranslationProbability(previousValueFrame));
+            Assert.AreEqual(value.WristPosition, reference.WristPosition);
+
+            for (int i = 0; i < reference.Fingers.Count; i++)
+            {
+                IFinger referenceFinger = reference.Fingers[i];
+
+                CompareAllValues(value.Finger(referenceFinger.Id), referenceFinger);
+            }
+        }
+
+        public static void CompareAllValues(IFinger value, IFinger reference)
+        {
+            Assert.AreEqual(value.IsValid, reference.IsValid);
+
+            //if (value.IsValid == false)
+            //    return;
+
+            Assert.AreEqual(value.Id, reference.Id);
+            Assert.AreEqual(value.FrameId, reference.FrameId);
+            Assert.AreEqual(value.HandId, reference.HandId);
+            Assert.AreEqual(value.TimeVisible, reference.TimeVisible);
+
+            Assert.AreEqual(value.Type, reference.Type);
+            Assert.AreEqual(value.IsExtended, reference.IsExtended);
+
+            Assert.AreEqual(value.Length, reference.Length);
+            Assert.AreEqual(value.Width, reference.Width);
+
+            Assert.AreEqual(value.Direction, reference.Direction);
+
+            Assert.AreEqual(value.StabilizedTipPosition, reference.StabilizedTipPosition);
+            Assert.AreEqual(value.TipPosition, reference.TipPosition);
+            Assert.AreEqual(value.TipVelocity, reference.TipVelocity);
+
+            int i = 0;
+
+            if (reference.Type == Finger.FingerType.TYPE_THUMB)
+                i = 1;
+
+            for (; i < 4; i++)
+            {
+                Bone.BoneType bt = (Bone.BoneType)i;
+
+                CompareAllValues(value.Bone(bt), reference.Bone(bt));
+            }
+        }
+
+        public static void CompareAllValues(IArm value, IArm reference)
+        {
+            Assert.AreEqual(value.IsValid, reference.IsValid);
+
+            if (value.IsValid == false)
+                return;
+
+            Assert.AreEqual(value.ElbowPosition, reference.ElbowPosition);
+            Assert.AreEqual(value.WristPosition, reference.WristPosition);
+
+            CompareAllValues((IBone)value, (IBone)reference);
+        }
+
+        public static void CompareAllValues(IBone value, IBone reference)
+        {
+            Assert.AreEqual(value.IsValid, reference.IsValid);
+
+            if (value.IsValid == false)
+                return;
+
+            Assert.AreEqual(value.Type, reference.Type);
+            Assert.AreEqual(value.Basis, reference.Basis);
+            Assert.AreEqual(value.Center, reference.Center);
+            Assert.AreEqual(value.Direction, reference.Direction);
+            Assert.AreEqual(value.NextJoint, reference.NextJoint);
+            Assert.AreEqual(value.PrevJoint, reference.PrevJoint);
+            Assert.AreEqual(value.Width, reference.Width);
+            Assert.AreEqual(value.Length, reference.Length);
+        }
+    }
+}

--- a/Assets/LeapC/Asserter.cs.meta
+++ b/Assets/LeapC/Asserter.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 43de38aab008b964cb0bcf3ccc9e3ab8
+timeCreated: 1456508844
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapC/Bone.cs
+++ b/Assets/LeapC/Bone.cs
@@ -33,7 +33,7 @@ namespace Leap
    * @since 2.0
    */
 
-    public class Bone
+    public class Bone : IBone
     {
         Vector _prevJoint;
         Vector _nextJoint;
@@ -84,10 +84,18 @@ namespace Leap
             _isValid = true;
         }
 
-        public Bone TransformedCopy(Matrix trs){
+        public IBone TransformedShallowCopy(ref Matrix trs)
+        {
+            return new TransformedBone(ref trs, this);
+        }
+
+        public IBone TransformedCopy(ref Matrix trs)
+        {
             float dScale = trs.zBasis.Magnitude;
             float hScale = trs.xBasis.Magnitude;
-            return new Bone(trs.TransformPoint(_prevJoint),
+
+            return new Bone(
+                trs.TransformPoint(_prevJoint),
                 trs.TransformPoint(_nextJoint),
                 trs.TransformPoint(_center),
                 trs.TransformDirection(_direction).Normalized,
@@ -293,9 +301,11 @@ namespace Leap
      * @returns The invalid Bone instance.
      * @since 2.0
      */
-        public static Bone Invalid {
+        private static IBone invalidBone = new InvalidBone();
+
+        public static IBone Invalid {
             get {
-                return new Bone();
+                return invalidBone;
             } 
         }
 

--- a/Assets/LeapC/Controller.cs
+++ b/Assets/LeapC/Controller.cs
@@ -302,9 +302,9 @@ namespace Leap
          * @param history The age of the frame to return, counting backwards from
          * the most recent frame (0) into the past and up to the maximum age (59).
          */
-        public Frame GetTransformedFrame (Matrix trs, int history = 0)
+        public IFrame GetTransformedFrame (Matrix trs, int history = 0)
         {
-            return Frame (history).TransformedCopy (trs);
+            return Frame (history).TransformedCopy (ref trs);
         }
 
 

--- a/Assets/LeapC/Finger.cs
+++ b/Assets/LeapC/Finger.cs
@@ -32,13 +32,15 @@ namespace Leap
    * @since 1.0
    */
 
-    public class Finger
+    public class Finger : IFinger
     {
-        Bone[] _bones = new Bone[4];
+        IBone[] _bones = new IBone[4];
         FingerType _type = FingerType.TYPE_UNKNOWN;
          int _frameId;
-         int _id = 0;
          int _handID = 0;
+         int _fingerId = 0;
+         int _id = 0;
+         
          Vector _tipPosition;
          Vector _tipVelocity;
          Vector _direction;
@@ -72,10 +74,10 @@ namespace Leap
                            float length,
                            bool isExtended,
                            Finger.FingerType type,
-                           Bone metacarpal,
-                           Bone proximal,
-                           Bone intermediate,
-                           Bone distal)
+                           IBone metacarpal,
+                           IBone proximal,
+                           IBone intermediate,
+                           IBone distal)
         {
             _type = type;
             _bones [0] = metacarpal;
@@ -83,8 +85,9 @@ namespace Leap
             _bones [2] = intermediate;
             _bones [3] = distal;
             _frameId = frameId;
-            _id = (handId * 10) + fingerId;
+            _fingerId = fingerId;
             _handID = handId;
+            _id = (handId * 10) + fingerId;
             _tipPosition = tipPosition;
             _tipVelocity = tipVelocity;
             _direction = direction;
@@ -96,12 +99,18 @@ namespace Leap
             _timeVisible = timeVisible;
         }
 
-        public Finger TransformedCopy(Matrix trs){
+        public IFinger TransformedShallowCopy(ref Matrix trs)
+        {
+            return new TransformedFinger(ref trs, this);
+        }
+
+        public IFinger TransformedCopy(ref Matrix trs) {
+
             float dScale = trs.zBasis.Magnitude;
             float hScale = trs.xBasis.Magnitude;
             return new Finger(_frameId,
                               _handID,
-                              _id,
+                              _fingerId,
                               _timeVisible,
                               trs.TransformPoint(_tipPosition),
                               trs.TransformPoint(_tipVelocity),
@@ -111,10 +120,10 @@ namespace Leap
                               _length * dScale,
                               _isExtended,
                               _type,
-                              _bones[0].TransformedCopy(trs),
-                              _bones[1].TransformedCopy(trs),
-                              _bones[2].TransformedCopy(trs),
-                              _bones[3].TransformedCopy(trs));
+                              _bones[0].TransformedCopy(ref trs),
+                              _bones[1].TransformedCopy(ref trs),
+                              _bones[2].TransformedCopy(ref trs),
+                              _bones[3].TransformedCopy(ref trs));
         }
 
 
@@ -128,7 +137,7 @@ namespace Leap
      * @returns The Bone that has the specified bone type.
      * @since 2.0
      */
-        public Bone Bone (Bone.BoneType boneIx)
+        public IBone Bone (Bone.BoneType boneIx)
         {
             return _bones[(int)boneIx];
         }
@@ -185,6 +194,13 @@ namespace Leap
             } 
         }
 
+        public int FrameId
+        {
+            get
+            {
+                return _frameId;
+            }
+        }
         /**
      * The Hand associated with a finger.
      *
@@ -356,9 +372,11 @@ namespace Leap
      * @returns The invalid Finger instance.
      * @since 1.0
      */
-        public static Finger Invalid {
+        static private IFinger invalidFinger = new InvalidFinger();
+
+        public static IFinger Invalid {
             get {
-                return new Finger ();
+                return invalidFinger;
             } 
         }
             

--- a/Assets/LeapC/FingerList.cs
+++ b/Assets/LeapC/FingerList.cs
@@ -22,7 +22,7 @@ namespace Leap
    * @since 1.0
    */
 
-    public class FingerList : List<Finger>
+    public class FingerList : List<IFinger>
     {
         public FingerList():base(){}
         public FingerList(int initialCapacity):base(initialCapacity){}
@@ -38,7 +38,7 @@ namespace Leap
      */
         public FingerList Extended ()
         {
-            return (FingerList) this.FindAll (delegate (Finger finger) {
+            return (FingerList) this.FindAll (delegate (IFinger finger) {
                 return finger.IsExtended;
             });
         }
@@ -55,7 +55,7 @@ namespace Leap
      */
         public FingerList FingerType (Finger.FingerType type)
         {
-            return (FingerList) this.FindAll (delegate (Finger finger) {
+            return (FingerList) this.FindAll (delegate (IFinger finger) {
                 return finger.Type == type;
             });
         }
@@ -85,12 +85,18 @@ namespace Leap
      * @returns The leftmost finger, or invalid if list is empty.
      * @since 1.0
      */
-        public Finger Leftmost {
+        public IFinger Leftmost {
             get {
-                Finger mostest = new Finger();
+                if (this.Count == 0)
+                    return Finger.Invalid;
+
+                IFinger mostest = null; // TODO: mostest = this[0] and proceed from there
                 float position = float.MaxValue;
-                foreach(Finger finger in this){
-                    if(finger.TipPosition.x < position){
+
+                foreach(IFinger finger in this)
+                {
+                    if(finger.TipPosition.x <= position)
+                    {
                         mostest = finger;
                         position = finger.TipPosition.x;
                     }
@@ -108,12 +114,18 @@ namespace Leap
      * @returns The rightmost finger, or invalid if list is empty.
      * @since 1.0
      */
-        public Finger Rightmost {
+        public IFinger Rightmost {
             get {
-                Finger mostest = new Finger();
+                if (this.Count == 0)
+                    return Finger.Invalid;
+
+                IFinger mostest = null;
                 float position = float.MaxValue;
-                foreach(Finger finger in this){
-                    if(finger.TipPosition.x > position){
+
+                foreach(IFinger finger in this)
+                {
+                    if(finger.TipPosition.x >= position)
+                    {
                         mostest = finger;
                         position = finger.TipPosition.x;
                     }
@@ -131,11 +143,16 @@ namespace Leap
      * @returns The frontmost finger, or invalid if list is empty.
      * @since 1.0
      */
-        public Finger Frontmost {
+        public IFinger Frontmost {
             get {
-                Finger mostest = new Finger();
+                if (this.Count == 0)
+                    return Finger.Invalid;
+
+                IFinger mostest = null;
                 float position = float.MaxValue;
-                foreach(Finger finger in this){
+
+                foreach(IFinger finger in this)
+                {
                     if(finger.TipPosition.z < position){
                         mostest = finger;
                         position = finger.TipPosition.z;

--- a/Assets/LeapC/Frame.cs
+++ b/Assets/LeapC/Frame.cs
@@ -27,7 +27,7 @@ namespace Leap
    * @since 1.0
    */
 
-    public class Frame
+    public class Frame : IFrame
     {
         FingerList _fingers;
         HandList _hands;
@@ -50,7 +50,12 @@ namespace Leap
             InteractionBox = interactionBox;
         }
 
-        public Frame TransformedCopy (Matrix trs)
+        public IFrame TransformedShallowCopy (ref Matrix trs)
+        {
+            return new TransformedFrame(ref trs, this);
+        }
+
+        public IFrame TransformedCopy (ref Matrix trs)
         {
             Frame transformedFrame = new Frame (_id, 
                                          _timestamp, 
@@ -59,11 +64,12 @@ namespace Leap
             //TODO should InteractionBox be transformed, too?
 
             for (int h = 0; h < this.Hands.Count; h++)
-                transformedFrame.AddHand (this.Hands [h].TransformedCopy (trs));
+                transformedFrame.AddHand (this.Hands [h].TransformedCopy (ref trs));
+
             return transformedFrame;
         }
 
-        public void AddHand (Hand hand)
+        public void AddHand (IHand hand)
         {
             if (_hands == null)
                 _hands = new HandList (3);
@@ -165,9 +171,9 @@ namespace Leap
      * otherwise, an invalid Hand object is returned.
      * @since 1.0
      */
-        public Hand Hand (int id)
+        public IHand Hand (int id)
         {
-            return this.Hands.Find (delegate(Hand item) {
+            return this.Hands.Find (delegate(IHand item) {
                 return item.Id == id;
             });
         }
@@ -192,9 +198,9 @@ namespace Leap
      * otherwise, an invalid Finger object is returned.
      * @since 1.0
      */
-        public Finger Finger (int id)
+        public IFinger Finger (int id)
         {
-            return this.Fingers.Find (delegate(Finger item) {
+            return this.Fingers.Find (delegate(IFinger item) {
                 return item.Id == id;
             });
         }
@@ -220,7 +226,7 @@ namespace Leap
      * in the sinceFrame parameter.
      * @since 1.0
      */
-        public Vector Translation (Frame sinceFrame)
+        public Vector Translation(IFrame sinceFrame)
         {
             return Vector.Zero;
         }
@@ -240,7 +246,7 @@ namespace Leap
      * is intended to be a translating motion.
      * @since 1.0
      */
-        public float TranslationProbability (Frame sinceFrame)
+        public float TranslationProbability(IFrame sinceFrame)
         {
             return 0;
         }
@@ -265,7 +271,7 @@ namespace Leap
      * and that specified in the sinceFrame parameter.
      * @since 1.0
      */
-        public Vector RotationAxis (Frame sinceFrame)
+        public Vector RotationAxis(IFrame sinceFrame)
         {
             return Vector.YAxis;
         }
@@ -292,7 +298,7 @@ namespace Leap
      * sinceFrame parameter.
      * @since 1.0
      */
-        public float RotationAngle (Frame sinceFrame)
+        public float RotationAngle(IFrame sinceFrame)
         {
             return 0;
         }
@@ -320,7 +326,7 @@ namespace Leap
      * parameter around the given axis.
      * @since 1.0
      */
-        public float RotationAngle (Frame sinceFrame, Vector axis)
+        public float RotationAngle(IFrame sinceFrame, Vector axis)
         {
             return 0;
         }
@@ -343,7 +349,7 @@ namespace Leap
      * sinceFrame parameter.
      * @since 1.0
      */
-        public Matrix RotationMatrix (Frame sinceFrame)
+        public Matrix RotationMatrix(IFrame sinceFrame)
         {
             return Matrix.Identity;
         }
@@ -363,7 +369,7 @@ namespace Leap
      * is intended to be a rotating motion.
      * @since 1.0
      */
-        public float RotationProbability (Frame sinceFrame)
+        public float RotationProbability(IFrame sinceFrame)
         {
             return 0;
         }
@@ -391,7 +397,7 @@ namespace Leap
      * sinceFrame parameter.
      * @since 1.0
      */
-        public float ScaleFactor (Frame sinceFrame)
+        public float ScaleFactor(IFrame sinceFrame)
         {
             return 1.0f;
         }
@@ -411,7 +417,7 @@ namespace Leap
      * is intended to be a scaling motion.
      * @since 1.0
      */
-        public float ScaleProbability (Frame sinceFrame)
+        public float ScaleProbability(IFrame sinceFrame)
         {
             return 0;
         }
@@ -425,7 +431,7 @@ namespace Leap
      * the exact same frame of tracking data and both Frame objects are valid.
      * @since 1.0
      */
-        public bool Equals (Frame other)
+        public bool Equals(IFrame other)
         {
             return this.IsValid && other.IsValid && (this.Id == other.Id) && (this.Timestamp == other.Timestamp);
         }
@@ -624,9 +630,11 @@ namespace Leap
      * @returns The invalid Frame instance.
      * @since 1.0
      */
-        public static Frame Invalid {
+        private static IFrame invalidFrame = new InvalidFrame();
+
+        public static IFrame Invalid {
             get {
-                return new Frame ();
+                return invalidFrame;
             } 
         }
 

--- a/Assets/LeapC/HandList.cs
+++ b/Assets/LeapC/HandList.cs
@@ -22,7 +22,7 @@ namespace Leap
    * @since 1.0
    */
     
-    public class HandList : List<Hand>
+    public class HandList : List<IHand>
     {
         public HandList():base(){}
         public HandList(int initialCapacity):base(initialCapacity){}
@@ -39,7 +39,7 @@ namespace Leap
      */
         public HandList HandType (bool leftHand)
         {
-            return (HandList) this.FindAll (delegate (Hand hand) {
+            return (HandList) this.FindAll (delegate (IHand hand) {
                 return hand.IsLeft == leftHand;
             });
         }
@@ -69,12 +69,16 @@ namespace Leap
      * @returns The leftmost hand, or invalid if list is empty.
      * @since 1.0
      */
-        public Hand Leftmost {
+        public IHand Leftmost {
             get {
-                Hand mostest = new Hand();
+                if (this.Count == 0)
+                    return Hand.Invalid;
+
+                IHand mostest = null;
                 float position = float.MaxValue;
-                foreach(Hand hand in this){
-                    if(hand.PalmPosition.x < position){
+
+                foreach(IHand hand in this){
+                    if(hand.PalmPosition.x <= position){
                         mostest = hand;
                         position = hand.PalmPosition.x;
                     }
@@ -92,12 +96,16 @@ namespace Leap
      * @returns The rightmost hand, or invalid if list is empty.
      * @since 1.0
      */
-        public Hand Rightmost {
+        public IHand Rightmost {
             get {
-                Hand mostest = new Hand();
+                if (this.Count == 0)
+                    return Hand.Invalid;
+
+                IHand mostest = null;
                 float position = float.MinValue;
-                foreach(Hand hand in this){
-                    if(hand.PalmPosition.x > position){
+
+                foreach(IHand hand in this){
+                    if(hand.PalmPosition.x >= position){
                         mostest = hand;
                         position = hand.PalmPosition.x;
                     }
@@ -115,12 +123,17 @@ namespace Leap
      * @returns The frontmost hand, or invalid if list is empty.
      * @since 1.0
      */
-        public Hand Frontmost {
+        public IHand Frontmost {
             get {
-                Hand mostest = new Hand();
+                if (this.Count == 0)
+                    return Hand.Invalid;
+
+                IHand mostest = null;
                 float position = float.MaxValue;
-                foreach(Hand hand in this){
-                    if(hand.PalmPosition.z < position){
+
+                foreach(IHand hand in this)
+                {
+                    if(hand.PalmPosition.z <= position){
                         mostest = hand;
                         position = hand.PalmPosition.z;
                     }

--- a/Assets/LeapC/IArm.cs
+++ b/Assets/LeapC/IArm.cs
@@ -1,0 +1,15 @@
+﻿using System;
+namespace Leap
+{
+    public interface IArm : IBone
+    {
+        Vector ElbowPosition { get; }
+        Vector WristPosition { get; }
+
+        new IArm TransformedShallowCopy(ref Matrix trs);
+        new IArm TransformedCopy(ref Matrix trs);
+
+        bool Equals(IArm other);
+        new string ToString();
+    }
+}

--- a/Assets/LeapC/IArm.cs.meta
+++ b/Assets/LeapC/IArm.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 58e7359e245795f4f810398f49b55d6a
+timeCreated: 1456508844
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapC/IBone.cs
+++ b/Assets/LeapC/IBone.cs
@@ -1,0 +1,25 @@
+﻿using System;
+
+namespace Leap
+{
+    public interface IBone
+    {
+        Bone.BoneType Type { get; }
+        bool IsValid { get; }
+
+        Matrix Basis { get; }
+        Vector Center { get; }
+        Vector Direction { get; }
+        
+        Vector NextJoint { get; }
+        Vector PrevJoint { get; }
+
+        float Width { get; }
+        float Length { get; }
+
+        IBone TransformedShallowCopy(ref Matrix trs);
+        IBone TransformedCopy(ref Matrix trs);
+        bool Equals(Bone other);
+        string ToString();
+    }
+}

--- a/Assets/LeapC/IBone.cs.meta
+++ b/Assets/LeapC/IBone.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 9a36156694adc8e41b755fe620540d8a
+timeCreated: 1456508844
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapC/IFinger.cs
+++ b/Assets/LeapC/IFinger.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace Leap
+{
+    public interface IFinger
+    {
+        int Id { get; }
+        int FrameId { get; }
+        int HandId { get; }
+        float TimeVisible { get; }
+
+        Finger.FingerType Type { get; }
+        bool IsExtended { get; }
+        bool IsValid { get; }
+
+        float Length { get; }
+        float Width { get; }
+
+        Vector Direction { get; }
+        Vector JointPosition(Finger.FingerJoint jointIx);
+        Vector StabilizedTipPosition { get; }
+        
+        Vector TipPosition { get; }
+        Vector TipVelocity { get; }
+
+        IBone Bone(Bone.BoneType boneIx);
+        IFinger TransformedShallowCopy(ref Matrix trs);
+        IFinger TransformedCopy(ref Matrix trs);
+
+        string ToString();
+    }
+}

--- a/Assets/LeapC/IFinger.cs.meta
+++ b/Assets/LeapC/IFinger.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: c3bcd69c121e9164682479cadf124317
+timeCreated: 1456508845
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapC/IFrame.cs
+++ b/Assets/LeapC/IFrame.cs
@@ -1,0 +1,43 @@
+﻿using System;
+namespace Leap
+{
+    public interface IFrame
+    {
+        long Id { get; }
+        bool IsValid { get; }
+        long Timestamp { get; }
+        float CurrentFramesPerSecond { get; }
+        
+        IFinger Finger(int id);
+        FingerList Fingers { get; }
+
+        void AddHand(IHand hand);
+        IHand Hand(int id);
+        HandList Hands { get; }
+        
+        InteractionBox InteractionBox { get; }
+        TrackedQuad TrackedQuad { get; set; }
+
+        Vector Translation(IFrame sinceFrame);
+        float TranslationProbability(IFrame sinceFrame);
+
+        float RotationAngle(IFrame sinceFrame);
+        float RotationAngle(IFrame sinceFrame, Vector axis);
+        Vector RotationAxis(IFrame sinceFrame);
+        Matrix RotationMatrix(IFrame sinceFrame);
+        float RotationProbability(IFrame sinceFrame);
+
+        float ScaleFactor(IFrame sinceFrame);
+        float ScaleProbability(IFrame sinceFrame);
+
+        int SerializeLength { get; }
+        byte[] Serialize { get; }
+        void Deserialize(byte[] arg);
+
+        IFrame TransformedShallowCopy(ref Matrix trs);
+        IFrame TransformedCopy(ref Matrix trs);
+
+        string ToString();
+        bool Equals(IFrame other);
+    }
+}

--- a/Assets/LeapC/IFrame.cs.meta
+++ b/Assets/LeapC/IFrame.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 6eadc17b4e6ddef478d2c3050e7dd700
+timeCreated: 1456508844
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapC/IHand.cs
+++ b/Assets/LeapC/IHand.cs
@@ -1,0 +1,59 @@
+﻿using System;
+namespace Leap
+{
+    public interface IHand
+    {
+        IArm Arm { get; }
+        FingerList Fingers { get; }
+
+        int Id { get; }        
+        int FrameId { get; }
+        float TimeVisible { get; }
+        float Confidence { get; }
+
+        float GrabAngle { get; }
+        float GrabStrength { get; }
+        
+        bool IsLeft { get; }
+        bool IsRight { get; }
+        bool IsValid { get; }
+
+        Matrix Basis { get; }
+        Vector Direction { get; }
+
+        float PalmWidth { get; }
+        Vector PalmNormal { get; }
+        Vector PalmPosition { get; }
+        Vector PalmVelocity { get; }
+        Vector StabilizedPalmPosition { get; }
+
+        Vector WristPosition { get; }
+
+        float PinchDistance { get; }
+        float PinchStrength { get; }
+
+        [Obsolete]
+        Vector SphereCenter { get; }
+        [Obsolete]
+        float SphereRadius { get; }
+        
+        Vector Translation(IFrame sinceFrame);
+        float TranslationProbability(IFrame sinceFrame);
+
+        float RotationAngle(IFrame sinceFrame);
+        float RotationAngle(IFrame sinceFrame, Vector axis);
+        Vector RotationAxis(IFrame sinceFrame);
+        Matrix RotationMatrix(IFrame sinceFrame);
+        float RotationProbability(IFrame sinceFrame);
+
+        float ScaleFactor(IFrame sinceFrame);
+        float ScaleProbability(IFrame sinceFrame);
+
+        IFinger Finger(int id);
+        IHand TransformedShallowCopy(ref Matrix trs);
+        IHand TransformedCopy(ref Matrix trs);
+        
+        string ToString();
+        bool Equals(IHand other);        
+    }
+}

--- a/Assets/LeapC/IHand.cs.meta
+++ b/Assets/LeapC/IHand.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 1607e0980a86af9438dacaeb0bc7b615
+timeCreated: 1456508844
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapC/InvalidArm.cs
+++ b/Assets/LeapC/InvalidArm.cs
@@ -1,0 +1,93 @@
+﻿using UnityEngine;
+using System.Collections;
+
+namespace Leap
+{
+    public class InvalidArm : IArm
+    {
+        public Vector ElbowPosition
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public Vector WristPosition
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public IArm TransformedShallowCopy(ref Matrix trs)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public IArm TransformedCopy(ref Matrix trs)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public bool Equals(IArm other)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Bone.BoneType Type
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public bool IsValid
+        {
+            get { return false; }
+        }
+
+        public Matrix Basis
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public Vector Center
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public Vector Direction
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public Vector NextJoint
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public Vector PrevJoint
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public float Width
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public float Length
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        IBone IBone.TransformedShallowCopy(ref Matrix trs)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        IBone IBone.TransformedCopy(ref Matrix trs)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public bool Equals(Bone other)
+        {
+            return other.IsValid == false;
+        }
+    }
+}

--- a/Assets/LeapC/InvalidArm.cs.meta
+++ b/Assets/LeapC/InvalidArm.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 6f08c03892ade004288e5338942db73d
+timeCreated: 1456508844
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapC/InvalidBone.cs
+++ b/Assets/LeapC/InvalidBone.cs
@@ -1,0 +1,68 @@
+﻿using UnityEngine;
+using System.Collections;
+
+namespace Leap
+{
+    public class InvalidBone : IBone
+    {
+        public Bone.BoneType Type
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public bool IsValid
+        {
+            get { return false; }
+        }
+
+        public Matrix Basis
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public Vector Center
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public Vector Direction
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public Vector NextJoint
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public Vector PrevJoint
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public float Width
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public float Length
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public IBone TransformedShallowCopy(ref Matrix trs)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public IBone TransformedCopy(ref Matrix trs)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public bool Equals(Bone other)
+        {
+            return other.IsValid == false;
+        }
+    }
+}

--- a/Assets/LeapC/InvalidBone.cs.meta
+++ b/Assets/LeapC/InvalidBone.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 153a85b406dd20342bed20f2edeb3a29
+timeCreated: 1456508844
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapC/InvalidFinger.cs
+++ b/Assets/LeapC/InvalidFinger.cs
@@ -1,0 +1,93 @@
+﻿using UnityEngine;
+using System.Collections;
+
+namespace Leap
+{
+    public class InvalidFinger : IFinger
+    {
+        public IBone Bone(Bone.BoneType boneIx)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Vector Direction
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public int HandId
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public int Id
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public int FrameId
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public bool IsExtended
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public bool IsValid
+        {
+            get { return false; }
+        }
+
+        public Vector JointPosition(Finger.FingerJoint jointIx)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public float Length
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public Vector StabilizedTipPosition
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public float TimeVisible
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public Vector TipPosition
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public Vector TipVelocity
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public IFinger TransformedShallowCopy(ref Matrix trs)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public IFinger TransformedCopy(ref Matrix trs)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Finger.FingerType Type
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public float Width
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+    }
+}

--- a/Assets/LeapC/InvalidFinger.cs.meta
+++ b/Assets/LeapC/InvalidFinger.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: d9490b33fcd7d9b43af7a90e1522f938
+timeCreated: 1456508845
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapC/InvalidFrame.cs
+++ b/Assets/LeapC/InvalidFrame.cs
@@ -1,0 +1,145 @@
+﻿using UnityEngine;
+using System.Collections;
+
+namespace Leap
+{
+    public class InvalidFrame : IFrame
+    {
+        public long Id
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public bool IsValid
+        {
+            get { return false; }
+        }
+
+        public long Timestamp
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public float CurrentFramesPerSecond
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public IFinger Finger(int id)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public FingerList Fingers
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public void AddHand(IHand hand)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public IHand Hand(int id)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public HandList Hands
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public InteractionBox InteractionBox
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public TrackedQuad TrackedQuad
+        {
+            get
+            {
+                throw new System.NotImplementedException();
+            }
+            set
+            {
+                throw new System.NotImplementedException();
+            }
+        }
+
+        public Vector Translation(IFrame sinceFrame)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public float TranslationProbability(IFrame sinceFrame)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public float RotationAngle(IFrame sinceFrame)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public float RotationAngle(IFrame sinceFrame, Vector axis)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Vector RotationAxis(IFrame sinceFrame)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Matrix RotationMatrix(IFrame sinceFrame)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public float RotationProbability(IFrame sinceFrame)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public float ScaleFactor(IFrame sinceFrame)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public float ScaleProbability(IFrame sinceFrame)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public int SerializeLength
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public byte[] Serialize
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public void Deserialize(byte[] arg)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public IFrame TransformedShallowCopy(ref Matrix trs)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public IFrame TransformedCopy(ref Matrix trs)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public bool Equals(IFrame other)
+        {
+            return other.IsValid == false;
+        }
+    }
+}

--- a/Assets/LeapC/InvalidFrame.cs.meta
+++ b/Assets/LeapC/InvalidFrame.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: e6767f3b0bc261b48b4272fdfe3de3b3
+timeCreated: 1456508845
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapC/InvalidHand.cs
+++ b/Assets/LeapC/InvalidHand.cs
@@ -1,0 +1,188 @@
+﻿using UnityEngine;
+using System.Collections;
+
+namespace Leap
+{
+    public class InvalidHand : IHand
+    {
+        public IArm Arm
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public Matrix Basis
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public float Confidence
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public Vector Direction
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public bool Equals(IHand other)
+        {
+            return other.IsValid == false;
+        }
+
+        public IFinger Finger(int id)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public FingerList Fingers
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public int FrameId
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public float GrabAngle
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public float GrabStrength
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public int Id
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public bool IsLeft
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public bool IsRight
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public bool IsValid
+        {
+            get { return false; }
+        }
+
+        public Vector PalmNormal
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public Vector PalmPosition
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public Vector PalmVelocity
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public float PalmWidth
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public float PinchDistance
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public float PinchStrength
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public float RotationAngle(IFrame sinceFrame)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public float RotationAngle(IFrame sinceFrame, Vector axis)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Vector RotationAxis(IFrame sinceFrame)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Matrix RotationMatrix(IFrame sinceFrame)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public float RotationProbability(IFrame sinceFrame)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public float ScaleFactor(IFrame sinceFrame)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public float ScaleProbability(IFrame sinceFrame)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Vector SphereCenter
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public float SphereRadius
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public Vector StabilizedPalmPosition
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public float TimeVisible
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public IHand TransformedShallowCopy(ref Matrix trs)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public IHand TransformedCopy(ref Matrix trs)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Vector Translation(IFrame sinceFrame)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public float TranslationProbability(IFrame sinceFrame)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Vector WristPosition
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+    }
+}

--- a/Assets/LeapC/InvalidHand.cs.meta
+++ b/Assets/LeapC/InvalidHand.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: d510d594b9e59e740b9ebc7b7248d1f4
+timeCreated: 1456508845
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapC/TransformedArm.cs
+++ b/Assets/LeapC/TransformedArm.cs
@@ -1,0 +1,66 @@
+﻿using UnityEngine;
+using System.Collections;
+
+namespace Leap
+{
+    public class TransformedArm : TransformedBone, IArm
+    {
+        private Matrix _trs;
+        private IArm _arm;
+
+        public TransformedArm(ref Matrix trs, IArm original) : base(ref trs, original)
+        {
+            _arm = original;
+        }
+
+        public void Set(ref Matrix trs, IArm original)
+        {
+            _trs = trs;
+            _arm = original;
+
+            base.Set(ref trs, original);
+        }
+
+        public Vector ElbowPosition
+        {
+            get { return _trs.TransformPoint(_arm.ElbowPosition); }
+        }
+
+        public Vector WristPosition
+        {
+            get {
+                Vector pos = _arm.WristPosition;
+                return _trs.TransformPoint(pos); 
+            }
+        }
+
+        new public IArm TransformedShallowCopy(ref Matrix trs)
+        {
+            return new TransformedArm(ref trs, this);
+        }
+
+        new public IArm TransformedCopy(ref Matrix trs)
+        {
+            // This may be much trickier than it seems.
+            // Only enable after automated testing.
+            throw new System.NotImplementedException();
+
+            //float dScale = trs.zBasis.Magnitude;
+            //float hScale = trs.xBasis.Magnitude;
+
+            //return new Arm(trs.TransformPoint(PrevJoint),
+            //    trs.TransformPoint(NextJoint),
+            //    trs.TransformPoint(Center),
+            //    trs.TransformDirection(Direction),
+            //    Length * dScale,
+            //    Width * hScale,
+            //    Type,
+            //    trs * Basis);
+        }
+
+        public bool Equals(IArm other)
+        {
+            return base.Equals(other as IBone);
+        }
+    }
+}

--- a/Assets/LeapC/TransformedArm.cs.meta
+++ b/Assets/LeapC/TransformedArm.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: af1cda5d91c783e48a1e0a7470296278
+timeCreated: 1456508845
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapC/TransformedBone.cs
+++ b/Assets/LeapC/TransformedBone.cs
@@ -1,0 +1,115 @@
+﻿using UnityEngine;
+using System.Collections;
+
+namespace Leap
+{
+    public class TransformedBone : IBone
+    {
+        private IBone _original;
+        private Matrix _trs;
+
+        public TransformedBone(ref Matrix trs, IBone original)
+        {
+            if (original == null)
+                Debug.Log("porra");
+
+            Set(ref trs, original);
+        }
+
+        public Bone.BoneType Type
+        {
+            get { return _original.Type; }
+        }
+
+        public bool IsValid
+        {
+            get { return _original.IsValid; }
+        }
+
+        public Matrix Basis
+        {
+            get { return _trs * _original.Basis; }
+        }
+
+        public Vector Center
+        {
+            get { return _trs.TransformPoint( _original.Center ); }
+        }
+
+        public Vector Direction
+        {
+            get { return _trs.TransformDirection(_original.Direction).Normalized; }
+        }
+
+        public Vector NextJoint
+        {
+            get { return _trs.TransformPoint( _original.NextJoint ); }
+        }
+
+        public Vector PrevJoint
+        {
+            get { return _trs.TransformPoint( _original.PrevJoint ); }
+        }
+
+        public float Width
+        {
+            get {
+                float hScale = _trs.xBasis.Magnitude;
+
+                return hScale * _original.Width;
+            }
+        }
+
+        public float Length
+        {
+            get {
+                float dScale = _trs.zBasis.Magnitude;
+
+                return dScale * _original.Length;
+            }
+        }
+
+        public IBone TransformedShallowCopy(ref Matrix trs)
+        {
+            return new TransformedBone(ref trs, this);
+        }
+
+        public IBone TransformedCopy(ref Matrix trs)
+        {
+            // This may be much trickier than it seems.
+            // Only enable after automated testing.
+            throw new System.NotImplementedException();
+
+            //float dScale = trs.zBasis.Magnitude;
+            //float hScale = trs.xBasis.Magnitude;
+
+            //return new Bone(
+            //    trs.TransformPoint(PrevJoint),
+            //    trs.TransformPoint(NextJoint),
+            //    trs.TransformPoint(Center),
+            //    trs.TransformDirection(Direction).Normalized,
+            //    Length * dScale,
+            //    Width * hScale,
+            //    Type,
+            //    trs * Basis);
+        }
+
+        public bool Equals(Bone other)
+        {
+            return this.IsValid &&
+                    other.IsValid &&
+                    (this.Center == other.Center) &&
+                    (this.Direction == other.Direction) &&
+                    (this.Length == other.Length);
+        }
+
+        public void Set(ref Matrix newTrs, IBone bone)
+        {
+            _trs = newTrs;
+            _original = bone;
+
+            if (bone == null)
+                Debug.Log("porra");
+        }
+    }
+}

--- a/Assets/LeapC/TransformedBone.cs.meta
+++ b/Assets/LeapC/TransformedBone.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 35485612494c9c849bc33b8aa5b51cd4
+timeCreated: 1456508844
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapC/TransformedFinger.cs
+++ b/Assets/LeapC/TransformedFinger.cs
@@ -1,0 +1,148 @@
+﻿using UnityEngine;
+using System.Collections;
+
+namespace Leap
+{
+    public class TransformedFinger : IFinger
+    {
+        private Matrix _trs;
+        private IFinger _original;
+        private TransformedBone[] _bones = new TransformedBone[4];
+
+        public TransformedFinger (ref Matrix trs, IFinger original)
+        {
+            Set(ref trs, original);
+        }
+
+        public int Id
+        {
+            get { return _original.Id; }
+        }
+
+        public int FrameId
+        {
+            get { return _original.FrameId; }
+        }
+
+        public int HandId
+        {
+            get { return _original.HandId; }
+        }
+
+        public float TimeVisible
+        {
+            get { return _original.TimeVisible; }
+        }
+
+        public Finger.FingerType Type
+        {
+            get { return _original.Type; }
+        }
+
+        public bool IsExtended
+        {
+            get { return _original.IsExtended; }
+        }
+
+        public bool IsValid
+        {
+            get { return _original.IsValid; }
+        }
+
+        public float Length
+        {
+            get {
+                float dScale = _trs.zBasis.Magnitude;
+                return dScale * _original.Length;
+            }
+        }
+
+        public float Width
+        {
+            get {
+                float hScale = _trs.xBasis.Magnitude;
+                return hScale * _original.Width;
+            }
+        }
+
+        public Vector Direction
+        {
+            get { return _trs.TransformDirection(_original.Direction).Normalized; }
+        }
+
+        public Vector JointPosition(Finger.FingerJoint jointIx)
+        {
+            return _trs.TransformPoint(_original.JointPosition(jointIx));
+        }
+
+        public Vector StabilizedTipPosition
+        {
+            get { return _trs.TransformPoint(_original.StabilizedTipPosition); }
+        }
+
+        public Vector TipPosition
+        {
+            get { return _trs.TransformPoint(_original.TipPosition); }
+        }
+
+        public Vector TipVelocity
+        {
+            get { return _trs.TransformPoint(_original.TipVelocity); }
+        }
+
+        public IBone Bone(Bone.BoneType boneIx)
+        {
+            return _bones[(int)boneIx];
+        }
+
+        public IFinger TransformedShallowCopy(ref Matrix trs)
+        {
+            return new TransformedFinger(ref trs, this);
+        }
+
+        public IFinger TransformedCopy(ref Matrix trs)
+        {
+            // This may be much trickier than it seems.
+            // Only enable after automated testing.
+            throw new System.NotImplementedException();
+
+            //float dScale = trs.zBasis.Magnitude;
+            //float hScale = trs.xBasis.Magnitude;
+
+            //return new Finger(FrameId,
+            //                  HandId,
+            //                  Id,
+            //                  TimeVisible,
+            //                  trs.TransformPoint(TipPosition),
+            //                  trs.TransformPoint(TipVelocity),
+            //                  trs.TransformDirection(Direction).Normalized,
+            //                  trs.TransformPoint(StabilizedTipPosition),
+            //                  Width * hScale,
+            //                  Length * dScale,
+            //                  IsExtended,
+            //                  Type,
+            //                  Bone(Leap.Bone.BoneType.TYPE_METACARPAL).TransformedCopy(ref trs),
+            //                  Bone(Leap.Bone.BoneType.TYPE_PROXIMAL).TransformedCopy(ref trs),
+            //                  Bone(Leap.Bone.BoneType.TYPE_INTERMEDIATE).TransformedCopy(ref trs),
+            //                  Bone(Leap.Bone.BoneType.TYPE_DISTAL).TransformedCopy(ref trs));
+        }
+
+        public void Set(ref Matrix newTrs, IFinger finger)
+        {
+            for (int i = 0; i < 4; i++)
+            {
+                if (_bones[i] == null)
+                {
+                    _bones[i] = (TransformedBone) finger.Bone((Bone.BoneType)i).TransformedShallowCopy(ref newTrs);
+                }
+                else
+                {
+                    _bones[i].Set(ref newTrs, finger.Bone((Bone.BoneType)i));
+                }
+            }
+
+            _trs = newTrs;
+            _original = finger;
+        }
+    }
+}

--- a/Assets/LeapC/TransformedFinger.cs.meta
+++ b/Assets/LeapC/TransformedFinger.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 320492775d3cc2d48a54b353cb52e09d
+timeCreated: 1456508844
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapC/TransformedFrame.cs
+++ b/Assets/LeapC/TransformedFrame.cs
@@ -1,0 +1,214 @@
+﻿using UnityEngine;
+using System.Collections;
+
+namespace Leap
+{
+    public class TransformedFrame : IFrame
+    {
+        private Matrix _trs;
+        private IFrame _original;
+
+        HandList _hands = new HandList(3);
+        FingerList _fingers = new FingerList(15);
+
+        public TransformedFrame (ref Matrix trs, IFrame original)
+        {
+            Set(ref trs, original);
+        }
+        
+        public void Set (ref Matrix newTrs, IFrame newOriginal)
+        {
+            for (int i = 0; i < newOriginal.Hands.Count; i++)
+            {
+                if (_hands.Count > i)
+                {
+                    ((TransformedHand)_hands[i]).Set(ref newTrs, newOriginal.Hands[i]);
+                    // In this case I don't have to add the fingers again
+                    // since the instances will be reused
+                }
+                else
+                {
+                    IHand transformedHand = newOriginal.Hands[i].TransformedShallowCopy(ref newTrs);
+                    _hands.Add(transformedHand);
+
+                    _fingers.AddRange(transformedHand.Fingers);
+                }
+            }
+
+            for (int i = newOriginal.Hands.Count; i < _hands.Count; i++)
+                _hands.RemoveAt(i);
+
+            _trs = newTrs;
+            _original = newOriginal;
+        }
+
+        public long Id
+        {
+            get { return _original.Id; }
+        }
+
+        public bool IsValid
+        {
+            get { return _original.IsValid; }
+        }
+
+        public long Timestamp
+        {
+            get { return _original.Timestamp; }
+        }
+
+        public float CurrentFramesPerSecond
+        {
+            get { return _original.CurrentFramesPerSecond; }
+        }
+
+        public IFinger Finger(int id)
+        {
+            return this.Fingers.Find(delegate(IFinger item)
+            {
+                return item.Id == id;
+            });
+        }
+
+        public FingerList Fingers
+        {
+            get { return _fingers; }
+        }
+
+        public void AddHand(IHand hand)
+        {
+            _hands.Add(hand);
+        }
+
+        public IHand Hand(int id)
+        {
+            return this.Hands.Find(delegate(IHand item)
+            {
+                return item.Id == id;
+            });
+        }
+
+        public HandList Hands
+        {
+            get { return _hands; }
+        }
+
+        public InteractionBox InteractionBox
+        {
+            get {
+                // TODO: should InteractionBox be transformed, too?
+                return _original.InteractionBox;
+            }
+        }
+
+        public TrackedQuad TrackedQuad
+        {
+            get
+            {
+                return _original.TrackedQuad;
+            }
+            set
+            {
+                _original.TrackedQuad = value;
+            }
+        }
+
+        public Vector Translation(IFrame sinceFrame)
+        {
+            return _trs.TransformDirection(_original.Translation(sinceFrame));
+        }
+
+        public float TranslationProbability(IFrame sinceFrame)
+        {
+            return _original.TranslationProbability(sinceFrame);
+        }
+
+        public float RotationAngle(IFrame sinceFrame)
+        {
+            return _original.RotationAngle(sinceFrame);
+        }
+
+        public float RotationAngle(IFrame sinceFrame, Vector axis)
+        {
+            return _original.RotationAngle(sinceFrame, _trs.RigidInverse().TransformDirection( axis ).Normalized);
+        }
+
+        public Vector RotationAxis(IFrame sinceFrame)
+        {
+            return _trs.TransformDirection(_original.RotationAxis(sinceFrame)).Normalized;
+        }
+
+        public Matrix RotationMatrix(IFrame sinceFrame)
+        {
+            // This is probably wrong. The RotationMatrix method
+            // is always returning the identity matrix, which means
+            // no rotation in any reference frame. This way, the
+            // original code can disregard the LeapMatrix provided
+            // in the TransformedCopy method.
+            return _original.RotationMatrix(sinceFrame);
+        }
+
+        public float RotationProbability(IFrame sinceFrame)
+        {
+            return _original.RotationProbability(sinceFrame);
+        }
+
+        public float ScaleFactor(IFrame sinceFrame)
+        {
+            return _original.ScaleFactor(sinceFrame);
+        }
+
+        public float ScaleProbability(IFrame sinceFrame)
+        {
+            return _original.ScaleProbability(sinceFrame);
+        }
+
+        public int SerializeLength
+        {
+            get { throw new System.NotImplementedException(); }
+        }
+
+        public byte[] Serialize
+        {
+            get {
+                return _original.TransformedCopy(ref _trs).Serialize;
+            }
+        }
+
+        public void Deserialize(byte[] arg)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public IFrame TransformedShallowCopy(ref Matrix trs)
+        {
+            return new TransformedFrame(ref trs, this);
+        }
+
+        public IFrame TransformedCopy(ref Matrix trs)
+        {
+            // This may be much trickier than it seems.
+            // Only enable after automated testing.
+            throw new System.NotImplementedException();
+
+            //Frame transformedFrame = new Frame(Id,
+            //                             Timestamp,
+            //                             CurrentFramesPerSecond,
+            //                             new InteractionBox(InteractionBox.Center, InteractionBox.Size));
+
+            ////TODO should InteractionBox be transformed, too?
+
+            //for (int h = 0; h < this.Hands.Count; h++)
+            //    transformedFrame.AddHand(this.Hands[h].TransformedCopy(ref trs));
+
+            //return transformedFrame;
+        }
+
+        public bool Equals(IFrame other)
+        {
+            return this.IsValid && other.IsValid && 
+                (this.Id == other.Id) && 
+                (this.Timestamp == other.Timestamp);
+        }
+    }
+}

--- a/Assets/LeapC/TransformedFrame.cs.meta
+++ b/Assets/LeapC/TransformedFrame.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 6382d33cafdc3d14caec056fc7bda7d1
+timeCreated: 1456508844
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapC/TransformedHand.cs
+++ b/Assets/LeapC/TransformedHand.cs
@@ -1,0 +1,276 @@
+﻿using UnityEngine;
+using System.Collections;
+
+namespace Leap
+{
+    public class TransformedHand : IHand
+    {
+        private IHand _original;
+        private Matrix _trs;
+
+        private FingerList _fingers = new FingerList(5);
+        private TransformedArm _arm;
+        
+        public TransformedHand(ref Matrix trs, IHand original)
+        {
+            Set(ref trs, original);
+        }
+
+        public IArm Arm
+        {
+            get { return _arm; }
+        }
+
+        public FingerList Fingers
+        {
+            get { return _fingers; }
+        }
+
+        public int Id
+        {
+            get { return _original.Id; }
+        }
+
+        public int FrameId
+        {
+            get { return _original.FrameId; }
+        }
+
+        public float TimeVisible
+        {
+            get { return _original.TimeVisible; }
+        }
+
+        public float Confidence
+        {
+            get { return _original.Confidence; }
+        }
+
+        public float GrabAngle
+        {
+            get { return _original.GrabAngle; }
+        }
+
+        public float GrabStrength
+        {
+            get { return _original.GrabStrength; }
+        }
+
+        public bool IsLeft
+        {
+            get { return _original.IsLeft; }
+        }
+
+        public bool IsRight
+        {
+            get { return _original.IsRight; }
+        }
+
+        public bool IsValid
+        {
+            get { return _original.IsValid; }
+        }
+
+        public Matrix Basis
+        {
+            get {
+                Matrix originalBasis = _original.Basis;
+                Matrix ret = new Matrix(
+                    _trs.TransformDirection(originalBasis.xBasis).Normalized,
+                    _trs.TransformDirection(originalBasis.yBasis).Normalized,
+                    _trs.TransformDirection(originalBasis.zBasis).Normalized
+                    );
+
+                return ret;
+                // return _trs * _original.Basis; 
+            }
+        }
+
+        public Vector Direction
+        {
+            get { return _trs.TransformDirection(_original.Direction).Normalized; }
+        }
+
+        public float PalmWidth
+        {
+            get {
+                float hScale = _trs.xBasis.Magnitude;
+                return hScale * _original.PalmWidth;
+            }
+        }
+
+        public Vector PalmNormal
+        {
+            get { return _trs.TransformDirection(_original.PalmNormal).Normalized; }
+        }
+
+        public Vector PalmPosition
+        {
+            get { return _trs.TransformPoint(_original.PalmPosition); }
+        }
+
+        public Vector PalmVelocity
+        {
+            get { return _trs.TransformPoint(_original.PalmVelocity); }
+        }
+
+        public Vector StabilizedPalmPosition
+        {
+            get { return _trs.TransformPoint(_original.StabilizedPalmPosition); }
+        }
+
+        public Vector WristPosition
+        {
+            get { return _trs.TransformPoint(_original.WristPosition); }
+        }
+
+        public float PinchDistance
+        {
+            get { return _original.PinchDistance; }
+        }
+
+        public float PinchStrength
+        {
+            get { return _original.PinchStrength;  }
+        }
+
+        public Vector SphereCenter
+        {
+            get { return _trs.TransformPoint(_original.SphereCenter); }
+        }
+
+        public float SphereRadius
+        {
+            get { return _original.SphereRadius; }
+        }
+
+        public Vector Translation(IFrame sinceFrame)
+        {
+            return _trs.TransformDirection(_original.Translation(sinceFrame));
+        }
+
+        public float TranslationProbability(IFrame sinceFrame)
+        {
+            return _original.TranslationProbability(sinceFrame);
+        }
+
+        public float RotationAngle(IFrame sinceFrame)
+        {
+            return _original.RotationAngle(sinceFrame);
+        }
+
+        public float RotationAngle(IFrame sinceFrame, Vector axis)
+        {
+            return _original.RotationAngle(sinceFrame, _trs.RigidInverse().TransformDirection( axis ).Normalized);
+        }
+
+        public Vector RotationAxis(IFrame sinceFrame)
+        {
+            return _trs.TransformDirection(_original.RotationAxis(sinceFrame)).Normalized;
+        }
+
+        public Matrix RotationMatrix(IFrame sinceFrame)
+        {
+            IHand sinceHand = sinceFrame.Hand(this.Id);
+
+            if (!sinceHand.IsValid)
+                return Matrix.Identity;
+
+            return this.Basis * sinceHand.Basis.RigidInverse();
+        }
+
+        public float RotationProbability(IFrame sinceFrame)
+        {
+            return _original.RotationProbability(sinceFrame);
+        }
+
+        public float ScaleFactor(IFrame sinceFrame)
+        {
+            return _original.ScaleFactor(sinceFrame);
+        }
+
+        public float ScaleProbability(IFrame sinceFrame)
+        {
+            return _original.ScaleProbability(sinceFrame);
+        }
+
+        public IFinger Finger(int id)
+        {
+            return this.Fingers.Find(delegate(IFinger item)
+            {
+                return item.Id == id;
+            });
+        }
+
+        public IHand TransformedShallowCopy(ref Matrix trs)
+        {
+            return new TransformedHand(ref trs, this);
+        }
+
+        public IHand TransformedCopy(ref Matrix trs)
+        {
+            // This may be much trickier than it seems.
+            // Only enable after automated testing.
+            throw new System.NotImplementedException();
+
+            //FingerList transformedFingers = new FingerList(5);
+            //for (int f = 0; f < this.Fingers.Count; f++)
+            //    transformedFingers.Add(Fingers[f].TransformedCopy(ref trs));
+
+            //float hScale = trs.xBasis.Magnitude;
+            //return new Hand(FrameId,
+            //    Id,
+            //    Confidence,
+            //    GrabStrength,
+            //    GrabAngle,
+            //    PinchStrength,
+            //    PinchDistance,
+            //    PalmWidth * hScale,
+            //    IsLeft,
+            //    TimeVisible,
+            //    Arm.TransformedCopy(ref trs),
+            //    transformedFingers,
+            //    trs.TransformPoint(PalmPosition),
+            //    trs.TransformPoint(StabilizedPalmPosition),
+            //    trs.TransformPoint(PalmVelocity),
+            //    trs.TransformDirection(PalmNormal).Normalized,
+            //    trs.TransformDirection(Direction).Normalized,
+            //    trs.TransformPoint(WristPosition));
+        }
+
+        public bool Equals(IHand other)
+        {
+            return this.IsValid &&
+                other.IsValid &&
+                (this.Id == other.Id) &&
+                (this.FrameId == other.FrameId);
+        }
+
+        public void Set(ref Matrix newTrs, IHand newOriginal)
+        {
+            for (int i = 0; i < newOriginal.Fingers.Count; i++)
+            {
+                if (_fingers.Count > i)
+                {
+                    ((TransformedFinger)_fingers[i]).Set(ref newTrs, newOriginal.Fingers[i]);
+                }
+                else
+                {
+                    _fingers.Add(newOriginal.Fingers[i].TransformedShallowCopy(ref newTrs));
+                }
+            }
+
+            if (_arm != null)
+            {
+                _arm.Set(ref newTrs, newOriginal.Arm);
+            }
+            else
+            { 
+                _arm = (TransformedArm) newOriginal.Arm.TransformedShallowCopy(ref newTrs);
+            }
+
+            _trs = newTrs;
+            _original = newOriginal;
+        }
+    }
+}

--- a/Assets/LeapC/TransformedHand.cs.meta
+++ b/Assets/LeapC/TransformedHand.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: e4e9ac88cf4b2c14495cc44af2be10a5
+timeCreated: 1456508845
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapMotion/Scripts/HandFactory.cs
+++ b/Assets/LeapMotion/Scripts/HandFactory.cs
@@ -9,6 +9,6 @@ namespace Leap {
     /// <param name="hand">The hand for which a repersentation is to be generaetd</param>
     /// <returns>A hand representation for the given hand</returns>
     
-    public abstract HandRepresentation MakeHandRepresentation(Leap.Hand hand, ModelType modelType);
+    public abstract HandRepresentation MakeHandRepresentation(Leap.IHand hand, ModelType modelType);
   }
 }

--- a/Assets/LeapMotion/Scripts/HandPool.cs
+++ b/Assets/LeapMotion/Scripts/HandPool.cs
@@ -33,7 +33,7 @@ namespace Leap {
       controller_ = GetComponent<LeapHandController>();
     }
 
-    public override HandRepresentation MakeHandRepresentation(Leap.Hand hand, ModelType modelType) {
+    public override HandRepresentation MakeHandRepresentation(Leap.IHand hand, ModelType modelType) {
       HandRepresentation handRep = null;
       for (int i = 0; i < ModelPool.Count; i++) {
         IHandModel model = ModelPool[i];

--- a/Assets/LeapMotion/Scripts/HandProxy.cs
+++ b/Assets/LeapMotion/Scripts/HandProxy.cs
@@ -9,7 +9,7 @@ namespace Leap {
     HandTransitionBehavior handFinishBehavior;
 
   
-    public HandProxy(HandPool parent, IHandModel handModel, Leap.Hand hand) :
+    public HandProxy(HandPool parent, IHandModel handModel, Leap.IHand hand) :
       base(hand.Id)
     {
       this.parent = parent;
@@ -38,7 +38,7 @@ namespace Leap {
       handModel = null;
     }
 
-    public override void UpdateRepresentation(Leap.Hand hand, ModelType modelType){
+    public override void UpdateRepresentation(Leap.IHand hand, ModelType modelType){
       handModel.SetLeapHand(hand);
       handModel.UpdateHand();
     }

--- a/Assets/LeapMotion/Scripts/HandRepresentation.cs
+++ b/Assets/LeapMotion/Scripts/HandRepresentation.cs
@@ -19,7 +19,7 @@ namespace Leap {
     /// Notifies the representation that a hand information update is available
     /// </summary>
     /// <param name="hand">The current Leap.Hand</param>
-    public abstract void UpdateRepresentation(Leap.Hand hand, ModelType modelType);
+    public abstract void UpdateRepresentation(Leap.IHand hand, ModelType modelType);
 
     /// <summary>
     /// Called when a hand representation is no longer needed

--- a/Assets/LeapMotion/Scripts/Hands/CapsuleHand.cs
+++ b/Assets/LeapMotion/Scripts/Hands/CapsuleHand.cs
@@ -36,7 +36,7 @@ public class CapsuleHand : IHandModel {
   private List<Transform> _sphereBTransforms;
 
   private Transform armFrontLeft, armFrontRight, armBackLeft, armBackRight;
-  private Hand hand_;
+    private IHand hand_;
 
   public override ModelType HandModelType {
     get {
@@ -51,11 +51,13 @@ public class CapsuleHand : IHandModel {
     }
   }
 
-  public override Hand GetLeapHand() {
+    public override IHand GetLeapHand()
+    {
     return hand_;
   }
 
-  public override void SetLeapHand(Hand hand) {
+    public override void SetLeapHand(IHand hand)
+    {
     hand_ = hand;
   }
 
@@ -104,9 +106,11 @@ public class CapsuleHand : IHandModel {
   private void updateSpheres() {
     //Update all spheres
     FingerList fingers = hand_.Fingers;
-    for (int i = 0; i < fingers.Count; i++) {
-      Finger finger = fingers[i];
-      for (int j = 0; j < 4; j++) {
+        for (int i = 0; i < fingers.Count; i++)
+        {
+            IFinger finger = fingers[i];
+            for (int j = 0; j < 4; j++)
+            {
         int key = getFingerJointIndex((int)finger.Type, j);
         Transform sphere = _jointSpheres[key];
         sphere.position = finger.JointPosition((Finger.FingerJoint)j).ToUnityScaled();
@@ -140,37 +144,51 @@ public class CapsuleHand : IHandModel {
     armBackLeft.position = elbow - right;
   }
 
-  private void updateCapsules() {
-    for (int i = 0; i < _capsuleTransforms.Count; i++) {
+    private void updateCapsules()
+    {
+        Vector3 scale;
+        scale.x = scale.z = CYLINDER_RADIUS * 2;
+
+        float lossyScaleXFactor = 0.5f / transform.lossyScale.x;
+
+        for (int i = 0; i < _capsuleTransforms.Count; i++)
+        {
       Transform capsule = _capsuleTransforms[i];
-      Transform sphereA = _sphereATransforms[i];
-      Transform sphereB = _sphereBTransforms[i];
+            Vector3 sphereA = _sphereATransforms[i].position;
+            Vector3 sphereB = _sphereBTransforms[i].position;
 
-      Vector3 delta = sphereA.position - sphereB.position;
+            Vector3 delta = sphereA - sphereB;
+            float deltaMag = delta.magnitude;
 
-      Vector3 scale = capsule.localScale;
-      scale.x = CYLINDER_RADIUS * 2;
-      scale.y = delta.magnitude * 0.5f / transform.lossyScale.x;
-      scale.z = CYLINDER_RADIUS * 2;
+            capsule.position = (sphereA + sphereB) / 2.0f;
 
-      capsule.localScale = scale;
+            scale.y = deltaMag * lossyScaleXFactor;
 
-      capsule.position = (sphereA.position + sphereB.position) / 2;
+            capsule.localScale = scale;
 
-      if (delta.sqrMagnitude <= Mathf.Epsilon) {
+            if (deltaMag <= Mathf.Epsilon)
+            {
         //Two spheres are at the same location, no rotation will be found
         continue;
       }
 
+            /*/
       Vector3 perp;
-      if (Vector3.Angle(delta, Vector3.up) > 170 || Vector3.Angle(delta, Vector3.up) < 10) {
+            float angleToUp = Vector3.Angle(delta, Vector3.up);
+            
+            if (angleToUp > 170 || angleToUp < 10)
+            {
         perp = Vector3.Cross(delta, Vector3.right);
       }
-      else {
+            else
+            {
         perp = Vector3.Cross(delta, Vector3.up);
       }
 
       capsule.rotation = Quaternion.LookRotation(perp, delta);
+            /*/
+            capsule.rotation = Quaternion.FromToRotation(Vector3.up, delta);
+            /**/
     }
   }
 
@@ -185,9 +203,11 @@ public class CapsuleHand : IHandModel {
   private void createSpheres() {
     //Create spheres for finger joints
     FingerList fingers = hand_.Fingers;
-    for (int i = 0; i < fingers.Count; i++) {
-      Finger finger = fingers[i];
-      for (int j = 0; j < 4; j++) {
+        for (int i = 0; i < fingers.Count; i++)
+        {
+            IFinger finger = fingers[i];
+            for (int j = 0; j < 4; j++)
+            {
         int key = getFingerJointIndex((int)finger.Type, j);
         _jointSpheres[key] = createSphere("Joint", SPHERE_RADIUS);
       }

--- a/Assets/LeapMotion/Scripts/Hands/FingerModel.cs
+++ b/Assets/LeapMotion/Scripts/Hands/FingerModel.cs
@@ -38,9 +38,9 @@ public abstract class FingerModel : MonoBehaviour {
   
   // Leap references
   /** The Leap Hand object. */
-  protected Hand hand_;
+  protected IHand hand_;
   /** The Leap Finger object. */
-  protected Finger finger_;
+  protected IFinger finger_;
   /** An added offset vector. */
   protected Vector3 offset_ = Vector3.zero;
   /** Whether this finger is mirrored. */
@@ -64,7 +64,7 @@ public abstract class FingerModel : MonoBehaviour {
   * parent HandModel object calls this function to set or update the underlying
   * finger. The tracking data in the Leap objects are used to update the FingerModel.
   */ 
-  public void SetLeapHand(Hand hand) {
+  public void SetLeapHand(IHand hand) {
     hand_ = hand;
     if (hand_ != null)
       finger_ = hand.Fingers[(int)fingerType];
@@ -89,9 +89,9 @@ public abstract class FingerModel : MonoBehaviour {
   }
 
   /** The Leap Hand object. */
-  public Hand GetLeapHand() { return hand_; }
+  public IHand GetLeapHand() { return hand_; }
   /** The Leap Finger object. */
-  public Finger GetLeapFinger() { return finger_; }
+  public IFinger GetLeapFinger() { return finger_; }
 
   /** 
   * Implement this function to initialize this finger after it is created.
@@ -153,7 +153,7 @@ public abstract class FingerModel : MonoBehaviour {
   /** Returns the center of the given bone on the finger */
   public Vector3 GetBoneCenter(int bone_type) {
     if (finger_ != null) {
-      Bone bone = finger_.Bone ((Bone.BoneType)(bone_type));
+      IBone bone = finger_.Bone ((Bone.BoneType)(bone_type));
       return bone.Center.ToUnityScaled();
 
     }

--- a/Assets/LeapMotion/Scripts/Hands/HandDrop.cs
+++ b/Assets/LeapMotion/Scripts/Hands/HandDrop.cs
@@ -5,7 +5,7 @@ namespace Leap {
   public class HandDrop : HandTransitionBehavior {
     private Vector3 startingPalmPosition;
     private Quaternion startingOrientation;
-    private Vector3 startingScale;
+    // private Vector3 startingScale;
     private Transform palm;
 
     // Use this for initialization
@@ -13,7 +13,7 @@ namespace Leap {
       palm = GetComponent<HandModel>().palm;
       startingPalmPosition = palm.localPosition;
       startingOrientation = palm.localRotation;
-      startingScale = transform.localScale;
+      // startingScale = transform.localScale;
     }
 
     public override void HandFinish() {

--- a/Assets/LeapMotion/Scripts/Hands/HandModel.cs
+++ b/Assets/LeapMotion/Scripts/Hands/HandModel.cs
@@ -54,7 +54,7 @@ public abstract class HandModel : IHandModel {
   
   // Leap references
   /** The Leap Hand object this hand model represents. */
-  protected Hand hand_;
+  protected IHand hand_;
   /** The parent HandController object for this hand. */
   //protected HandController controller_;
   protected LeapHandController controller_;
@@ -214,7 +214,7 @@ public abstract class HandModel : IHandModel {
   * Leap Hand object are relative to the Leap Motion coordinate system,
   * which uses a right-handed axes and units of millimeters.
   */
-  public override Hand GetLeapHand() {
+  public override IHand GetLeapHand() {
     return hand_;
   }
 
@@ -223,7 +223,7 @@ public abstract class HandModel : IHandModel {
   * Note that the Leap Hand objects are recreated every frame. The parent 
   * HandController calls this method to set or update the underlying hand.
   */
-  public override void SetLeapHand(Hand hand) {
+  public override void SetLeapHand(IHand hand) {
     hand_ = hand;
     for (int i = 0; i < fingers.Length; ++i) {
       if (fingers[i] != null) {
@@ -259,7 +259,7 @@ public abstract class HandModel : IHandModel {
   * by the Leap Motion device.
   */
   public override void InitHand() {
-    Debug.Log("HandModel.InitHand() +++++++++++++++++++++++++++++++++++++++++++");
+    
     for (int f = 0; f < fingers.Length; ++f) {
       if (fingers[f] != null) {
         fingers[f].fingerType = (Finger.FingerType)f;

--- a/Assets/LeapMotion/Scripts/Hands/IHandModel.cs
+++ b/Assets/LeapMotion/Scripts/Hands/IHandModel.cs
@@ -17,8 +17,8 @@ public abstract class IHandModel : MonoBehaviour {
     //Debug.Log("IHandModel.InitHand()");
   }
   public abstract void UpdateHand();
-  public abstract Hand GetLeapHand(); 
-  public abstract void SetLeapHand(Hand hand);
+  public abstract IHand GetLeapHand(); 
+  public abstract void SetLeapHand(IHand hand);
   private bool isLeft;
 #if UNITY_EDITOR
   void Awake() {
@@ -27,7 +27,8 @@ public abstract class IHandModel : MonoBehaviour {
       if (Handedness == Chirality.Left) {
         isLeft = true;
       }
-      SetLeapHand(TestHandFactory.MakeTestHand(0, 0, isLeft).TransformedCopy(GetLeapMatrix()));
+      Matrix leapMatrix = GetLeapMatrix();
+      SetLeapHand(TestHandFactory.MakeTestHand(0, 0, isLeft).TransformedCopy(ref leapMatrix));
       InitHand();
     }
   }
@@ -37,7 +38,8 @@ public abstract class IHandModel : MonoBehaviour {
         isLeft = true;
       }
       //Debug.Log("IHandModel.Update()");
-      SetLeapHand(TestHandFactory.MakeTestHand(0, 0, isLeft).TransformedCopy(GetLeapMatrix()));
+      Matrix leapMatrix = GetLeapMatrix();
+      SetLeapHand(TestHandFactory.MakeTestHand(0, 0, isLeft).TransformedCopy(ref leapMatrix));
       UpdateHand();
     }
   }

--- a/Assets/LeapMotion/Scripts/Hands/MinimalHand.cs
+++ b/Assets/LeapMotion/Scripts/Hands/MinimalHand.cs
@@ -23,7 +23,7 @@ public class MinimalHand : IHandModel {
   [SerializeField]
   private Material _jointMat;
 
-  private Hand _hand;
+  private IHand _hand;
   private Transform _palm;
   private Transform[] _joints;
 
@@ -39,11 +39,11 @@ public class MinimalHand : IHandModel {
     }
   }
 
-  public override void SetLeapHand(Hand hand) {
+  public override void SetLeapHand(IHand hand) {
     _hand = hand;
   }
 
-  public override Hand GetLeapHand() {
+  public override IHand GetLeapHand() {
     return _hand;
   }
 
@@ -60,7 +60,7 @@ public class MinimalHand : IHandModel {
     var list = _hand.Fingers;
     int index = 0;
     for (int i = 0; i < 5; i++) {
-      Finger finger = list[i];
+      IFinger finger = list[i];
       for (int j = 0; j < 4; j++) {
         _joints[index++].position = finger.JointPosition((Finger.FingerJoint)j).ToVector3();
       }

--- a/Assets/LeapMotion/Scripts/Hands/TestHandFactory.cs
+++ b/Assets/LeapMotion/Scripts/Hands/TestHandFactory.cs
@@ -15,7 +15,8 @@ using System.Runtime.InteropServices;
             return testFrame;
         }
 
-        public static Hand MakeTestHand(int frameId, int handId, bool isLeft){
+        public static IHand MakeTestHand(int frameId, int handId, bool isLeft)
+        {
             FingerList fingers = new FingerList(5);
             fingers.Add(MakeThumb (frameId, handId));
             fingers.Add(MakeIndexFinger (frameId, handId));
@@ -51,7 +52,7 @@ using System.Runtime.InteropServices;
                 return testHand;
             } else {
                 Matrix leftToRight = new Matrix(Vector.Right, Vector.Up, Vector.Forward);
-                return testHand.TransformedCopy(leftToRight);
+                return testHand.TransformedCopy(ref leftToRight);
             }
         }
          static Finger MakeThumb(int frameId, int handId){

--- a/Assets/LeapMotion/Scripts/LeapHandController.cs
+++ b/Assets/LeapMotion/Scripts/LeapHandController.cs
@@ -83,7 +83,7 @@ namespace Leap {
     }
     /** Updates the graphics HandRepresentations. */
     void Update() {
-      Frame frame = Provider.CurrentFrame;
+      IFrame frame = Provider.CurrentFrame;
       if (frame.Id != prev_graphics_id_ && graphicsEnabled) {
         UpdateHandRepresentations(graphicsReps, ModelType.Graphics);
         prev_graphics_id_ = frame.Id;
@@ -98,7 +98,12 @@ namespace Leap {
     * created and added to the dictionary. 
     */
     void UpdateHandRepresentations(Dictionary<int, HandRepresentation> all_hand_reps, ModelType modelType) {
-      foreach (Leap.Hand curHand in Provider.CurrentFrame.Hands) {
+      // foreach (Leap.IHand curHand in Provider.CurrentFrame.Hands) {
+      // Avoid iterator allocation
+      IFrame frame = Provider.CurrentFrame;
+      for(int i = 0; i < frame.Hands.Count; i++)
+      {
+        IHand curHand = frame.Hands[i];
         HandRepresentation rep;
         if (!all_hand_reps.TryGetValue(curHand.Id, out rep)) {
           rep = Factory.MakeHandRepresentation(curHand, modelType);
@@ -142,7 +147,7 @@ namespace Leap {
       var latestFrame = Provider.CurrentFrame;
       Provider.PerFrameFixedUpdateOffset = latestFrame.Timestamp * NS_TO_S - Time.fixedTime;
 
-      Frame frame = Provider.GetFixedFrame();
+      IFrame frame = Provider.GetFixedFrame();
 
       if (frame.Id != prev_physics_id_ && physicsEnabled) {
         UpdateHandRepresentations(physicsReps, ModelType.Physics);

--- a/Assets/LeapMotion/Scripts/LeapImageRetriever.cs
+++ b/Assets/LeapMotion/Scripts/LeapImageRetriever.cs
@@ -89,6 +89,10 @@ public class LeapImageRetriever : MonoBehaviour {
       TextureFormat format = getTextureFormat(image);
 
       if (_combinedTexture != null) {
+				if ((_combinedTexture.height == combinedHeight) &&
+				    (_combinedTexture.width == combinedWidth))
+					return;
+
         DestroyImmediate(_combinedTexture);
       }
 
@@ -353,7 +357,7 @@ public class LeapImageRetriever : MonoBehaviour {
       _lastTime = _startTime;
     }
     _requestedImages++;
-    Frame imageFrame = provider.CurrentFrame;
+    IFrame imageFrame = provider.CurrentFrame;
     Controller controller = provider.GetLeapController();
 
     _requestedImage = controller.RequestImages(imageFrame.Id, Image.ImageType.DEFAULT);


### PR DESCRIPTION
…with zero-copy implementations of TransformedCopy.
The objective was to eliminate most memory allocations that contribute to GC stutter, most of which happened on Frame.TransformedCopy.
This was achieved by creating classes which transform the original values on demand, instead of transforming and copying all the values before-hand. Instances of these classes are obtained calling TransformedShallowCopy.
Of course, these Transformed* classes have different performance characteristics, but in the demo scene, using the CapsuleHand, the aggregated performance was improved. Even thou TransformedShallowCopy is much faster than TransformedCopy, the following scripts are slower since the actual calculation is happening lazily. In the end it's a clear win.

I needed to check whether those implementations were correct, so I created an Asserter class which compares two IFrame instances (and all it's children objects). This uncovered a few bugs in the original implementations and the new Transformed classes. For example, the bug #6 reported early doesn't affect the new classes. Anyway, there is some new code in LeapProvider.Update to optionally compare Frames transformed by TransformedCopy and TransformedShallowCopy.

Once those interfaces were created, I also created Invalid versions of those objects. These implementations throw NotImplementedExceptions (should change to something more appropriate like  IllegalOperationException) for every method, except IsValid and Equals. This allows a much more defensive coding style, where you MUST check IsValid before accessing an object, otherwise an exception is thrown. The static Invalid properties then were changed to return appropriate Invalid* singletons too, further reducing memory allocation.

Another huge source of memory allocations was in LeapImageRetriever. The _combinedTexture was being destroyed every frame just to be recreated. This was fixed too.

Looking at the Unity profiler, there is just a 44 byte allocation of a iterator in UpdateHandRepresentations now. 

Remaining fixes and improvements:
FIX: Leap.Arm.TransformedCopy didn't normalize Direction.
FIX: Fixed FingerId propagation issue (#15)
IMP: TransformedCopy methods now receive Matrix by ref.
IMP: Methods FingerList.{Left, Front, Right}most don't allocate a temporary invalid Finger.
IMP: Methods HandList.{Left, Front, Right}most don't allocate a temporary invalid Finger.
IMP: CapsuleHand.updateCapsules performance improvements
IMP: LeapProvider.GetFixedFrame: only transform the returned frame.
