### PR TITLE
Fix assumption about projection matrices

### DIFF
--- a/Assets/LeapMotion/Prefabs/LMHeadMountedRig.prefab
+++ b/Assets/LeapMotion/Prefabs/LMHeadMountedRig.prefab
@@ -11,10 +11,9 @@ GameObject:
   - 81: {fileID: 8146722}
   - 20: {fileID: 2068494}
   - 114: {fileID: 11462492}
-  - 114: {fileID: 11472702}
   - 114: {fileID: 11407670}
   m_Layer: 0
-  m_Name: CenterEyeAnchor
+  m_Name: RightEyeAnchor
   m_TagString: MainCamera
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -69,6 +68,26 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!1 &165976
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 407640}
+  - 81: {fileID: 8108524}
+  - 20: {fileID: 2013352}
+  - 114: {fileID: 11451076}
+  - 114: {fileID: 11472702}
+  - 114: {fileID: 11468840}
+  m_Layer: 0
+  m_Name: LeftEyeAnchor
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
 --- !u!1 &178432
 GameObject:
   m_ObjectHideFlags: 1
@@ -86,6 +105,20 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!4 &407640
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 165976}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children:
+  - {fileID: 436396}
+  m_Father: {fileID: 492502}
+  m_RootOrder: 0
 --- !u!4 &411750
 Transform:
   m_ObjectHideFlags: 1
@@ -95,6 +128,7 @@ Transform:
   m_LocalRotation: {x: 0.000000115202326, y: -0.7071067, z: -0.7071068, w: -0.00000011520231}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 436396}
   m_RootOrder: 0
@@ -107,10 +141,11 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 411750}
   - {fileID: 478400}
-  m_Father: {fileID: 455116}
+  m_Father: {fileID: 407640}
   m_RootOrder: 0
 --- !u!4 &455116
 Transform:
@@ -121,10 +156,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 436396}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
   m_Father: {fileID: 492502}
-  m_RootOrder: 0
+  m_RootOrder: 1
 --- !u!4 &478400
 Transform:
   m_ObjectHideFlags: 1
@@ -134,6 +169,7 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0.137}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 436396}
   m_RootOrder: 1
@@ -146,10 +182,46 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
+  - {fileID: 407640}
   - {fileID: 455116}
   m_Father: {fileID: 0}
   m_RootOrder: 0
+--- !u!20 &2013352
+Camera:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 165976}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 2
+  m_BackGroundColor: {r: 0.32352942, g: 0.32352942, b: 0.32352942, a: 0.019607844}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.01
+  far clip plane: 100
+  field of view: 106.092
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 1
+  m_HDR: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+  m_StereoMirrorMode: 0
 --- !u!20 &2068494
 Camera:
   m_ObjectHideFlags: 1
@@ -178,7 +250,7 @@ Camera:
   m_RenderingPath: -1
   m_TargetTexture: {fileID: 0}
   m_TargetDisplay: 0
-  m_TargetEye: 3
+  m_TargetEye: 2
   m_HDR: 0
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
@@ -217,6 +289,13 @@ MeshFilter:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 178432}
   m_Mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!81 &8108524
+AudioListener:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 165976}
+  m_Enabled: 1
 --- !u!81 &8146722
 AudioListener:
   m_ObjectHideFlags: 1
@@ -235,9 +314,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 025cc0fa7b46aa541aba29d28d35ac09, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _isHeadMounted: 0
-  overrideDeviceType: 1
+  _isHeadMounted: 1
+  _overrideDeviceType: 0
   _overrideDeviceTypeWith: 1
+  _useInterpolation: 0
+  _interpolationDelay: 15
 --- !u!114 &11407670
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -250,7 +331,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _eyeType:
-    _orderType: 3
+    _orderType: 2
   _overrideEyePosition: 1
 --- !u!114 &11408046
 MonoBehaviour:
@@ -269,6 +350,7 @@ MonoBehaviour:
   - {fileID: 0}
   - {fileID: 0}
   ModelPool: []
+  EnforceHandedness: 0
 --- !u!114 &11415308
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -280,7 +362,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 215a4d49fc705b74a9d3c5cbfa2c9601, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  handMovementScale: {x: 1, y: 1, z: 1}
 --- !u!114 &11429104
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -303,6 +384,18 @@ MonoBehaviour:
   unlockHold: 0
   moreRewind: 276
   lessRewind: 275
