### PR TITLE
LeapImageRetriever is destroyed when the device is lost. This change …

### DIFF
--- a/Assets/LeapMotion/Scripts/LeapImageRetriever.cs
+++ b/Assets/LeapMotion/Scripts/LeapImageRetriever.cs
@@ -270,7 +270,7 @@ namespace Leap.Unity{
       }
     }
   #endif
-  
+
     void Start() {
       if (_provider == null) {
         Debug.LogWarning("Cannot use LeapImageRetriever if there is no LeapProvider!");
@@ -282,25 +282,19 @@ namespace Leap.Unity{
       ApplyGammaCorrectionValues();
       ApplyCameraProjectionValues();
     }
-  
+
     void HandleOnValidCameraParams(LeapVRCameraControl.CameraParams camParams) {
       ApplyCameraProjectionValues();
     }
   
     void OnEnable() {
-      _provider.GetLeapController().DistortionChange += onDistortionChange;
-      _provider.GetLeapController().Connect += delegate {
-          _provider.GetLeapController().Config.Get("images_mode", (Int32 enabled) => {
-              this.imagesEnabled = enabled == 0 ? false : true;
-          });
-      };
-      StartCoroutine(checkImageMode());
+      StartCoroutine(waitForController());
     }
-  
+
     void OnDisable() {
       _provider.GetLeapController().DistortionChange -= onDistortionChange;
+      LeapVRCameraControl.OnValidCameraParams -= HandleOnValidCameraParams;
     }
-  
     void OnDestroy() {
       _provider.GetLeapController().DistortionChange -= onDistortionChange;
       LeapVRCameraControl.OnValidCameraParams -= HandleOnValidCameraParams;
@@ -323,7 +317,7 @@ namespace Leap.Unity{
         }
       }
     }
-    
+
     void Update() {
       if(imagesEnabled){
           Frame imageFrame = _provider.CurrentFrame;
@@ -334,6 +328,21 @@ namespace Leap.Unity{
       }
     }
     
+    private IEnumerator waitForController(){
+      Controller controller = _provider.GetLeapController();
+      if(controller == null){
+        yield return true;
+      }
+        controller.DistortionChange += onDistortionChange;
+        controller.Connect += delegate {
+          _provider.GetLeapController().Config.Get("images_mode", (Int32 enabled) => {
+                this.imagesEnabled = enabled == 0 ? false : true;
+            });
+        };
+      StartCoroutine(checkImageMode());
+      yield return false;
+    }
+
     private IEnumerator checkImageMode(){
       checkingImageState = true;
       yield return new WaitForSeconds(IMAGE_SETTING_POLL_RATE);

--- a/Assets/LeapMotion/Scripts/LeapImageRetriever.cs
+++ b/Assets/LeapMotion/Scripts/LeapImageRetriever.cs
@@ -331,7 +331,7 @@ namespace Leap.Unity{
     private IEnumerator waitForController(){
       Controller controller = _provider.GetLeapController();
       if(controller == null){
-        yield return true;
+        yield return null;
       }
         controller.DistortionChange += onDistortionChange;
         controller.Connect += delegate {
@@ -339,8 +339,10 @@ namespace Leap.Unity{
                 this.imagesEnabled = enabled == 0 ? false : true;
             });
         };
-      StartCoroutine(checkImageMode());
-      yield return false;
+       if(!checkingImageState){
+         StartCoroutine(checkImageMode());
+      }
+      yield break;
     }
 
     private IEnumerator checkImageMode(){

--- a/Assets/LeapMotion/Scripts/LeapImageRetriever.cs
+++ b/Assets/LeapMotion/Scripts/LeapImageRetriever.cs
@@ -301,6 +301,11 @@ namespace Leap.Unity{
       _provider.GetLeapController().DistortionChange -= onDistortionChange;
     }
   
+    void OnDestroy() {
+      _provider.GetLeapController().DistortionChange -= onDistortionChange;
+      LeapVRCameraControl.OnValidCameraParams -= HandleOnValidCameraParams;
+    }
+
     void OnPreRender() {
       if(imagesEnabled){
         Controller controller = _provider.GetLeapController();


### PR DESCRIPTION
Somewhere, the LeapImageRetriever component is destroyed when a device is lost and then recreated. This change cleans up the LeapImageRetriever event subscriptions so that the event handlers of the destroyed object are not invoked.