### PR TITLE
Adding Custom Editor Base

### DIFF
--- a/Assets/LeapMotion/Editor/CustomEditorBase.cs
+++ b/Assets/LeapMotion/Editor/CustomEditorBase.cs
@@ -8,9 +8,11 @@ public class CustomEditorBase : Editor {
   protected Dictionary<string, List<Action<SerializedProperty>>> _specifiedDecorators;
   protected Dictionary<string, string> _conditionalProperties;
 
-  /**
-   * Specify a callback to be used to draw a specific named property.  Should be called in OnEnable
-   */
+  /// <summary>
+  /// Specify a callback to be used to draw a specific named property.  Should be called in OnEnable.
+  /// </summary>
+  /// <param name="propertyName"></param>
+  /// <param name="propertyDrawer"></param>
   protected void specifyCustomDrawer(string propertyName, Action<SerializedProperty> propertyDrawer) {
     if (serializedObject.FindProperty(propertyName) != null) {
       _specifiedDrawers[propertyName] = propertyDrawer;
@@ -19,6 +21,11 @@ public class CustomEditorBase : Editor {
     }
   }
 
+  /// <summary>
+  /// Specify a callback to be used to draw a decorator for a specific named property.  Should be called in OnEnable.
+  /// </summary>
+  /// <param name="propertyName"></param>
+  /// <param name="decoratorDrawer"></param>
   protected void specifyCustomDecorator(string propertyName, Action<SerializedProperty> decoratorDrawer) {
     if (serializedObject.FindProperty(propertyName) != null) {
 
@@ -34,6 +41,12 @@ public class CustomEditorBase : Editor {
     }
   }
 
+  /// <summary>
+  /// Specify a list of properties that should only be displayed if the conditional property has a value of true.
+  /// Should be called in OnEnable.
+  /// </summary>
+  /// <param name="conditionalName"></param>
+  /// <param name="dependantProperties"></param>
   protected void specifyConditionalDrawing(string conditionalName, params string[] dependantProperties) {
     for (int i = 0; i < dependantProperties.Length; i++) {
       _conditionalProperties[dependantProperties[i]] = conditionalName;

--- a/Assets/LeapMotion/Editor/CustomEditorBase.cs
+++ b/Assets/LeapMotion/Editor/CustomEditorBase.cs
@@ -1,0 +1,87 @@
+﻿using UnityEngine;
+using UnityEditor;
+using System;
+using System.Collections.Generic;
+
+public class CustomEditorBase : Editor {
+  protected Dictionary<string, Action<SerializedProperty>> _specifiedDrawers;
+  protected Dictionary<string, List<Action<SerializedProperty>>> _specifiedDecorators;
+  protected Dictionary<string, string> _conditionalProperties;
+
+  /**
+   * Specify a callback to be used to draw a specific named property.  Should be called in OnEnable
+   */
+  protected void specifyCustomDrawer(string propertyName, Action<SerializedProperty> propertyDrawer) {
+    if (serializedObject.FindProperty(propertyName) != null) {
+      _specifiedDrawers[propertyName] = propertyDrawer;
+    } else {
+      Debug.LogWarning("Specified a custom drawer for the nonexistant property [" + propertyName + "] !\nWas it renamed or deleted?");
+    }
+  }
+
+  protected void specifyCustomDecorator(string propertyName, Action<SerializedProperty> decoratorDrawer) {
+    if (serializedObject.FindProperty(propertyName) != null) {
+
+      List<Action<SerializedProperty>> list;
+      if (!_specifiedDecorators.TryGetValue(propertyName, out list)) {
+        list = new List<Action<SerializedProperty>>();
+        _specifiedDecorators[propertyName] = list;
+      }
+
+      list.Add(decoratorDrawer);
+    } else {
+      Debug.LogWarning("Specified a custom drawer for the nonexistant property [" + propertyName + "] !\nWas it renamed or deleted?");
+    }
+  }
+
+  protected void specifyConditionalDrawing(string conditionalName, params string[] dependantProperties) {
+    for (int i = 0; i < dependantProperties.Length; i++) {
+      _conditionalProperties[dependantProperties[i]] = conditionalName;
+    }
+  }
+
+  protected virtual void OnEnable() {
+    _specifiedDrawers = new Dictionary<string, Action<SerializedProperty>>();
+    _specifiedDecorators = new Dictionary<string, List<Action<SerializedProperty>>>();
+    _conditionalProperties = new Dictionary<string, string>();
+  }
+
+  /* 
+   * This method draws all visible properties, mirroring the default behavior of OnInspectorGUI. 
+   * Individual properties can be specified to have custom drawers.
+   */
+  public override void OnInspectorGUI() {
+    SerializedProperty iterator = serializedObject.GetIterator();
+    bool isFirst = true;
+
+    while (iterator.NextVisible(isFirst)) {
+      isFirst = false;
+
+      string conditionalPropertyName;
+      if (_conditionalProperties.TryGetValue(iterator.name, out conditionalPropertyName)) {
+        SerializedProperty conditionalProperty = serializedObject.FindProperty(conditionalPropertyName);
+        if (!conditionalProperty.boolValue) {
+          continue;
+        }
+      }
+
+      Action<SerializedProperty> customDrawer;
+
+      List<Action<SerializedProperty>> decoratorList;
+      if (_specifiedDecorators.TryGetValue(iterator.name, out decoratorList)) {
+        for (int i = 0; i < decoratorList.Count; i++) {
+          decoratorList[i](iterator);
+        }
+      }
+
+      if (_specifiedDrawers.TryGetValue(iterator.name, out customDrawer)) {
+        customDrawer(iterator);
+      } else {
+        EditorGUILayout.PropertyField(iterator, true);
+      }
+    }
+
+    serializedObject.ApplyModifiedProperties();
+  }
+
+}

--- a/Assets/LeapMotion/Editor/CustomEditorBase.cs
+++ b/Assets/LeapMotion/Editor/CustomEditorBase.cs
@@ -3,98 +3,100 @@ using UnityEditor;
 using System;
 using System.Collections.Generic;
 
-public class CustomEditorBase : Editor {
-  protected Dictionary<string, Action<SerializedProperty>> _specifiedDrawers;
-  protected Dictionary<string, List<Action<SerializedProperty>>> _specifiedDecorators;
-  protected Dictionary<string, string> _conditionalProperties;
+namespace Leap.Unity {
 
-  /// <summary>
-  /// Specify a callback to be used to draw a specific named property.  Should be called in OnEnable.
-  /// </summary>
-  /// <param name="propertyName"></param>
-  /// <param name="propertyDrawer"></param>
-  protected void specifyCustomDrawer(string propertyName, Action<SerializedProperty> propertyDrawer) {
-    if (serializedObject.FindProperty(propertyName) != null) {
-      _specifiedDrawers[propertyName] = propertyDrawer;
-    } else {
-      Debug.LogWarning("Specified a custom drawer for the nonexistant property [" + propertyName + "] !\nWas it renamed or deleted?");
-    }
-  }
+  public class CustomEditorBase : Editor {
+    protected Dictionary<string, Action<SerializedProperty>> _specifiedDrawers;
+    protected Dictionary<string, List<Action<SerializedProperty>>> _specifiedDecorators;
+    protected Dictionary<string, string> _conditionalProperties;
 
-  /// <summary>
-  /// Specify a callback to be used to draw a decorator for a specific named property.  Should be called in OnEnable.
-  /// </summary>
-  /// <param name="propertyName"></param>
-  /// <param name="decoratorDrawer"></param>
-  protected void specifyCustomDecorator(string propertyName, Action<SerializedProperty> decoratorDrawer) {
-    if (serializedObject.FindProperty(propertyName) != null) {
-
-      List<Action<SerializedProperty>> list;
-      if (!_specifiedDecorators.TryGetValue(propertyName, out list)) {
-        list = new List<Action<SerializedProperty>>();
-        _specifiedDecorators[propertyName] = list;
-      }
-
-      list.Add(decoratorDrawer);
-    } else {
-      Debug.LogWarning("Specified a custom drawer for the nonexistant property [" + propertyName + "] !\nWas it renamed or deleted?");
-    }
-  }
-
-  /// <summary>
-  /// Specify a list of properties that should only be displayed if the conditional property has a value of true.
-  /// Should be called in OnEnable.
-  /// </summary>
-  /// <param name="conditionalName"></param>
-  /// <param name="dependantProperties"></param>
-  protected void specifyConditionalDrawing(string conditionalName, params string[] dependantProperties) {
-    for (int i = 0; i < dependantProperties.Length; i++) {
-      _conditionalProperties[dependantProperties[i]] = conditionalName;
-    }
-  }
-
-  protected virtual void OnEnable() {
-    _specifiedDrawers = new Dictionary<string, Action<SerializedProperty>>();
-    _specifiedDecorators = new Dictionary<string, List<Action<SerializedProperty>>>();
-    _conditionalProperties = new Dictionary<string, string>();
-  }
-
-  /* 
-   * This method draws all visible properties, mirroring the default behavior of OnInspectorGUI. 
-   * Individual properties can be specified to have custom drawers.
-   */
-  public override void OnInspectorGUI() {
-    SerializedProperty iterator = serializedObject.GetIterator();
-    bool isFirst = true;
-
-    while (iterator.NextVisible(isFirst)) {
-      isFirst = false;
-
-      string conditionalPropertyName;
-      if (_conditionalProperties.TryGetValue(iterator.name, out conditionalPropertyName)) {
-        SerializedProperty conditionalProperty = serializedObject.FindProperty(conditionalPropertyName);
-        if (!conditionalProperty.boolValue) {
-          continue;
-        }
-      }
-
-      Action<SerializedProperty> customDrawer;
-
-      List<Action<SerializedProperty>> decoratorList;
-      if (_specifiedDecorators.TryGetValue(iterator.name, out decoratorList)) {
-        for (int i = 0; i < decoratorList.Count; i++) {
-          decoratorList[i](iterator);
-        }
-      }
-
-      if (_specifiedDrawers.TryGetValue(iterator.name, out customDrawer)) {
-        customDrawer(iterator);
+    /// <summary>
+    /// Specify a callback to be used to draw a specific named property.  Should be called in OnEnable.
+    /// </summary>
+    /// <param name="propertyName"></param>
+    /// <param name="propertyDrawer"></param>
+    protected void specifyCustomDrawer(string propertyName, Action<SerializedProperty> propertyDrawer) {
+      if (serializedObject.FindProperty(propertyName) != null) {
+        _specifiedDrawers[propertyName] = propertyDrawer;
       } else {
-        EditorGUILayout.PropertyField(iterator, true);
+        Debug.LogWarning("Specified a custom drawer for the nonexistant property [" + propertyName + "] !\nWas it renamed or deleted?");
       }
     }
 
-    serializedObject.ApplyModifiedProperties();
-  }
+    /// <summary>
+    /// Specify a callback to be used to draw a decorator for a specific named property.  Should be called in OnEnable.
+    /// </summary>
+    /// <param name="propertyName"></param>
+    /// <param name="decoratorDrawer"></param>
+    protected void specifyCustomDecorator(string propertyName, Action<SerializedProperty> decoratorDrawer) {
+      if (serializedObject.FindProperty(propertyName) != null) {
 
+        List<Action<SerializedProperty>> list;
+        if (!_specifiedDecorators.TryGetValue(propertyName, out list)) {
+          list = new List<Action<SerializedProperty>>();
+          _specifiedDecorators[propertyName] = list;
+        }
+
+        list.Add(decoratorDrawer);
+      } else {
+        Debug.LogWarning("Specified a custom drawer for the nonexistant property [" + propertyName + "] !\nWas it renamed or deleted?");
+      }
+    }
+
+    /// <summary>
+    /// Specify a list of properties that should only be displayed if the conditional property has a value of true.
+    /// Should be called in OnEnable.
+    /// </summary>
+    /// <param name="conditionalName"></param>
+    /// <param name="dependantProperties"></param>
+    protected void specifyConditionalDrawing(string conditionalName, params string[] dependantProperties) {
+      for (int i = 0; i < dependantProperties.Length; i++) {
+        _conditionalProperties[dependantProperties[i]] = conditionalName;
+      }
+    }
+
+    protected virtual void OnEnable() {
+      _specifiedDrawers = new Dictionary<string, Action<SerializedProperty>>();
+      _specifiedDecorators = new Dictionary<string, List<Action<SerializedProperty>>>();
+      _conditionalProperties = new Dictionary<string, string>();
+    }
+
+    /* 
+     * This method draws all visible properties, mirroring the default behavior of OnInspectorGUI. 
+     * Individual properties can be specified to have custom drawers.
+     */
+    public override void OnInspectorGUI() {
+      SerializedProperty iterator = serializedObject.GetIterator();
+      bool isFirst = true;
+
+      while (iterator.NextVisible(isFirst)) {
+        isFirst = false;
+
+        string conditionalPropertyName;
+        if (_conditionalProperties.TryGetValue(iterator.name, out conditionalPropertyName)) {
+          SerializedProperty conditionalProperty = serializedObject.FindProperty(conditionalPropertyName);
+          if (!conditionalProperty.boolValue) {
+            continue;
+          }
+        }
+
+        Action<SerializedProperty> customDrawer;
+
+        List<Action<SerializedProperty>> decoratorList;
+        if (_specifiedDecorators.TryGetValue(iterator.name, out decoratorList)) {
+          for (int i = 0; i < decoratorList.Count; i++) {
+            decoratorList[i](iterator);
+          }
+        }
+
+        if (_specifiedDrawers.TryGetValue(iterator.name, out customDrawer)) {
+          customDrawer(iterator);
+        } else {
+          EditorGUILayout.PropertyField(iterator, true);
+        }
+      }
+
+      serializedObject.ApplyModifiedProperties();
+    }
+  }
 }

--- a/Assets/LeapMotion/Editor/CustomEditorBase.cs
+++ b/Assets/LeapMotion/Editor/CustomEditorBase.cs
@@ -70,8 +70,6 @@ namespace Leap.Unity {
       bool isFirst = true;
 
       while (iterator.NextVisible(isFirst)) {
-        isFirst = false;
-
         string conditionalPropertyName;
         if (_conditionalProperties.TryGetValue(iterator.name, out conditionalPropertyName)) {
           SerializedProperty conditionalProperty = serializedObject.FindProperty(conditionalPropertyName);
@@ -92,8 +90,12 @@ namespace Leap.Unity {
         if (_specifiedDrawers.TryGetValue(iterator.name, out customDrawer)) {
           customDrawer(iterator);
         } else {
-          EditorGUILayout.PropertyField(iterator, true);
+          using (new EditorGUI.DisabledGroupScope(isFirst)) {
+            EditorGUILayout.PropertyField(iterator, true);
+          }
         }
+
+        isFirst = false;
       }
 
       serializedObject.ApplyModifiedProperties();

--- a/Assets/LeapMotion/Editor/CustomEditorBase.cs.meta
+++ b/Assets/LeapMotion/Editor/CustomEditorBase.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 5153a3309ec1fdb4fb6d7ebecfc60279
+timeCreated: 1459454776
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapMotion/Editor/LeapHandControllerEditor.cs
+++ b/Assets/LeapMotion/Editor/LeapHandControllerEditor.cs
@@ -9,92 +9,69 @@ using UnityEngine;
 using System.Collections;
 using Leap;
 
-namespace Leap.Unity{
-    [CustomEditor(typeof(LeapHandController))]
-    public class LeapHandControllerEditor : Editor {
+namespace Leap.Unity {
+  [CustomEditor(typeof(LeapHandController))]
+  public class LeapHandControllerEditor : CustomEditorBase {
+    private const float BOX_RADIUS = 0.45f;
+    private const float BOX_WIDTH = 0.965f;
+    private const float BOX_DEPTH = 0.6671f;
 
-      private const float BOX_RADIUS = 0.45f;
-      private const float BOX_WIDTH = 0.965f;
-      private const float BOX_DEPTH = 0.6671f;
+    private LeapHandController controller;
 
-      private LeapHandController controller;
-
-      void OnEnable() {
-        controller = target as LeapHandController;
-      }
-
-      public void OnSceneGUI() {
-        Vector3 origin = controller.transform.TransformPoint(Vector3.zero);
-
-        Vector3 local_top_left, top_left, local_top_right, top_right,
-                local_bottom_left, bottom_left, local_bottom_right, bottom_right;
-        getLocalGlobalPoint(-1, 1, 1, out local_top_left, out top_left);
-        getLocalGlobalPoint(1, 1, 1, out local_top_right, out top_right);
-        getLocalGlobalPoint(-1, 1, -1, out local_bottom_left, out bottom_left);
-        getLocalGlobalPoint(1, 1, -1, out local_bottom_right, out bottom_right);
-
-        Handles.DrawLine(origin, top_left);
-        Handles.DrawLine(origin, top_right);
-        Handles.DrawLine(origin, bottom_left);
-        Handles.DrawLine(origin, bottom_right);
-
-        drawControllerEdge(origin, local_top_left, local_top_right);
-        drawControllerEdge(origin, local_bottom_left, local_top_left);
-        drawControllerEdge(origin, local_bottom_left, local_bottom_right);
-        drawControllerEdge(origin, local_bottom_right, local_top_right);
-
-        drawControllerArc(origin, local_top_left, local_bottom_left, local_top_right, local_bottom_right, -Vector3.forward);
-        drawControllerArc(origin, local_top_left, local_top_right, local_bottom_left, local_bottom_right, -Vector3.right);
-      }
-
-      private void getLocalGlobalPoint(int x, int y, int z, out Vector3 local, out Vector3 global) {
-        local = new Vector3(x * BOX_WIDTH, y * BOX_RADIUS, z * BOX_DEPTH);
-        global = controller.transform.TransformPoint(BOX_RADIUS * local.normalized);
-      }
-
-      private void drawControllerEdge(Vector3 origin,
-                                      Vector3 edge0, Vector3 edge1) {
-        Vector3 right_normal = controller.transform.TransformDirection(Vector3.Cross(edge0, edge1));
-        float right_angle = Vector3.Angle(edge0, edge1);
-        Handles.DrawWireArc(origin, right_normal,
-                            controller.transform.TransformDirection(edge0),
-                            right_angle, controller.transform.lossyScale.x * BOX_RADIUS);
-      }
-
-      private void drawControllerArc(Vector3 origin,
-                                      Vector3 edgeA0, Vector3 edgeA1,
-                                      Vector3 edgeB0, Vector3 edgeB1,
-                                      Vector3 direction) {
-        Vector3 faceA = Vector3.Lerp(edgeA0, edgeA1, 0.5f);
-        Vector3 faceB = Vector3.Lerp(edgeB0, edgeB1, 0.5f);
-
-        Vector3 depth_normal = controller.transform.TransformDirection(direction);
-        float angle = Vector3.Angle(faceA, faceB);
-        Handles.DrawWireArc(origin, depth_normal,
-                            controller.transform.TransformDirection(faceA),
-                            angle, controller.transform.lossyScale.x * BOX_RADIUS);
-      }
-
-      public override void OnInspectorGUI() {
-        serializedObject.Update();
-        SerializedProperty properties = serializedObject.GetIterator();
-
-        EditorGUI.BeginChangeCheck();
-
-        bool useEnterChildren = true;
-        while (properties.NextVisible(useEnterChildren)) {
-          useEnterChildren = false;
-
-          switch (properties.name) {
-            default:
-              EditorGUILayout.PropertyField(properties);
-              break;
-          }
-        }
-
-        if (EditorGUI.EndChangeCheck()) {
-          serializedObject.ApplyModifiedProperties();
-        }
-      }
+    protected override void OnEnable() {
+      controller = target as LeapHandController;
     }
+
+    public void OnSceneGUI() {
+      Vector3 origin = controller.transform.TransformPoint(Vector3.zero);
+
+      Vector3 local_top_left, top_left, local_top_right, top_right,
+              local_bottom_left, bottom_left, local_bottom_right, bottom_right;
+      getLocalGlobalPoint(-1, 1, 1, out local_top_left, out top_left);
+      getLocalGlobalPoint(1, 1, 1, out local_top_right, out top_right);
+      getLocalGlobalPoint(-1, 1, -1, out local_bottom_left, out bottom_left);
+      getLocalGlobalPoint(1, 1, -1, out local_bottom_right, out bottom_right);
+
+      Handles.DrawLine(origin, top_left);
+      Handles.DrawLine(origin, top_right);
+      Handles.DrawLine(origin, bottom_left);
+      Handles.DrawLine(origin, bottom_right);
+
+      drawControllerEdge(origin, local_top_left, local_top_right);
+      drawControllerEdge(origin, local_bottom_left, local_top_left);
+      drawControllerEdge(origin, local_bottom_left, local_bottom_right);
+      drawControllerEdge(origin, local_bottom_right, local_top_right);
+
+      drawControllerArc(origin, local_top_left, local_bottom_left, local_top_right, local_bottom_right, -Vector3.forward);
+      drawControllerArc(origin, local_top_left, local_top_right, local_bottom_left, local_bottom_right, -Vector3.right);
+    }
+
+    private void getLocalGlobalPoint(int x, int y, int z, out Vector3 local, out Vector3 global) {
+      local = new Vector3(x * BOX_WIDTH, y * BOX_RADIUS, z * BOX_DEPTH);
+      global = controller.transform.TransformPoint(BOX_RADIUS * local.normalized);
+    }
+
+    private void drawControllerEdge(Vector3 origin,
+                                    Vector3 edge0, Vector3 edge1) {
+      Vector3 right_normal = controller.transform.TransformDirection(Vector3.Cross(edge0, edge1));
+      float right_angle = Vector3.Angle(edge0, edge1);
+      Handles.DrawWireArc(origin, right_normal,
+                          controller.transform.TransformDirection(edge0),
+                          right_angle, controller.transform.lossyScale.x * BOX_RADIUS);
+    }
+
+    private void drawControllerArc(Vector3 origin,
+                                    Vector3 edgeA0, Vector3 edgeA1,
+                                    Vector3 edgeB0, Vector3 edgeB1,
+                                    Vector3 direction) {
+      Vector3 faceA = Vector3.Lerp(edgeA0, edgeA1, 0.5f);
+      Vector3 faceB = Vector3.Lerp(edgeB0, edgeB1, 0.5f);
+
+      Vector3 depth_normal = controller.transform.TransformDirection(direction);
+      float angle = Vector3.Angle(faceA, faceB);
+      Handles.DrawWireArc(origin, depth_normal,
+                          controller.transform.TransformDirection(faceA),
+                          angle, controller.transform.lossyScale.x * BOX_RADIUS);
+    }
+  }
 }

--- a/Assets/LeapMotion/Editor/LeapHandControllerEditor.cs
+++ b/Assets/LeapMotion/Editor/LeapHandControllerEditor.cs
@@ -19,6 +19,8 @@ namespace Leap.Unity {
     private LeapHandController controller;
 
     protected override void OnEnable() {
+      base.OnEnable();
+
       controller = target as LeapHandController;
     }
 

--- a/Assets/LeapMotion/Editor/LeapImageRetrieverEditor.cs
+++ b/Assets/LeapMotion/Editor/LeapImageRetrieverEditor.cs
@@ -5,27 +5,22 @@ using System.Collections.Generic;
 
 namespace Leap.Unity{
   [CustomEditor(typeof(LeapImageRetriever))]
-  public class LeapImageRetrieverEditor : Editor {
+  public class LeapImageRetrieverEditor : CustomEditorBase {
 
     private GUIContent _brightTextureGUIContent;
     private GUIContent _rawTextureGUIContent;
     private GUIContent _distortionTextureGUIContent;
 
-    void OnEnable() {
+    protected override void OnEnable() {
+      base.OnEnable();
+
       _brightTextureGUIContent = new GUIContent("Bright Texture");
       _rawTextureGUIContent = new GUIContent("Raw Texture");
       _distortionTextureGUIContent = new GUIContent("Distortion Texture");
     }
 
     public override void OnInspectorGUI() {
-      serializedObject.Update();
-      SerializedProperty properties = serializedObject.GetIterator();
-
-      bool useEnterChildren = true;
-      while (properties.NextVisible(useEnterChildren) == true) {
-        useEnterChildren = false;
-        EditorGUILayout.PropertyField(properties, true);
-      }
+      base.OnInspectorGUI();
 
       if (Application.isPlaying) {
         LeapImageRetriever retriever = target as LeapImageRetriever;
@@ -38,8 +33,6 @@ namespace Leap.Unity{
         EditorGUILayout.ObjectField(_distortionTextureGUIContent, data.Distortion.CombinedTexture, dataType, true);
         EditorGUI.EndDisabledGroup();
       }
-
-      serializedObject.ApplyModifiedProperties();
     }
   }
 }

--- a/Assets/LeapMotion/Editor/LeapServiceProviderEditor.cs
+++ b/Assets/LeapMotion/Editor/LeapServiceProviderEditor.cs
@@ -1,40 +1,17 @@
-﻿using UnityEngine;
-using UnityEditor;
-using System.Collections.Generic;
+﻿using UnityEditor;
 
 namespace Leap.Unity {
 
   [CustomEditor(typeof(LeapServiceProvider))]
-  public class LeapServiceProviderEditor : Editor {
-    public static string _interpolationToggleProperty = "_useInterpolation";
-    public static List<string> _interpolationProperties = new List<string> { "_interpolationDelay" };
+  public class LeapServiceProviderEditor : CustomEditorBase {
+    protected override void OnEnable() {
+      base.OnEnable();
 
-    public static string _overrideDeviceToggleProperty = "_overrideDeviceType";
-    public static List<string> _deviceTypeProperties = new List<string> { "_overrideDeviceTypeWith" };
+      specifyConditionalDrawing("_useInterpolation",
+                                "_interpolationDelay");
 
-    public override void OnInspectorGUI() {
-      serializedObject.Update();
-      SerializedProperty properties = serializedObject.GetIterator();
-
-      bool useInterpolation = serializedObject.FindProperty(_interpolationToggleProperty).boolValue;
-      bool overrideDeviceType = serializedObject.FindProperty(_overrideDeviceToggleProperty).boolValue;
-
-      bool useEnterChildren = true;
-      while (properties.NextVisible(useEnterChildren)) {
-        useEnterChildren = false;
-
-        if (_interpolationProperties.Contains(properties.name) && !useInterpolation) {
-          continue;
-        }
-
-        if (_deviceTypeProperties.Contains(properties.name) && !overrideDeviceType) {
-          continue;
-        }
-
-        EditorGUILayout.PropertyField(properties, true);
-      }
-
-      serializedObject.ApplyModifiedProperties();
+      specifyConditionalDrawing("_overrideDeviceType",
+                                "_overrideDeviceTypeWith");
     }
   }
 }

--- a/Assets/LeapMotion/Scripts/VR/Editor/EyeTypeEditor.cs
+++ b/Assets/LeapMotion/Scripts/VR/Editor/EyeTypeEditor.cs
@@ -1,12 +1,13 @@
 ﻿using UnityEngine;
 using UnityEditor;
-using System.Collections;
-using Leap.Unity;
 
-[CustomPropertyDrawer(typeof(EyeType))]
-public class EyeTypeEditor : PropertyDrawer {
+namespace Leap.Unity {
 
-  public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
-    EditorGUI.PropertyField(position, property.FindPropertyRelative("_orderType"));
+  [CustomPropertyDrawer(typeof(EyeType))]
+  public class EyeTypeEditor : PropertyDrawer {
+
+    public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
+      EditorGUI.PropertyField(position, property.FindPropertyRelative("_orderType"));
+    }
   }
 }

--- a/Assets/LeapMotion/Scripts/VR/Editor/LeapTemporalWarpingEditor.cs
+++ b/Assets/LeapMotion/Scripts/VR/Editor/LeapTemporalWarpingEditor.cs
@@ -1,23 +1,19 @@
-﻿using UnityEngine;
-using UnityEditor;
-using System.Collections;
-using System.Collections.Generic;
-using Leap.Unity;
+﻿using UnityEditor;
 
-[CustomEditor(typeof(LeapVRTemporalWarping))]
-public class LeapTemporalWarpingEditor : Editor {
+namespace Leap.Unity {
 
-  public override void OnInspectorGUI() {
-    serializedObject.Update();
-    SerializedProperty properties = serializedObject.GetIterator();
+  [CustomEditor(typeof(LeapVRTemporalWarping))]
+  public class LeapTemporalWarpingEditor : CustomEditorBase {
 
-    bool useEnterChildren = true;
-    while (properties.NextVisible(useEnterChildren) == true) {
-      useEnterChildren = false;
-      EditorGUILayout.PropertyField(properties, true);
+    protected override void OnEnable() {
+      base.OnEnable();
+
+      specifyConditionalDrawing("allowManualTimeAlignment",
+                                "warpingAdjustment",
+                                "unlockHold",
+                                "moreRewind",
+                                "lessRewind");
     }
-    serializedObject.ApplyModifiedProperties();
   }
 }
-
   


### PR DESCRIPTION
This adds a CustomEditorBase class for use creating custom editors more easily.  The class allows you to:
- Specify a custom drawer for a named property
- Specify a custom decorator for a named property
- Conditionally display properties based on a boolean

There are all very common things to do when creating a custom editor, and using this base class can help reduce boilerplate and also reduce errors.  To test, verify that all custom editors are still behaving as expected.

fixes #102 