+--- !u!114 &11451076
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 165976}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4499ae867a57a90449cb9069c466ade0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _depthTextureMode: 0
 --- !u!114 &11462492
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -315,12 +408,26 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _depthTextureMode: 0
+--- !u!114 &11468840
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 165976}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cfb12777e12bf9941b23356a343f5016, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _eyeType:
+    _orderType: 1
+  _overrideEyePosition: 1
 --- !u!114 &11472702
 MonoBehaviour:
   m_ObjectHideFlags: 1
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  m_GameObject: {fileID: 101514}
+  m_GameObject: {fileID: 165976}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fd815635398474cbbba564563a209f82, type: 3}

--- a/Assets/LeapMotion/Scenes/Leap_Hands_Demo_AR.unity
+++ b/Assets/LeapMotion/Scenes/Leap_Hands_Demo_AR.unity
@@ -808,6 +808,14 @@ Prefab:
       propertyPath: m_LocalScale.z
       value: 1.0000001
       objectReference: {fileID: 0}
+    - target: {fileID: 475100, guid: 23f2cce114628a448bfeaae171b4c0c0, type: 2}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 475100, guid: 23f2cce114628a448bfeaae171b4c0c0, type: 2}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 23f2cce114628a448bfeaae171b4c0c0, type: 2}
   m_IsPrefabParent: 0
@@ -1598,6 +1606,14 @@ Prefab:
       propertyPath: m_LocalScale.z
       value: 1.0000001
       objectReference: {fileID: 0}
+    - target: {fileID: 415952, guid: c8515ebee271c0649b9db1321f3026a4, type: 2}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 415952, guid: c8515ebee271c0649b9db1321f3026a4, type: 2}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: c8515ebee271c0649b9db1321f3026a4, type: 2}
   m_IsPrefabParent: 0
@@ -1644,6 +1660,14 @@ Prefab:
       objectReference: {fileID: 0}
     - target: {fileID: 464466, guid: 869d20cdda15af24aab9e72b5f2eec78, type: 2}
       propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464466, guid: 869d20cdda15af24aab9e72b5f2eec78, type: 2}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464466, guid: 869d20cdda15af24aab9e72b5f2eec78, type: 2}
+      propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
@@ -1697,6 +1721,14 @@ Prefab:
     - target: {fileID: 464466, guid: 39d18871c11b53c4082d8202e3db68a3, type: 2}
       propertyPath: m_RootOrder
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 464466, guid: 39d18871c11b53c4082d8202e3db68a3, type: 2}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 464466, guid: 39d18871c11b53c4082d8202e3db68a3, type: 2}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 39d18871c11b53c4082d8202e3db68a3, type: 2}
@@ -1759,6 +1791,7 @@ Transform:
   m_LocalRotation: {x: 0.40821794, y: -0.23456973, z: 0.109381676, w: 0.87542605}
   m_LocalPosition: {x: 0, y: 3, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -1817,10 +1850,6 @@ Prefab:
       propertyPath: ModelCollection.Array.data[3]
       value: 
       objectReference: {fileID: 1167543056}
-    - target: {fileID: 11402294, guid: 18d6bf9063dcb1842be63f411fd9fc26, type: 2}
-      propertyPath: _isHeadMounted
-      value: 1
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 18d6bf9063dcb1842be63f411fd9fc26, type: 2}
   m_IsPrefabParent: 0

--- a/Assets/LeapMotion/Scripts/VR/LeapVRCameraControl.cs
+++ b/Assets/LeapMotion/Scripts/VR/LeapVRCameraControl.cs
@@ -2,7 +2,7 @@
 using UnityEngine.Rendering;
 using System;
 
