### PR TITLE
Fix vrviz strobe

### DIFF
--- a/Assets/LeapMotion/Scripts/LeapImageRetriever.cs
+++ b/Assets/LeapMotion/Scripts/LeapImageRetriever.cs
@@ -270,7 +270,7 @@ namespace Leap.Unity{
       }
     }
   #endif
-  
+
     void Start() {
       if (_provider == null) {
         Debug.LogWarning("Cannot use LeapImageRetriever if there is no LeapProvider!");
@@ -282,25 +282,19 @@ namespace Leap.Unity{
       ApplyGammaCorrectionValues();
       ApplyCameraProjectionValues();
     }
-  
+
     void HandleOnValidCameraParams(LeapVRCameraControl.CameraParams camParams) {
       ApplyCameraProjectionValues();
     }
   
     void OnEnable() {
-      _provider.GetLeapController().DistortionChange += onDistortionChange;
-      _provider.GetLeapController().Connect += delegate {
-          _provider.GetLeapController().Config.Get("images_mode", (Int32 enabled) => {
-              this.imagesEnabled = enabled == 0 ? false : true;
-          });
-      };
-      StartCoroutine(checkImageMode());
+      StartCoroutine(waitForController());
     }
-  
+
     void OnDisable() {
       _provider.GetLeapController().DistortionChange -= onDistortionChange;
+      LeapVRCameraControl.OnValidCameraParams -= HandleOnValidCameraParams;
     }
-  
     void OnDestroy() {
       _provider.GetLeapController().DistortionChange -= onDistortionChange;
       LeapVRCameraControl.OnValidCameraParams -= HandleOnValidCameraParams;
@@ -323,7 +317,7 @@ namespace Leap.Unity{
         }
       }
     }
-    
+
     void Update() {
       if(imagesEnabled){
           Frame imageFrame = _provider.CurrentFrame;
@@ -334,6 +328,21 @@ namespace Leap.Unity{
       }
     }
     
+    private IEnumerator waitForController(){
+      Controller controller = _provider.GetLeapController();
+      if(controller == null){
+        yield return true;
+      }
+        controller.DistortionChange += onDistortionChange;
+        controller.Connect += delegate {
+          _provider.GetLeapController().Config.Get("images_mode", (Int32 enabled) => {
+                this.imagesEnabled = enabled == 0 ? false : true;
+            });
+        };
+      StartCoroutine(checkImageMode());
+      yield return false;
+    }
+
     private IEnumerator checkImageMode(){
       checkingImageState = true;
       yield return new WaitForSeconds(IMAGE_SETTING_POLL_RATE);

--- a/Assets/LeapMotion/Scripts/LeapImageRetriever.cs
+++ b/Assets/LeapMotion/Scripts/LeapImageRetriever.cs
@@ -292,11 +292,18 @@ namespace Leap.Unity{
     }
 
     void OnDisable() {
-      _provider.GetLeapController().DistortionChange -= onDistortionChange;
+      Controller controller = _provider.GetLeapController();
+      if (controller != null) {
+        controller.DistortionChange -= onDistortionChange;
+      }
       LeapVRCameraControl.OnValidCameraParams -= HandleOnValidCameraParams;
     }
+
     void OnDestroy() {
-        _provider.GetLeapController().DistortionChange -= onDistortionChange;
+      Controller controller = _provider.GetLeapController();
+      if (controller != null) {
+        controller.DistortionChange -= onDistortionChange;
+      }
       LeapVRCameraControl.OnValidCameraParams -= HandleOnValidCameraParams;
     }
 

--- a/Assets/LeapMotion/Scripts/LeapImageRetriever.cs
+++ b/Assets/LeapMotion/Scripts/LeapImageRetriever.cs
@@ -140,26 +140,26 @@ namespace Leap.Unity{
       public bool CheckStale() {
         return _combinedTexture == null;
       }
-  
-      public void Reconstruct(Image image, string shaderName) {
+
+      public void Reconstruct(Image image, string shaderName)
+      {
         int combinedWidth = image.DistortionWidth / 2;
         int combinedHeight = image.DistortionHeight * 2;
-  
+
         if (_combinedTexture != null) {
           DestroyImmediate(_combinedTexture);
         }
-  
+
         Color32[] colorArray = new Color32[combinedWidth * combinedHeight];
         _combinedTexture = new Texture2D(combinedWidth, combinedHeight, TextureFormat.RGBA32, false, true);
         _combinedTexture.filterMode = FilterMode.Bilinear;
         _combinedTexture.wrapMode = TextureWrapMode.Clamp;
         _combinedTexture.hideFlags = HideFlags.DontSave;
-  
+
         addDistortionData(image, colorArray, 0);
-  
+
         _combinedTexture.SetPixels32(colorArray);
         _combinedTexture.Apply();
-  
         Shader.SetGlobalTexture(shaderName, _combinedTexture);
       }
   
@@ -296,7 +296,7 @@ namespace Leap.Unity{
       LeapVRCameraControl.OnValidCameraParams -= HandleOnValidCameraParams;
     }
     void OnDestroy() {
-      _provider.GetLeapController().DistortionChange -= onDistortionChange;
+        _provider.GetLeapController().DistortionChange -= onDistortionChange;
       LeapVRCameraControl.OnValidCameraParams -= HandleOnValidCameraParams;
     }
 
@@ -329,20 +329,23 @@ namespace Leap.Unity{
     }
     
     private IEnumerator waitForController(){
-      Controller controller = _provider.GetLeapController();
-      if(controller == null){
+      while (_provider == null) {
         yield return null;
       }
-        controller.DistortionChange += onDistortionChange;
-        controller.Connect += delegate {
-          _provider.GetLeapController().Config.Get("images_mode", (Int32 enabled) => {
-                this.imagesEnabled = enabled == 0 ? false : true;
-            });
-        };
-       if(!checkingImageState){
-         StartCoroutine(checkImageMode());
+      Controller controller = null;
+      while (controller == null) {
+          controller = _provider.GetLeapController();
+          yield return null;
       }
-      yield break;
+      controller.DistortionChange += onDistortionChange;
+      controller.Connect += delegate {
+        _provider.GetLeapController().Config.Get("images_mode", (Int32 enabled) => {
+          this.imagesEnabled = enabled == 0 ? false : true;
+        });
+      };
+      if (!checkingImageState) {
+        StartCoroutine(checkImageMode());
+      }
     }
 
     private IEnumerator checkImageMode(){

--- a/Assets/LeapMotion/Scripts/LeapImageRetriever.cs
+++ b/Assets/LeapMotion/Scripts/LeapImageRetriever.cs
@@ -331,7 +331,7 @@ namespace Leap.Unity{
     private IEnumerator waitForController(){
       Controller controller = _provider.GetLeapController();
       if(controller == null){
-        yield return true;
+        yield return null;
       }
         controller.DistortionChange += onDistortionChange;
         controller.Connect += delegate {
@@ -339,8 +339,10 @@ namespace Leap.Unity{
                 this.imagesEnabled = enabled == 0 ? false : true;
             });
         };
-      StartCoroutine(checkImageMode());
-      yield return false;
+       if(!checkingImageState){
+         StartCoroutine(checkImageMode());
+      }
+      yield break;
     }
 
     private IEnumerator checkImageMode(){

--- a/Assets/LeapMotion/Scripts/LeapImageRetriever.cs
+++ b/Assets/LeapMotion/Scripts/LeapImageRetriever.cs
@@ -301,6 +301,11 @@ namespace Leap.Unity{
       _provider.GetLeapController().DistortionChange -= onDistortionChange;
     }
   
+    void OnDestroy() {
+      _provider.GetLeapController().DistortionChange -= onDistortionChange;
+      LeapVRCameraControl.OnValidCameraParams -= HandleOnValidCameraParams;
+    }
+
     void OnPreRender() {
       if(imagesEnabled){
         Controller controller = _provider.GetLeapController();

--- a/Assets/LeapMotion/Scripts/LeapServiceProvider.cs
+++ b/Assets/LeapMotion/Scripts/LeapServiceProvider.cs
@@ -202,6 +202,9 @@ namespace Leap.Unity {
      * The POLICY_OPTIMIZE_HMD flag improves tracking for head-mounted devices.
      */
     protected void initializeFlags() {
+      if (leap_controller_ == null) {
+        return;
+      }
       //Optimize for top-down tracking if on head mounted display.
       if (_isHeadMounted) {
         leap_controller_.SetPolicy(Controller.PolicyFlag.POLICY_OPTIMIZE_HMD);
@@ -217,10 +220,12 @@ namespace Leap.Unity {
       }
 
       leap_controller_ = new Controller();
-      if (leap_controller_.IsConnected) {
-        initializeFlags();
+      if (leap_controller_.IsConnected)
+      {
+          initializeFlags();
+      } else {
+        leap_controller_.Device += onHandControllerConnect;
       }
-      leap_controller_.Device += onHandControllerConnect;
     }
 
     /** Calling this method stop the connection for the existing instance of a Controller, 

--- a/Assets/LeapMotion/Scripts/VR/LeapVRTemporalWarping.cs
+++ b/Assets/LeapMotion/Scripts/VR/LeapVRTemporalWarping.cs
@@ -274,7 +274,7 @@ namespace Leap.Unity{
     }
     
     private void updateTemporalWarping() {
-      if (_trackingAnchor == null) {
+      if (_trackingAnchor == null || provider.GetLeapController() == null) {
         return;
       }
   

--- a/Assets/LeapMotion/Scripts/VR/LeapVRTemporalWarping.cs
+++ b/Assets/LeapMotion/Scripts/VR/LeapVRTemporalWarping.cs
@@ -218,7 +218,11 @@ namespace Leap.Unity{
     protected void OnDisable() {
       LeapVRCameraControl.OnValidCameraParams -= onValidCameraParams;
     }
-  
+
+    protected void OnDestroy() {
+        LeapVRCameraControl.OnValidCameraParams -= onValidCameraParams;
+    }
+
     protected void Update() {
       if (Input.GetKeyDown(recenter)) {
         InputTracking.Recenter();
@@ -244,8 +248,10 @@ namespace Leap.Unity{
     private void onValidCameraParams(LeapVRCameraControl.CameraParams cameraParams) {
       _projectionMatrix = cameraParams.ProjectionMatrix;
       _trackingAnchor = cameraParams.TrackingAnchor;
-  
-      updateHistory();
+
+      if (provider != null) { 
+        updateHistory(); 
+      }
   
       if (syncMode == SyncMode.LOW_LATENCY) {
         updateTemporalWarping();

--- a/Assets/LeapMotionModules/VRVisualizer/ScenesResources/Scripts/VisualizerManager.cs
+++ b/Assets/LeapMotionModules/VRVisualizer/ScenesResources/Scripts/VisualizerManager.cs
@@ -75,11 +75,6 @@ namespace Leap.Unity.VRVisualizer{
         return;
       }
   
-      if (m_leapConnected == false && m_controller.IsConnected)
-      {
-        // HACK (wyu): LeapProvider should listen to events and update itself when Leap devices are connected/disconnected instead of having to reload the scene to reinitialize variables
-        SceneManager.LoadScene(SceneManager.GetActiveScene().name);
-      }
       m_leapConnected = m_controller.IsConnected;
       if (!m_leapConnected)
       {

--- a/Assets/LeapMotionModules/VRVisualizer/ScenesResources/Scripts/VisualizerManager.cs
+++ b/Assets/LeapMotionModules/VRVisualizer/ScenesResources/Scripts/VisualizerManager.cs
@@ -33,33 +33,38 @@ namespace Leap.Unity.VRVisualizer{
       if (provider != null)
         m_controller = provider.GetLeapController();
     }
-  
-    void Awake()
-    {
-      Screen.SetResolution(Screen.currentResolution.width, Screen.currentResolution.height, false);
-      if (VRDevice.isPresent)
-      {
+
+    private void goVR() {
         m_PCVisualizer.gameObject.SetActive(false);
         m_VRVisualizer.gameObject.SetActive(true);
-        m_warningText.text = "Please put on your head-mounted display";
-      }
-      else
-      {
+        m_warningText.text = "Please put on your head-mounted display";      
+    }
+
+    private void goDesktop() {
         m_VRVisualizer.gameObject.SetActive(false);
         m_PCVisualizer.gameObject.SetActive(true);
-        m_warningText.text = "No head-mounted display detected. Orion performs best in a head-mounted display";
-      }
-
-      m_deltaTime = new SmoothedFloat();
-      m_deltaTime.delay = 0.1f;
+        m_warningText.text = "No head-mounted display detected. Orion performs best in a head-mounted display";      
     }
-  
+
     void Start()
     {
       m_trackingText.text = "";
       FindController();
       if (m_controller != null)
         m_leapConnected = m_controller.IsConnected;
+
+      Screen.SetResolution(Screen.currentResolution.width, Screen.currentResolution.height, false);
+      if (VRDevice.isPresent)
+      {
+        goVR();    
+      }
+      else
+      {
+        goDesktop();
+      }
+
+      m_deltaTime = new SmoothedFloat();
+      m_deltaTime.delay = 0.1f;
     }
   
     void Update()
@@ -98,11 +103,13 @@ namespace Leap.Unity.VRVisualizer{
         else
         {
           m_trackingText.text += " (Press '" + keyToToggleHMD + "' to switch to head-mounted mode)";
-          if (Input.GetKeyDown(keyToToggleHMD))
-            m_controller.SetPolicy(Controller.PolicyFlag.POLICY_OPTIMIZE_HMD);
+          if (Input.GetKeyDown(keyToToggleHMD)) {
+              m_controller.SetPolicy(Controller.PolicyFlag.POLICY_OPTIMIZE_HMD);
+          }
         }
-      }
-      //update render frame display
+      } 
+
+        //update render frame display
       m_deltaTime.Update(Time.deltaTime, Time.deltaTime);
       if (m_framrateUpdateCount > m_framerateUpdateInterval) {
         updateRenderFrameRate();


### PR DESCRIPTION
The VR visualizer strobe was caused by 3 issues. 

One set of problems was caused by the VisualizerManager enabling core components before the system was really ready for them. This resulted in the Controller being null when those core components executed. I added several checks for null Controller objects to avoid these.

Another set of problems was caused by event handlers between core components not being cleaned up when objects where destroyed, leading to the old handlers being called after their owning object had been destroyed. I removed the event handlers onDestroy to avoid these.

Finally, the VisualizerManager itself reloaded the scene every update loop in some circumstances. This created a race condition such that if this script initialized before a controller was available, it would reload forever. I removed this logic since it is no longer needed anyway. For good measure, I moved the manager initialization to Start() so that other scripts had a chance to initialize and receive OnEnable.

Fixes #139