### PR TITLE
Updated ShapePool and improved memory safety

### DIFF
--- a/Assets/LeapMotionModules/InteractionEngine/Scenes/ExampleScene.unity
+++ b/Assets/LeapMotionModules/InteractionEngine/Scenes/ExampleScene.unity
@@ -946,8 +946,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 025cc0fa7b46aa541aba29d28d35ac09, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _isHeadMounted: 0
-  _overrideDeviceType: 0
+  _isHeadMounted: 1
+  _overrideDeviceType: 1
   _overrideDeviceTypeWith: 1
   _useInterpolation: 0
   _interpolationDelay: 15

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
@@ -287,7 +287,7 @@ namespace Leap.Unity.Interaction {
     /// with the manager before interaction can be enabled.
     /// </summary>
     public void EnableInteraction() {
-      if (!_isRegisteredWithManager) {
+      if (_isRegisteredWithManager) {
         return;
       }
 

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionC/InteractionC.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionC/InteractionC.cs
@@ -114,7 +114,7 @@ namespace Leap.Unity.Interaction.CApi {
   public struct LEAP_IE_CONVEX_POLYHEDRON_DESCRIPTION {
     public LEAP_IE_SHAPE_DESCRIPTION shape;
     public UInt32 nVerticies;
-    public IntPtr pVertices; //LEAP_VECTOR*
+    public LEAP_VECTOR[] pVertices;
     public float radius;
   }
 
@@ -123,7 +123,7 @@ namespace Leap.Unity.Interaction.CApi {
     public LEAP_IE_SHAPE_DESCRIPTION shape;
     public UInt32 nShapes;
     public IntPtr pShapes; //LEAP_IE_SHAPE_DESCRIPTION**
-    public IntPtr pTransforms; //LEAP_IE_TRANSFORM*
+    public LEAP_IE_TRANSFORM[] pTransforms;
   }
 
   [StructLayout(LayoutKind.Sequential, Pack = 1)]

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
@@ -115,7 +115,7 @@ namespace Leap.Unity.Interaction {
       _registeredBehaviours.Add(interactionBehaviour);
 
       //Don't create right away if we are not enabled, creation will be done in OnEnable
-      if (enabled) {
+      if (isActiveAndEnabled) {
         createInteractionShape(interactionBehaviour);
       }
     }
@@ -129,7 +129,7 @@ namespace Leap.Unity.Interaction {
       _registeredBehaviours.Remove(interactionBehaviour);
 
       //Don't destroy if we are not enabled, everything already got destroyed in OnDisable
-      if (enabled) {
+      if (isActiveAndEnabled) {
         destroyInteractionShape(interactionBehaviour);
       }
     }

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/ShapeDescriptionPool.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/ShapeDescriptionPool.cs
@@ -136,8 +136,8 @@ namespace Leap.Unity.Interaction {
       LEAP_IE_COMPOUND_DESCRIPTION compoundDesc = new LEAP_IE_COMPOUND_DESCRIPTION();
       compoundDesc.shape.type = eLeapIEShapeType.eLeapIEShape_Compound;
       compoundDesc.nShapes = (uint)_tempColliderList.Count;
-      compoundDesc.pShapes = StructAllocator.AllocateArray<LEAP_IE_TRANSFORM>(_tempColliderList.Count);
-      compoundDesc.pTransforms = StructAllocator.AllocateArray<IntPtr>(_tempColliderList.Count);
+      compoundDesc.pShapes = StructAllocator.AllocateArray<IntPtr>(_tempColliderList.Count);
+      compoundDesc.pTransforms = new LEAP_IE_TRANSFORM[_tempColliderList.Count];
 
       for (int i = 0; i < _tempColliderList.Count; i++) {
         Collider collider = _tempColliderList[i];
@@ -202,7 +202,7 @@ namespace Leap.Unity.Interaction {
         ieTransform.rotation = new LEAP_QUATERNION(Quaternion.Inverse(parentObject.transform.rotation) * globalRot);
 
         StructMarshal<IntPtr>.CopyIntoArray(compoundDesc.pShapes, shapePtr, i);
-        StructMarshal<LEAP_IE_TRANSFORM>.CopyIntoArray(compoundDesc.pTransforms, ieTransform, i);
+        compoundDesc.pTransforms[i] = ieTransform;
       }
 
       LEAP_IE_SHAPE_DESCRIPTION_HANDLE handle;
@@ -245,9 +245,9 @@ namespace Leap.Unity.Interaction {
       meshDesc.shape.type = eLeapIEShapeType.eLeapIEShape_Convex;
       meshDesc.radius = radius;
       meshDesc.nVerticies = 2;
-      meshDesc.pVertices = StructAllocator.AllocateArray<LEAP_VECTOR>(2);
-      StructMarshal<LEAP_VECTOR>.CopyIntoArray(meshDesc.pVertices, new LEAP_VECTOR(p0), 0);
-      StructMarshal<LEAP_VECTOR>.CopyIntoArray(meshDesc.pVertices, new LEAP_VECTOR(p1), 1);
+      meshDesc.pVertices = new LEAP_VECTOR[2];
+      meshDesc.pVertices[0] = new LEAP_VECTOR(p0);
+      meshDesc.pVertices[1] = new LEAP_VECTOR(p1);
 
       IntPtr capsulePtr = StructAllocator.AllocateStruct(meshDesc);
       return capsulePtr;
@@ -258,10 +258,10 @@ namespace Leap.Unity.Interaction {
       meshDesc.shape.type = eLeapIEShapeType.eLeapIEShape_Convex;
       meshDesc.radius = 0.0f;
       meshDesc.nVerticies = (uint)mesh.vertexCount;
-      meshDesc.pVertices = StructAllocator.AllocateArray<LEAP_VECTOR>(mesh.vertexCount);
+      meshDesc.pVertices = new LEAP_VECTOR[mesh.vertexCount];
       for (int i = 0; i < mesh.vertexCount; i++) {
         LEAP_VECTOR v = new LEAP_VECTOR(mesh.vertices[i] * scale);
-        StructMarshal<LEAP_VECTOR>.CopyIntoArray(meshDesc.pVertices, v, i);
+        meshDesc.pVertices[i] = v;
       }
 
       IntPtr meshPtr = StructAllocator.AllocateStruct(meshDesc);


### PR DESCRIPTION
- ShapeDescriptionPool.GetAuto() now has tons of NotImplementedExceptions in place to catch against unsupported cases.
- ShapeDescriptionPool.GetAuto() optimizes the single collider case to return that description instead of a composite shape.
- Fixed bug in InteractionBehaviour that prevented it from ever getting registered with the manager in the first place.
- Fixed bug involving the difference between enable/isActiveAndEnabled
- Updated scene to use headMountedMode
- Improved memory safety by using typed arrays where possible.

@ajohnston33 