### PR TITLE
Revert timeout in LeapPollConnection to 1000

### DIFF
--- a/Assets/LeapC/Connection.cs
+++ b/Assets/LeapC/Connection.cs
@@ -172,7 +172,7 @@ namespace LeapInternal
           lock(_connLocker) {
             if (_leapConnection == IntPtr.Zero)
               break;
-            uint timeout = 1;
+            uint timeout = 1000;
             result = LeapC.PollConnection(_leapConnection, timeout, ref _msg);
           }
 


### PR DESCRIPTION
The timeout was changed to 1 to temporally fix - Unity hang after play and stop for 3 times.
The current platform develop branch fixed this issue.
I verified on Mac and Shaun verified on Windows, the bug should be fixed with leap service built from the current platform develop.
So revert the temporary fix.