### PR TITLE
Added Interpolation to Service Provider

### DIFF
--- a/Assets/LeapMotion/Editor/LeapServiceProviderEditor.cs
+++ b/Assets/LeapMotion/Editor/LeapServiceProviderEditor.cs
@@ -1,0 +1,40 @@
+﻿using UnityEngine;
+using UnityEditor;
+using System.Collections.Generic;
+
+namespace Leap.Unity {
+
+  [CustomEditor(typeof(LeapServiceProvider))]
+  public class LeapServiceProviderEditor : Editor {
+    public static string _interpolationToggleProperty = "_useInterpolation";
+    public static List<string> _interpolationProperties = new List<string> { "_interpolationDelay" };
+
+    public static string _overrideDeviceToggleProperty = "_overrideDeviceType";
+    public static List<string> _deviceTypeProperties = new List<string> { "_overrideDeviceTypeWith" };
+
+    public override void OnInspectorGUI() {
+      serializedObject.Update();
+      SerializedProperty properties = serializedObject.GetIterator();
+
+      bool useInterpolation = serializedObject.FindProperty(_interpolationToggleProperty).boolValue;
+      bool overrideDeviceType = serializedObject.FindProperty(_overrideDeviceToggleProperty).boolValue;
+
+      bool useEnterChildren = true;
+      while (properties.NextVisible(useEnterChildren)) {
+        useEnterChildren = false;
+
+        if (_interpolationProperties.Contains(properties.name) && !useInterpolation) {
+          continue;
+        }
+
+        if (_deviceTypeProperties.Contains(properties.name) && !overrideDeviceType) {
+          continue;
+        }
+
+        EditorGUILayout.PropertyField(properties, true);
+      }
+
+      serializedObject.ApplyModifiedProperties();
+    }
+  }
+}

