### PR TITLE
Per scene settings component

### DIFF
--- a/Assets/LeapMotion/Scripts/Utils/SceneSettings.cs
+++ b/Assets/LeapMotion/Scripts/Utils/SceneSettings.cs
@@ -1,0 +1,40 @@
+﻿using UnityEngine;
+using System;
+
+namespace Leap.Unity {
+
+  public class SceneSettings : MonoBehaviour {
+
+    public class ToggleValue<T> {
+      public bool Override;
+      public T Value;
+    }
+
+    [Serializable]
+    public class ToggleFloat : ToggleValue<float> { }
+
+    [Serializable]
+    public class ToggleVector3 : ToggleValue<Vector3> { }
+
+    [SerializeField]
+    private ToggleFloat _shadowDistance;
+
+    [SerializeField]
+    private ToggleVector3 _gravity;
+
+    void Reset() {
+      _shadowDistance.Value = QualitySettings.shadowDistance;
+      _gravity.Value = Physics.gravity;
+    }
+
+    void Awake() {
+      if (_shadowDistance.Override) {
+        QualitySettings.shadowDistance = _shadowDistance.Value;
+      }
+
+      if (_gravity.Override) {
+        Physics.gravity = _gravity.Value;
+      }
+    }
+  }
+}

--- a/Assets/LeapMotion/Scripts/Utils/SceneSettings.cs
+++ b/Assets/LeapMotion/Scripts/Utils/SceneSettings.cs
@@ -17,10 +17,10 @@ namespace Leap.Unity {
     public class ToggleVector3 : ToggleValue<Vector3> { }
 
     [SerializeField]
-    private ToggleFloat _shadowDistance;
+    private ToggleFloat _shadowDistance = new ToggleFloat();
 
     [SerializeField]
-    private ToggleVector3 _gravity;
+    private ToggleVector3 _gravity = new ToggleVector3();
 
     void Reset() {
       _shadowDistance.Value = QualitySettings.shadowDistance;

--- a/Assets/LeapMotion/Scripts/Utils/SceneSettings.cs.meta
+++ b/Assets/LeapMotion/Scripts/Utils/SceneSettings.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 430cf29676d3e214d98657ef55500c0c
+timeCreated: 1461609896
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -95,7 +95,7 @@ PlayerSettings:
   metroEnableIndependentInputSource: 0
   metroEnableLowLatencyPresentationAPI: 0
   xboxOneDisableKinectGpuReservation: 0
-  virtualRealitySupported: 0
+  virtualRealitySupported: 1
   productGUID: 7095a052d2dfd6642a958de988530851
   AndroidBundleVersionCode: 1
   AndroidMinSdkVersion: 18
@@ -196,6 +196,7 @@ PlayerSettings:
   wiiUSystemHeapSize: 128
   wiiUTVStartupScreen: {fileID: 0}
   wiiUGamePadStartupScreen: {fileID: 0}
+  wiiUDrcBufferDisabled: 0
   wiiUProfilerLibPath: 
   actionOnDotNetUnhandledException: 1
   enableInternalProfiler: 0
@@ -263,6 +264,7 @@ PlayerSettings:
   ps4DownloadDataSize: 0
   ps4GarlicHeapSize: 2048
   ps4Passcode: frAQBc8Wsa1xVPfvJcrgRYwTiizs2trQ
+  ps4UseDebugIl2cppLibs: 0
   ps4pnSessions: 1
   ps4pnPresence: 1
   ps4pnFriends: 1
@@ -328,6 +330,7 @@ PlayerSettings:
   psp2UseLibLocation: 0
   psp2InfoBarOnStartup: 0
   psp2InfoBarColor: 0
+  psp2UseDebugIl2cppLibs: 0
   psmSplashimage: {fileID: 0}
   spritePackerPolicy: 
   scriptingDefineSymbols: {}

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 5.3.3f1
+m_EditorVersion: 5.3.4p4
 m_StandardAssetsVersion: 0


### PR DESCRIPTION
Adding a component that allows us to set some settings per scene.  This way when one scene wants to have shorter shadows, or decreased gravity, it doesn't have to affect the entire project.  I have only added shadow distance and gravity for now, but we can add more in the future as they become needed.

(Also turned VR back on and updated unity version)

@protodeep 