### PR TITLE
Fix device check

### DIFF
--- a/Assets/LeapMotion/Scripts/VR/LeapVRTemporalWarping.cs
+++ b/Assets/LeapMotion/Scripts/VR/LeapVRTemporalWarping.cs
@@ -198,7 +198,6 @@ namespace Leap.Unity{
 
     protected void OnDevice(object sender, DeviceEventArgs args) {
       deviceInfo = provider.GetDeviceInfo();
-      Debug.Log("Device gotten: " + deviceInfo.type);
       if (deviceInfo.type == LeapDeviceType.Invalid) {
         Debug.LogWarning("Invalid Leap Device -> enabled = false");
         enabled = false;

--- a/Assets/LeapMotion/Scripts/VR/LeapVRTemporalWarping.cs
+++ b/Assets/LeapMotion/Scripts/VR/LeapVRTemporalWarping.cs
@@ -182,12 +182,23 @@ namespace Leap.Unity{
     }
   
     protected void Start() {
-      Controller controller = provider.GetLeapController();
-      controller.Device += OnDevice;
+      if(provider.IsConnected()){
+        deviceInfo = provider.GetDeviceInfo();
+        LeapVRCameraControl.OnValidCameraParams += onValidCameraParams;
+        if (deviceInfo.type == LeapDeviceType.Invalid) {
+          Debug.LogWarning("Invalid Leap Device -> enabled = false");
+          enabled = false;
+          return;
+        }
+      } else {
+        Controller controller = provider.GetLeapController();
+        controller.Device += OnDevice;
+      }
     }
 
     protected void OnDevice(object sender, DeviceEventArgs args) {
       deviceInfo = provider.GetDeviceInfo();
+      Debug.Log("Device gotten: " + deviceInfo.type);
       if (deviceInfo.type == LeapDeviceType.Invalid) {
         Debug.LogWarning("Invalid Leap Device -> enabled = false");
         enabled = false;


### PR DESCRIPTION
Previous attempt to fix temporal warping turning itself off when the device list had not been populated yet ignored the case where the device list was already populated before the LeapVRTempralWarping class initialized. This PR corrects that. 