-namespace Leap.Unity{
+namespace Leap.Unity {
   /**Provides a variety of VR related camera utilities, for example controlling IPD and camera distance */
   [RequireComponent(typeof(Camera))]
   [ExecuteInEditMode]
@@ -10,25 +10,24 @@ namespace Leap.Unity{
     public const string GLOBAL_EYE_UV_OFFSET_NAME = "_LeapGlobalStereoUVOffset";
     private static Vector2 LEFT_EYE_UV_OFFSET = new Vector2(0, 0);
     private static Vector2 RIGHT_EYE_UV_OFFSET = new Vector2(0, 0.5f);
-  
+
     //When using VR, the cameras do not have valid parameters until the first frame begins rendering, 
     //so if you need valid parameters for initialization, you can use this callback to get notified 
     //when they become available.
     public static event Action<CameraParams> OnValidCameraParams;
     private static bool _hasDispatchedValidCameraParams = false;
-  
-    public static event Action OnLeftPreRender;
-    public static event Action OnRightPreRender;
-    
-  
+
+    public static event Action<Camera> OnLeftPreRender;
+    public static event Action<Camera> OnRightPreRender;
+
     [SerializeField]
     private EyeType _eyeType = new EyeType(EyeType.OrderType.CENTER);
-  
+
     [SerializeField]
     private bool _overrideEyePosition = true;
-  
+
     public bool OverrideEyePosition { get { return _overrideEyePosition; } set { _overrideEyePosition = value; } }
-  
+
     private Camera _cachedCamera;
     private Camera _camera {
       get {
@@ -38,72 +37,72 @@ namespace Leap.Unity{
         return _cachedCamera;
       }
     }
-  
+
     private Matrix4x4 _finalCenterMatrix;
     private LeapDeviceInfo _deviceInfo;
-  
+
     void Start() {
-  #if UNITY_EDITOR
+#if UNITY_EDITOR
       if (!Application.isPlaying) {
         return;
       }
-  #endif
-  
+#endif
+
       _deviceInfo = new LeapDeviceInfo(LeapDeviceType.Peripheral);
     }
-  
+
     void Update() {
-  #if UNITY_EDITOR
+#if UNITY_EDITOR
       _eyeType.UpdateOrderGivenComponent(this);
-  
+
       if (!Application.isPlaying) {
         return;
       }
-  #endif
-  
+#endif
+
       _hasDispatchedValidCameraParams = false;
     }
-  
+
     void OnPreCull() {
-  #if UNITY_EDITOR
+#if UNITY_EDITOR
       if (!Application.isPlaying) {
         return;
       }
-  #endif
-  
+#endif
+
       _camera.ResetWorldToCameraMatrix();
       _finalCenterMatrix = _camera.worldToCameraMatrix;
-  
+
       if (!_hasDispatchedValidCameraParams) {
         CameraParams cameraParams = new CameraParams(_cachedCamera);
-  
-        if(OnValidCameraParams != null) {
+
+        if (OnValidCameraParams != null) {
           OnValidCameraParams(cameraParams);
         }
-        
+
         _hasDispatchedValidCameraParams = true;
       }
     }
-  
+
     void OnPreRender() {
-  #if UNITY_EDITOR
+#if UNITY_EDITOR
       if (!Application.isPlaying) {
         return;
       }
-  #endif
-  
+#endif
+
       _eyeType.BeginCamera();
-  
+
       if (_eyeType.IsLeftEye) {
         Shader.SetGlobalVector(GLOBAL_EYE_UV_OFFSET_NAME, LEFT_EYE_UV_OFFSET);
-        if (OnLeftPreRender != null) OnLeftPreRender();
+        if (OnLeftPreRender != null) OnLeftPreRender(_cachedCamera);
       } else {
         Shader.SetGlobalVector(GLOBAL_EYE_UV_OFFSET_NAME, RIGHT_EYE_UV_OFFSET);
-        if (OnRightPreRender != null) OnRightPreRender();
+        if (OnRightPreRender != null) OnRightPreRender(_cachedCamera);
       }
-  
+
       Matrix4x4 offsetMatrix;
-  
+
       if (_overrideEyePosition) {
         offsetMatrix = _finalCenterMatrix;
         //Debug.Log(_deviceInfo.baseline);
@@ -113,22 +112,22 @@ namespace Leap.Unity{
       } else {
         offsetMatrix = _camera.worldToCameraMatrix;
       }
-  
+
       _camera.worldToCameraMatrix = offsetMatrix;
     }
-  
+
     public struct CameraParams {
       public readonly Transform TrackingAnchor;
       public readonly Transform CenterEyeTransform;
       public readonly Matrix4x4 ProjectionMatrix;
       public readonly int Width;
       public readonly int Height;
-  
+
       public CameraParams(Camera camera) {
         TrackingAnchor = camera.transform.parent;
         CenterEyeTransform = camera.transform;
         ProjectionMatrix = camera.projectionMatrix;
-  
+
         switch (SystemInfo.graphicsDeviceType) {
           case GraphicsDeviceType.Direct3D9:
           case GraphicsDeviceType.Direct3D11:
@@ -142,7 +141,7 @@ namespace Leap.Unity{
             }
             break;
         }
-  
+
         Width = camera.pixelWidth;
         Height = camera.pixelHeight;
       }


### PR DESCRIPTION
The logic for undistortion was assuming that the projection matrix was the same for the left and the right cameras.  This assumption turns out not to be true when rendering to the Vive!  This PR puts in a fix to allow the projection vector passed in for undirsortion to be recalculated for each eye each frame.

