### PR TITLE
Added public properties for RTS PinchDetector properties

### DIFF
--- a/Assets/LeapMotionModules/PinchUtility/Scripts/LeapRTS.cs
+++ b/Assets/LeapMotionModules/PinchUtility/Scripts/LeapRTS.cs
@@ -16,7 +16,7 @@ namespace Leap.Unity.PinchUtility {
 
     [SerializeField]
     private LeapPinchDetector _pinchDetectorA;
-    public LeapPinchDetector LeapPinchDetectorA {
+    public LeapPinchDetector PinchDetectorA {
       get {
         return _pinchDetectorA;
       }
@@ -27,7 +27,7 @@ namespace Leap.Unity.PinchUtility {
 
     [SerializeField]
     private LeapPinchDetector _pinchDetectorB;
-    public LeapPinchDetector LeapPinchDetectorB {
+    public LeapPinchDetector PinchDetectorB {
       get {
         return _pinchDetectorB;
       }
@@ -56,7 +56,7 @@ namespace Leap.Unity.PinchUtility {
 
     private float _defaultNearClip;
 
-    void Awake() {
+    void Start() {
       if (_pinchDetectorA == null || _pinchDetectorB == null) {
         Debug.LogWarning("Both Pinch Detectors of the LeapRTS component must be assigned. This component has been disabled.");
         enabled = false;

--- a/Assets/LeapMotionModules/PinchUtility/Scripts/LeapRTS.cs
+++ b/Assets/LeapMotionModules/PinchUtility/Scripts/LeapRTS.cs
@@ -16,9 +16,25 @@ namespace Leap.Unity.PinchUtility {
 
     [SerializeField]
     private LeapPinchDetector _pinchDetectorA;
+    public LeapPinchDetector LeapPinchDetectorA {
+      get {
+        return _pinchDetectorA;
+      }
+      set {
+        _pinchDetectorA = value;
+      }
+    }
 
     [SerializeField]
     private LeapPinchDetector _pinchDetectorB;
+    public LeapPinchDetector LeapPinchDetectorB {
+      get {
+        return _pinchDetectorB;
+      }
+      set {
+        _pinchDetectorB = value;
+      }
+    }
 
     [SerializeField]
     private RotationMethod _oneHandedRotationMethod;


### PR DESCRIPTION
This change adds public properties for the PinchDetector objects used by the RTS script. This allows RTS-using components to be made into prefabs. Otherwise, the connections to the pinch detectors are lost when the object is made into a prefab and, with only private variables, the connection cannot be restored at runtime.