### PR TITLE
Fixed physics classification in manager.

### DIFF
--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionC/InteractionC.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionC/InteractionC.cs
@@ -127,15 +127,31 @@ namespace Leap.Unity.Interaction.CApi {
   }
 
   [StructLayout(LayoutKind.Sequential, Pack = 1)]
-  public struct LEAP_IE_SHAPE_DESCRIPTION_HANDLE {
+  public struct LEAP_IE_SHAPE_DESCRIPTION_HANDLE : IEquatable<LEAP_IE_SHAPE_DESCRIPTION_HANDLE> {
     public UInt32 handle;
     public IntPtr pDEBUG; // LeapIEShapeDescriptionData*
+
+    public bool Equals(LEAP_IE_SHAPE_DESCRIPTION_HANDLE other) {
+      return handle == other.handle;
+    }
+
+    public override int GetHashCode() {
+      return (int)handle;
+    }
   }
 
   [StructLayout(LayoutKind.Sequential, Pack = 1)]
-  public struct LEAP_IE_SHAPE_INSTANCE_HANDLE {
+  public struct LEAP_IE_SHAPE_INSTANCE_HANDLE : IEquatable<LEAP_IE_SHAPE_INSTANCE_HANDLE> {
     public UInt32 handle;
     public IntPtr pDEBUG; // LeapIEShapeInstanceData*
+
+    public bool Equals(LEAP_IE_SHAPE_INSTANCE_HANDLE other) {
+      return handle == other.handle;
+    }
+
+    public override int GetHashCode() {
+      return (int)handle;
+    }
   }
 
   [StructLayout(LayoutKind.Sequential, Pack = 1)]
@@ -415,8 +431,7 @@ namespace Leap.Unity.Interaction.CApi {
       IntPtr arrayPtr;
       GetDebugLines(ref scene, out lines, out arrayPtr);
 
-      for (int i = 0; i < lines; i++)
-      {
+      for (int i = 0; i < lines; i++) {
         LEAP_IE_DEBUG_LINE line = StructMarshal<LEAP_IE_DEBUG_LINE>.ArrayElementToStruct(arrayPtr, i);
         line.Draw();
       }

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
@@ -253,7 +253,7 @@ namespace Leap.Unity.Interaction {
                                        out classification,
                                        out instance);
 
-        InteractionBehaviour interactionBehaviour = _instanceHandleToBehaviour[instance];
+        
 
         //Get the InteractionHand associated with this hand id
         InteractionHand interactionHand;
@@ -290,6 +290,7 @@ namespace Leap.Unity.Interaction {
         switch (classification.classification) {
           case eLeapIEClassification.eLeapIEClassification_Grasp:
             {
+              InteractionBehaviour interactionBehaviour = _instanceHandleToBehaviour[instance];
               if (interactionHand.graspedObject == null) {
                 _graspedBehaviours.Add(interactionBehaviour);
                 interactionHand.GraspObject(interactionBehaviour);
@@ -299,7 +300,7 @@ namespace Leap.Unity.Interaction {
           case eLeapIEClassification.eLeapIEClassification_Physics:
             {
               if (interactionHand.graspedObject != null) {
-                _graspedBehaviours.Remove(interactionBehaviour);
+                _graspedBehaviours.Remove(interactionHand.graspedObject);
                 interactionHand.ReleaseObject();
               }
               break;


### PR DESCRIPTION
- No handle is returned in the case of the physics classification, use the reference already stored in InteractionHand instead.
- Had the low level handles implement the IEquatable interface so they can be used as keys.

@ajohnston33 