### PR TITLE
Saved solved position to prevent 1frame lag

### DIFF
--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/InteractionBehaviour.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/InteractionBehaviour.cs
@@ -76,6 +76,9 @@ namespace Leap.Unity.Interaction {
     protected bool _recievedVelocityUpdate = false;
     protected bool _notifiedOfTeleport = false;
 
+    protected Vector3 _solvedPosition;
+    protected Quaternion _solvedRotation;
+
     protected Vector3 _accumulatedLinearAcceleration = Vector3.zero;
     protected Vector3 _accumulatedAngularAcceleration = Vector3.zero;
 
@@ -380,6 +383,9 @@ namespace Leap.Unity.Interaction {
       Quaternion newRotation;
       getSolvedTransform(hands, out newPosition, out newRotation);
 
+      _solvedPosition = newPosition;
+      _solvedRotation = newRotation;
+
       //Apply new transform to object
       if (_notifiedOfTeleport) {
         _rigidbody.position = newPosition;
@@ -556,8 +562,8 @@ namespace Leap.Unity.Interaction {
     #region INTERNAL
     protected INTERACTION_TRANSFORM getRigidbodyTransform() {
       INTERACTION_TRANSFORM interactionTransform = new INTERACTION_TRANSFORM();
-      interactionTransform.position = _rigidbody.position.ToCVector();
-      interactionTransform.rotation = _rigidbody.rotation.ToCQuaternion();
+      interactionTransform.position = _solvedPosition.ToCVector();
+      interactionTransform.rotation = _solvedRotation.ToCQuaternion();
       interactionTransform.wallTime = Time.fixedTime;
       return interactionTransform;
     }

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionC/InteractionC.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionC/InteractionC.cs
@@ -232,7 +232,7 @@ namespace Leap.Unity.Interaction.CApi {
                                            ref INTERACTION_SCENE_INFO sceneInfo,
                                                string dataPath) {
       var rs = LeapIECreateScene(ref scene, ref sceneInfo, dataPath);
-      Logger.HandleReturnStatus(scene, "Create Scene", LogLevel.Info, rs);
+      Logger.HandleReturnStatus("Create Scene", LogLevel.Info, rs);
       return rs;
     }
 
@@ -260,16 +260,9 @@ namespace Leap.Unity.Interaction.CApi {
 
     /*** Get Last Error ***/
     [DllImport(DLL_NAME, EntryPoint = "LeapIEGetLastError")]
-    private static extern ReturnStatus GetLastError(ref INTERACTION_SCENE scene);
+    public static extern ReturnStatus GetLastError(ref INTERACTION_SCENE scene);
     [DllImport(DLL_NAME, EntryPoint = "LeapIEGetLastErrorString")]
-    private static extern IntPtr GetLastErrorString();
-
-    public static ReturnStatus GetLastError(ref INTERACTION_SCENE scene,
-                                            out string message) {
-      ReturnStatus rs = GetLastError(ref scene);
-      message = Marshal.PtrToStringAnsi(GetLastErrorString());
-      return rs;
-    }
+    public static extern IntPtr GetLastErrorString();
 
     public static ReturnStatus GetLastError(ref INTERACTION_SCENE scene,
                                             out IntPtr messagePtr) {

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionC/Logger.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionC/Logger.cs
@@ -26,7 +26,8 @@ namespace Leap.Unity.Interaction.CApi {
 
     [Conditional("ENABLE_LOGGING")]
     public static void HandleReturnStatus(string methodName, LogLevel methodLevel, ReturnStatus rs) {
-      handleReturnStatusInternal(methodName, methodLevel, rs, IntPtr.Zero);
+      IntPtr messagePtr = InteractionC.GetLastErrorString();
+      handleReturnStatusInternal(methodName, methodLevel, rs, messagePtr);
     }
 
     public static void handleReturnStatusInternal(string methodName, LogLevel methodLevel, ReturnStatus rs, IntPtr textPtr) {


### PR DESCRIPTION
Using Rigidbody.MovePosition does not always result in Rigidbody.position immediately returning the set value, which was resulting in a lag of 1 frame in reported position, which was causing some classification issues.