### PR TITLE
Adding unit tests for frame validation

### DIFF
--- a/Assets/LeapMotion/Editor/Tests.meta
+++ b/Assets/LeapMotion/Editor/Tests.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 394831bde754ade43abc1e88bb98b6d3
+folderAsset: yes
+timeCreated: 1461711885
+licenseType: Pro
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapMotion/Editor/Tests/FrameValidator.cs
+++ b/Assets/LeapMotion/Editor/Tests/FrameValidator.cs
@@ -1,0 +1,120 @@
+﻿using System.Linq;
+using NUnit.Framework;
+
+namespace Leap.Unity.Tests {
+
+  public abstract class FrameValidator {
+    protected const float TOLERANCE = 0.0001f;
+    private static Finger.FingerType[] _fingers = {
+      Finger.FingerType.TYPE_INDEX,
+      Finger.FingerType.TYPE_MIDDLE,
+      Finger.FingerType.TYPE_PINKY,
+      Finger.FingerType.TYPE_RING,
+      Finger.FingerType.TYPE_THUMB
+    };
+
+    private static Bone.BoneType[] _bones = {
+      Bone.BoneType.TYPE_DISTAL,
+      Bone.BoneType.TYPE_INTERMEDIATE,
+      Bone.BoneType.TYPE_METACARPAL,
+      Bone.BoneType.TYPE_PROXIMAL
+    };
+
+    protected Frame _frame;
+
+    [SetUp]
+    public virtual void Setup() {
+      _frame = createFrame();
+    }
+
+    [SetUp]
+    public virtual void Teardown() {
+      _frame = null;
+    }
+
+    protected abstract Frame createFrame();
+
+    [Test]
+    public void HandsAreUnique() {
+      bool existDuplicates = _frame.Hands.GroupBy(h => h.Id).Any(g => g.Count() > 1);
+      Assert.That(existDuplicates, Is.False);
+    }
+
+    [Test]
+    public void HandsHaveFiveFingers() {
+      foreach (Hand hand in _frame.Hands) {
+        Assert.That(hand.Fingers.Count, Is.EqualTo(5));
+      }
+    }
+
+    [Test]
+    public void FingersHaveFourBones([ValueSource(typeof(FrameValidator), "_fingers")] Finger.FingerType fingerType,
+                                     [ValueSource(typeof(FrameValidator), "_bones")] Bone.BoneType boneType) {
+      foreach (Hand hand in _frame.Hands) {
+        Bone bone = getBone(hand, fingerType, boneType);
+        Assert.That(bone, Is.Not.Null);
+      }
+    }
+
+    [Test]
+    public void BoneLength([ValueSource(typeof(FrameValidator), "_fingers")] Finger.FingerType fingerType,
+                           [ValueSource(typeof(FrameValidator), "_bones")] Bone.BoneType boneType) {
+      foreach (Hand hand in _frame.Hands) {
+        Bone bone = getBone(hand, fingerType, boneType);
+        float apparentLength = bone.NextJoint.DistanceTo(bone.PrevJoint);
+        float actualLength = bone.Length;
+        Assert.That(actualLength, Is.EqualTo(apparentLength).Within(TOLERANCE));
+      }
+    }
+
+    [Test]
+    public void JointsMatch([ValueSource(typeof(FrameValidator), "_fingers")] Finger.FingerType fingerType,
+                            [ValueSource(typeof(FrameValidator), "_bones")] Bone.BoneType boneType) {
+      foreach (Hand hand in _frame.Hands) {
+        Bone prevBone = getBone(hand, fingerType, boneType - 1);
+        Bone bone = getBone(hand, fingerType, boneType);
+        Bone nextBone = getBone(hand, fingerType, boneType + 1);
+
+        if (prevBone != null) {
+          assertVectorsEqual(prevBone.NextJoint, bone.PrevJoint);
+        }
+
+        if (nextBone != null) {
+          assertVectorsEqual(nextBone.PrevJoint, bone.NextJoint);
+        }
+      }
+    }
+
+    [Test]
+    public void CenterIsBetweenJoints([ValueSource(typeof(FrameValidator), "_fingers")] Finger.FingerType fingerType,
+                                      [ValueSource(typeof(FrameValidator), "_bones")] Bone.BoneType boneType) {
+      foreach (Hand hand in _frame.Hands) {
+        Bone bone = getBone(hand, fingerType, boneType);
+        
+        Vector jointAverage = (bone.NextJoint + bone.PrevJoint) * 0.5f;
+        assertVectorsEqual(jointAverage, bone.Center);
+      }
+    }
+
+    protected Bone getBone(Hand hand, Finger.FingerType fingerType, Bone.BoneType boneType) {
+      if (boneType < 0 || (int)boneType >= 4) {
+        return null;
+      }
+
+      foreach (Finger finger in hand.Fingers) {
+        if (finger.Type != fingerType) {
+          continue;
+        }
+
+        return finger.Bone(boneType);
+      }
+      return null;
+    }
+
+    protected void assertVectorsEqual(Vector a, Vector b) {
+      Assert.That(a.x, Is.EqualTo(b.x).Within(TOLERANCE));
+      Assert.That(a.y, Is.EqualTo(b.y).Within(TOLERANCE));
+      Assert.That(a.z, Is.EqualTo(b.z).Within(TOLERANCE));
+    }
+  }
+}