--- a/Assets/LeapMotion/Editor/LeapServiceProviderEditor.cs.meta
+++ b/Assets/LeapMotion/Editor/LeapServiceProviderEditor.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 820a690b04c5ed7449f6d0bd3a657f06
+timeCreated: 1458765852
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapMotion/Scripts/LeapHandController.cs
+++ b/Assets/LeapMotion/Scripts/LeapHandController.cs
@@ -69,7 +69,7 @@ namespace Leap.Unity {
     protected virtual void Update() {
       Frame frame = Provider.CurrentFrame;
 
-      if (graphicsEnabled) {
+      if (frame != null && graphicsEnabled) {
         UpdateHandRepresentations(graphicsReps, ModelType.Graphics, frame);
       }
     }
@@ -78,7 +78,7 @@ namespace Leap.Unity {
     protected virtual void FixedUpdate() {
       Frame fixedFrame = Provider.CurrentFixedFrame;
 
-      if (physicsEnabled) {
+      if (fixedFrame != null && physicsEnabled) {
         UpdateHandRepresentations(physicsReps, ModelType.Physics, fixedFrame);
       }
     }

--- a/Assets/LeapMotion/Scripts/LeapHandController.cs
+++ b/Assets/LeapMotion/Scripts/LeapHandController.cs
@@ -53,8 +53,6 @@ namespace Leap.Unity {
         }
       }
     }
-    private long prev_graphics_id_ = 0;
-    private long prev_physics_id_ = 0;
 
     /** Draws the Leap Motion gizmo when in the Unity editor. */
     void OnDrawGizmos() {
@@ -70,10 +68,9 @@ namespace Leap.Unity {
     /** Updates the graphics HandRepresentations. */
     protected virtual void Update() {
       Frame frame = Provider.CurrentFrame;
-      if (frame.Id != prev_graphics_id_ && graphicsEnabled) {
-        UpdateHandRepresentations(graphicsReps, ModelType.Graphics, frame);
-        prev_graphics_id_ = frame.Id;
 
+      if (graphicsEnabled) {
+        UpdateHandRepresentations(graphicsReps, ModelType.Graphics, frame);
       }
     }
 
@@ -81,9 +78,8 @@ namespace Leap.Unity {
     protected virtual void FixedUpdate() {
       Frame fixedFrame = Provider.CurrentFixedFrame;
 
-      if (fixedFrame.Id != prev_physics_id_ && physicsEnabled) {
+      if (physicsEnabled) {
         UpdateHandRepresentations(physicsReps, ModelType.Physics, fixedFrame);
-        prev_physics_id_ = fixedFrame.Id;
       }
     }
 

--- a/Assets/LeapMotion/Scripts/LeapServiceProvider.cs
+++ b/Assets/LeapMotion/Scripts/LeapServiceProvider.cs
@@ -28,8 +28,9 @@ namespace Leap.Unity {
     protected LeapDeviceType _overrideDeviceTypeWith = LeapDeviceType.Peripheral;
 
     [Header("Interpolation")]
+    [Tooltip("Interpolate frames to deliver a potentially smoother experience.  Currently experimental.")]
     [SerializeField]
-    protected bool _useInterpolation = true;
+    protected bool _useInterpolation = false;
 
     [Tooltip("How much delay should be added to interpolation.  A non-zero amount is needed to prevent extrapolation artifacts.")]
     [SerializeField]

--- a/Assets/LeapMotion/Scripts/LeapServiceProvider.cs
+++ b/Assets/LeapMotion/Scripts/LeapServiceProvider.cs
@@ -64,6 +64,24 @@ namespace Leap.Unity {
       }
     }
 
+    public bool UseInterpolation {
+      get {
+        return _useInterpolation;
+      }
+      set {
+        _useInterpolation = value;
+      }
+    }
+
+    public long InterpolationDelay {
+      get {
+        return _interpolationDelay;
+      }
+      set {
+        _interpolationDelay = value;
+      }
+    }
+
     /** Returns the Leap Controller instance. */
     public Controller GetLeapController() {
 #if UNITY_EDITOR
@@ -136,7 +154,7 @@ namespace Leap.Unity {
         Debug.LogWarning("Unity hot reloading not currently supported. Stopping Editor Playback.");
       }
 #endif
-      
+
       Int64 unityTime = (Int64)(Time.time * 1e6);
       clockCorrelator.UpdateRebaseEstimate(unityTime);
 
@@ -157,7 +175,8 @@ namespace Leap.Unity {
 
     protected virtual void FixedUpdate() {
       //TODO: Find suitable interpolation strategy for FixedUpdate
-      _currentFixedFrame = leap_controller_.Frame();
+      Matrix leapMat = UnityMatrixExtension.GetLeapMatrix(transform);
+      _currentFixedFrame = leap_controller_.Frame().TransformedCopy(leapMat);
     }
 
     protected virtual void OnDestroy() {
@@ -216,7 +235,6 @@ namespace Leap.Unity {
         leap_controller_ = null;
       }
     }
-
 
     protected void onHandControllerConnect(object sender, LeapEventArgs args) {
       initializeFlags();

--- a/Assets/LeapMotion/Scripts/LeapServiceProvider.cs
+++ b/Assets/LeapMotion/Scripts/LeapServiceProvider.cs
@@ -19,13 +19,15 @@ namespace Leap.Unity {
     [SerializeField]
     protected bool _isHeadMounted = false;
 
+    [Header("Device Type")]
     [SerializeField]
-    protected bool overrideDeviceType = false;
+    protected bool _overrideDeviceType = false;
 
     [Tooltip("If overrideDeviceType is enabled, the hand controller will return a device of this type.")]
     [SerializeField]
     protected LeapDeviceType _overrideDeviceTypeWith = LeapDeviceType.Peripheral;
 
+    [Header("Interpolation")]
     [SerializeField]
     protected bool _useInterpolation = true;
 
@@ -81,7 +83,7 @@ namespace Leap.Unity {
 
     /** Returns information describing the device hardware. */
     public LeapDeviceInfo GetDeviceInfo() {
-      if (overrideDeviceType) {
+      if (_overrideDeviceType) {
         return new LeapDeviceInfo(_overrideDeviceTypeWith);
       }
 

--- a/Assets/LeapMotion/Scripts/LeapServiceProvider.cs
+++ b/Assets/LeapMotion/Scripts/LeapServiceProvider.cs
@@ -88,7 +88,6 @@ namespace Leap.Unity {
       //Null check to deal with hot reloading
       if (leap_controller_ == null) {
         createController();
-        Debug.Log("GetLeapController() calling createController()");
       }
 #endif
       return leap_controller_;
@@ -213,7 +212,6 @@ namespace Leap.Unity {
      * and subscribe to connection event */
     protected void createController() {
       if (leap_controller_ != null) {
-        Debug.Log("Did destroy?");
         destroyController();
       }
 

--- a/Assets/LeapMotion/Scripts/LeapServiceProvider.cs
+++ b/Assets/LeapMotion/Scripts/LeapServiceProvider.cs
@@ -125,6 +125,8 @@ namespace Leap.Unity {
 
     protected virtual void Start() {
       createController();
+      _currentFrame = new Frame();
+      _currentFixedFrame = new Frame();
     }
 
     protected virtual void Update() {

--- a/Assets/LeapMotion/Scripts/LeapServiceProvider.cs.meta
+++ b/Assets/LeapMotion/Scripts/LeapServiceProvider.cs.meta
@@ -1,11 +1,11 @@
 fileFormatVersion: 2
 guid: 025cc0fa7b46aa541aba29d28d35ac09
-timeCreated: 1457404108
-licenseType: Pro
+timeCreated: 1458755922
+licenseType: Free
 MonoImporter:
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: -1000
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 5.3.2f1
+m_EditorVersion: 5.3.4f1
 m_StandardAssetsVersion: 0


### PR DESCRIPTION
- LeapServiceProvider now has an option (which is enabled by default) to use interpolation for it's frames. (Currently this only affects update frames, not physics frames).
- There is an option for an interpolation delay, which helps reduce extrapolation artifacts (this can be done more automatically in the future)
- A custom editor has been added to LeapServiceProvider to allow easier editing.  When features are disabled, settings for that feature are hidden.  
- LeapHandController always updates representations now, even if the IDs are the same.  This is to allow for interpolation when tracking is running at low framerate (which results in multiple different interpolated frames with the same ID)

@protodeep 

To test:
- [x] Visit the VR scene and verify that the representations are interpolated smoothly.
- [x] Trigger robust mode and verify that representations are still interpolated smoothly (delay might need to be increased)
- [x] Trigger low resource mode and verify that representations are still interpolated smoothly (delay might need to be increased)