### PR TITLE
Fix problem with temporal warping disabling itself

### DIFF
--- a/Assets/LeapMotion/Scripts/VR/LeapVRTemporalWarping.cs
+++ b/Assets/LeapMotion/Scripts/VR/LeapVRTemporalWarping.cs
@@ -182,13 +182,12 @@ namespace Leap.Unity{
     }
   
     protected void Start() {
-
       Controller controller = provider.GetLeapController();
       controller.Device += OnDevice;
     }
-    
+
     protected void OnDevice(object sender, DeviceEventArgs args) {
-       deviceInfo = provider.GetDeviceInfo();
+      deviceInfo = provider.GetDeviceInfo();
       if (deviceInfo.type == LeapDeviceType.Invalid) {
         Debug.LogWarning("Invalid Leap Device -> enabled = false");
         enabled = false;
@@ -199,16 +198,14 @@ namespace Leap.Unity{
       LeapVRCameraControl.OnValidCameraParams += onValidCameraParams;
    }
 
-    protected void OnEnable()
-    {
+    protected void OnEnable() {
       if (deviceInfo.type != LeapDeviceType.Invalid){
         LeapVRCameraControl.OnValidCameraParams -= onValidCameraParams; //avoid multiple subscription
         LeapVRCameraControl.OnValidCameraParams += onValidCameraParams;
       }
     }
 
-    protected void OnDisable()
-    {
+    protected void OnDisable() {
       LeapVRCameraControl.OnValidCameraParams -= onValidCameraParams;
     }
   

--- a/Assets/LeapMotion/Scripts/VR/LeapVRTemporalWarping.cs
+++ b/Assets/LeapMotion/Scripts/VR/LeapVRTemporalWarping.cs
@@ -195,13 +195,16 @@ namespace Leap.Unity{
         return;
       }
       //Get a callback right as rendering begins for this frame so we can update the history and warping.
+      LeapVRCameraControl.OnValidCameraParams -= onValidCameraParams; //avoid multiple subscription
       LeapVRCameraControl.OnValidCameraParams += onValidCameraParams;
    }
 
     protected void OnEnable()
     {
-      if (deviceInfo.type != LeapDeviceType.Invalid)
+      if (deviceInfo.type != LeapDeviceType.Invalid){
+        LeapVRCameraControl.OnValidCameraParams -= onValidCameraParams; //avoid multiple subscription
         LeapVRCameraControl.OnValidCameraParams += onValidCameraParams;
+      }
     }
 
     protected void OnDisable()

--- a/Assets/LeapMotion/Scripts/VR/LeapVRTemporalWarping.cs
+++ b/Assets/LeapMotion/Scripts/VR/LeapVRTemporalWarping.cs
@@ -182,17 +182,28 @@ namespace Leap.Unity{
     }
   
     protected void Start() {
-      //Get a callback right as rendering begins for this frame so we can update the history and warping.
-      LeapVRCameraControl.OnValidCameraParams += onValidCameraParams;
-  
-      deviceInfo = provider.GetDeviceInfo();
+
+      Controller controller = provider.GetLeapController();
+      controller.Device += OnDevice;
+    }
+    
+    protected void OnDevice(object sender, DeviceEventArgs args) {
+       deviceInfo = provider.GetDeviceInfo();
       if (deviceInfo.type == LeapDeviceType.Invalid) {
         Debug.LogWarning("Invalid Leap Device -> enabled = false");
         enabled = false;
         return;
       }
+      //Get a callback right as rendering begins for this frame so we can update the history and warping.
+      LeapVRCameraControl.OnValidCameraParams += onValidCameraParams;
+   }
+
+    protected void OnEnable()
+    {
+      if (deviceInfo.type != LeapDeviceType.Invalid)
+        LeapVRCameraControl.OnValidCameraParams += onValidCameraParams;
     }
-  
+
     protected void OnDisable()
     {
       LeapVRCameraControl.OnValidCameraParams -= onValidCameraParams;


### PR DESCRIPTION
Fixes #121 

What was happening was the DeviceList was empty when LeapVRTemporalWarping checked for device type, resulting in the check returning "DEVICE_INVALID" and LeapVRTemporalWarping turning itself off.

This change doesn't check for device type until a device is available and also handles unplugging and plugging in different types of device. 