--- a/Assets/LeapMotion/Editor/Tests/FrameValidator.cs
+++ b/Assets/LeapMotion/Editor/Tests/FrameValidator.cs
@@ -5,7 +5,7 @@ namespace Leap.Unity.Tests {
 
   public abstract class FrameValidator {
     protected const float TOLERANCE = 0.0001f;
-    private static Finger.FingerType[] _fingers = {
+    protected static Finger.FingerType[] _fingers = {
       Finger.FingerType.TYPE_INDEX,
       Finger.FingerType.TYPE_MIDDLE,
       Finger.FingerType.TYPE_PINKY,
@@ -13,7 +13,7 @@ namespace Leap.Unity.Tests {
       Finger.FingerType.TYPE_THUMB
     };
 
-    private static Bone.BoneType[] _bones = {
+    protected static Bone.BoneType[] _bones = {
       Bone.BoneType.TYPE_DISTAL,
       Bone.BoneType.TYPE_INTERMEDIATE,
       Bone.BoneType.TYPE_METACARPAL,

--- a/Assets/LeapMotion/Editor/Tests/FrameValidator.cs
+++ b/Assets/LeapMotion/Editor/Tests/FrameValidator.cs
@@ -90,9 +90,25 @@ namespace Leap.Unity.Tests {
                                       [ValueSource(typeof(FrameValidator), "_bones")] Bone.BoneType boneType) {
       foreach (Hand hand in _frame.Hands) {
         Bone bone = getBone(hand, fingerType, boneType);
-        
+
         Vector jointAverage = (bone.NextJoint + bone.PrevJoint) * 0.5f;
         assertVectorsEqual(jointAverage, bone.Center);
+      }
+    }
+
+    [Test]
+    public void DirectionMatchesJoints([ValueSource(typeof(FrameValidator), "_fingers")] Finger.FingerType fingerType,
+                                       [ValueSource(typeof(FrameValidator), "_bones")] Bone.BoneType boneType) {
+      foreach (Hand hand in _frame.Hands) {
+        Bone bone = getBone(hand, fingerType, boneType);
+
+        //If the joints are at the same position this test is meaningless
+        if (bone.NextJoint.DistanceTo(bone.PrevJoint) < TOLERANCE) {
+          continue;
+        }
+
+        Vector jointDirection = (bone.NextJoint - bone.PrevJoint).Normalized;
+        assertVectorsEqual(jointDirection, bone.Direction);
       }
     }
 

--- a/Assets/LeapMotion/Editor/Tests/FrameValidator.cs.meta
+++ b/Assets/LeapMotion/Editor/Tests/FrameValidator.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 7c6eb467dcf4a1446badf724a74ce9e3
+timeCreated: 1461712111
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapMotion/Editor/Tests/HandFactoryTest.cs
+++ b/Assets/LeapMotion/Editor/Tests/HandFactoryTest.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace Leap.Unity.Tests {
+
+  [TestFixture(Category = "TestHandFactory")]
+  public class HandFactoryTwoHands : FrameValidator {
+    protected override Frame createFrame() {
+      return TestHandFactory.MakeTestFrame(0, true, true);
+    }
+
+    [Test]
+    public void CorrectHandCount() {
+      Assert.That(_frame.Hands.Count, Is.EqualTo(2));
+    }
+  }
+
+  [TestFixture(Category = "TestHandFactory")]
+  public class HandFactoryLeft : FrameValidator {
+    protected override Frame createFrame() {
+      return TestHandFactory.MakeTestFrame(0, true, false);
+    }
+
+    [Test]
+    public void CorrectHandCount() {
+      Assert.That(_frame.Hands.Count, Is.EqualTo(1));
+    }
+  }
+
+  [TestFixture(Category = "TestHandFactory")]
+  public class HandFactoryRight : FrameValidator {
+    protected override Frame createFrame() {
+      return TestHandFactory.MakeTestFrame(0, false, true);
+    }
+
+    [Test]
+    public void CorrectHandCount() {
+      Assert.That(_frame.Hands.Count, Is.EqualTo(1));
+    }
+  }
+}

--- a/Assets/LeapMotion/Editor/Tests/HandFactoryTest.cs.meta
+++ b/Assets/LeapMotion/Editor/Tests/HandFactoryTest.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 0fb0f9371f59c894f8597f3dcaefec54
+timeCreated: 1461711202
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapMotion/Editor/Tests/TransformCopyTest.cs
+++ b/Assets/LeapMotion/Editor/Tests/TransformCopyTest.cs
@@ -1,5 +1,4 @@
 ﻿using NUnit.Framework;
-using System.Linq;
 
 namespace Leap.Unity.Tests {
 

--- a/Assets/LeapMotion/Editor/Tests/TransformCopyTest.cs
+++ b/Assets/LeapMotion/Editor/Tests/TransformCopyTest.cs
@@ -1,0 +1,59 @@
+﻿using NUnit.Framework;
+using System.Linq;
+
+namespace Leap.Unity.Tests {
+
+  public class TransformCopyIdentity : FrameValidator {
+    protected Frame _originalFrame;
+
+    protected override Frame createFrame() {
+      _originalFrame = TestHandFactory.MakeTestFrame(0, true, true);
+      return _originalFrame.TransformedCopy(LeapTransform.Identity);
+    }
+
+    [Test]
+    public void IdsAreSame() {
+      Assert.That(_frame.Hands.Count, Is.EqualTo(_originalFrame.Hands.Count));
+
+      for (int i = 0; i < _frame.Hands.Count; i++) {
+        Hand oldHand = _originalFrame.Hands[i];
+        Hand newHand = _frame.Hands[i];
+        Assert.That(oldHand.Id, Is.EqualTo(newHand.Id));
+
+        for (int j = 0; j < 5; j++) {
+          Finger oldFinger = oldHand.Fingers[j];
+          Finger newFinger = newHand.Fingers[j];
+          Assert.That(oldFinger.Id, Is.EqualTo(newFinger.Id));
+        }
+      }
+    }
+  }
+
+  public class TransformCopyTranslation : FrameValidator {
+    protected static Vector translation = Vector.Forward;
+    protected Frame _originalFrame;
+
+    protected override Frame createFrame() {
+      _originalFrame = TestHandFactory.MakeTestFrame(0, true, true);
+      LeapTransform forwardTransform = new LeapTransform(translation, LeapQuaternion.Identity);
+      return _originalFrame.TransformedCopy(forwardTransform);
+    }
+
+    [Test]
+    public void IsTranslated() {
+      for (int i = 0; i < _frame.Hands.Count; i++) {
+        Hand oldHand = _originalFrame.Hands[i];
+        Hand newHand = _frame.Hands[i];
+
+        assertVectorsEqual(oldHand.PalmPosition + translation, newHand.PalmPosition);
+
+        for (int j = 0; j < 5; j++) {
+          Finger oldFinger = oldHand.Fingers[j];
+          Finger newFinger = newHand.Fingers[j];
+
+          assertVectorsEqual(oldFinger.TipPosition + translation, newFinger.TipPosition);
+        }
+      }
+    }
+  }
+}

--- a/Assets/LeapMotion/Editor/Tests/TransformCopyTest.cs.meta
+++ b/Assets/LeapMotion/Editor/Tests/TransformCopyTest.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 735f00b9d48456f469d7d7fce9a5a333
+timeCreated: 1461711984
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapMotion/Scripts/Hands/TestHandFactory.cs
+++ b/Assets/LeapMotion/Scripts/Hands/TestHandFactory.cs
@@ -106,6 +106,10 @@ using System.Runtime.InteropServices;
 
          static Finger MakeFinger(Finger.FingerType name, Vector position, Vector forward, Vector up, float[] jointLengths,
             int frameId, int handId, int fingerId, bool isLeft){
+
+            forward = forward.Normalized;
+            up = up.Normalized;
+
             Bone[] bones = new Bone[5];
             float proximalDistance = -jointLengths[0];
             Bone metacarpal = MakeBone (Bone.BoneType.TYPE_METACARPAL, position + forward * proximalDistance, jointLengths[0], 8f, forward, up, isLeft);


### PR DESCRIPTION
This PR adds some Unity side unit tests using the built in unit test functionality.  These tests currently only cover a subset of things, but hopefully we can add tests as time goes on.  There is a base FrameValidator class which is used for the basis of any test that wants to check whether or not a process generates valid frames.  Currently it is being used as the base to test HandFactory and TransformCopy.  

These tests were prompted by me noticing that the hands returned by HandFactory were slightly incorrect.  Specifically the lengths of the thumb bones did not match the distance between the joints.  I used the unit tests to quickly iterate and try different solutions, and found that the up/forward vectors passed into the MakeBone method were not always of unit length, which could break the logic.

To test
 - [x] Verify that the tests show up when you go to Window -> Editor Test Runner
 - [x] Verify that all tests pass
 - [x] Verify that the hands appear normal in the scene preview when you visit a scene.