### PR TITLE
Fixed frames being incorrect if the transform was moved since it was calculated

### DIFF
--- a/Assets/LeapMotion/Scripts/LeapServiceProvider.cs
+++ b/Assets/LeapMotion/Scripts/LeapServiceProvider.cs
@@ -38,18 +38,21 @@ namespace Leap.Unity {
 
     protected Controller leap_controller_;
 
-    protected Frame _currentFrame;
+    protected Frame _untransformedUpdateFrame;
+    protected Frame _transformedUpdateFrame;
     protected Image _currentImage;
     protected int _currentUpdateCount = -1;
 
-    protected Frame _currentFixedFrame;
+    protected Frame _untransformedFixedFrame;
+    protected Frame _transformedFixedFrame;
     protected float _currentFixedTime = -1;
 
     private ClockCorrelator clockCorrelator;
 
     public override Frame CurrentFrame {
       get {
-        return _currentFrame;
+        updateIfTransformMoved(_untransformedUpdateFrame, ref _transformedUpdateFrame);
+        return _transformedUpdateFrame;
       }
     }
 
@@ -61,7 +64,8 @@ namespace Leap.Unity {
 
     public override Frame CurrentFixedFrame {
       get {
-        return _currentFixedFrame;
+        updateIfTransformMoved(_untransformedFixedFrame, ref _transformedFixedFrame);
+        return _transformedFixedFrame;
       }
     }
 
@@ -138,13 +142,12 @@ namespace Leap.Unity {
 
     protected virtual void Awake() {
       clockCorrelator = new ClockCorrelator();
-
     }
 
     protected virtual void Start() {
       createController();
-      _currentFrame = new Frame();
-      _currentFixedFrame = new Frame();
+      _untransformedUpdateFrame = new Frame();
+      _untransformedFixedFrame = new Frame();
     }
 
     protected virtual void Update() {
@@ -158,25 +161,19 @@ namespace Leap.Unity {
       Int64 unityTime = (Int64)(Time.time * 1e6);
       clockCorrelator.UpdateRebaseEstimate(unityTime);
 
-      Frame serviceFrame;
       if (_useInterpolation) {
         Int64 unityOffsetTime = unityTime - _interpolationDelay * 1000;
         Int64 leapFrameTime = clockCorrelator.ExternalClockToLeapTime(unityOffsetTime);
-        serviceFrame = leap_controller_.GetInterpolatedFrame(leapFrameTime);
+        _untransformedUpdateFrame = leap_controller_.GetInterpolatedFrame(leapFrameTime);
       } else {
-        serviceFrame = leap_controller_.Frame();
-      }
-
-      if (serviceFrame != null) {
-        LeapTransform leapMat = transform.GetLeapMatrix();
-        _currentFrame = serviceFrame.TransformedCopy(leapMat);
+        _untransformedUpdateFrame = leap_controller_.Frame();
       }
     }
 
     protected virtual void FixedUpdate() {
       //TODO: Find suitable interpolation strategy for FixedUpdate
       LeapTransform leapMat = transform.GetLeapMatrix();
-      _currentFixedFrame = leap_controller_.Frame().TransformedCopy(leapMat);
+      _untransformedFixedFrame = leap_controller_.Frame().TransformedCopy(leapMat);
     }
 
     protected virtual void OnDestroy() {
@@ -220,9 +217,8 @@ namespace Leap.Unity {
       }
 
       leap_controller_ = new Controller();
-      if (leap_controller_.IsConnected)
-      {
-          initializeFlags();
+      if (leap_controller_.IsConnected) {
+        initializeFlags();
       } else {
         leap_controller_.Device += onHandControllerConnect;
       }
@@ -245,5 +241,16 @@ namespace Leap.Unity {
       leap_controller_.Device -= onHandControllerConnect;
     }
 
+    protected void updateIfTransformMoved(Frame source, ref Frame toUpdate) {
+      if (transform.hasChanged) {
+        _transformedFixedFrame = null;
+        _transformedUpdateFrame = null;
+        transform.hasChanged = false;
+      }
+
+      if (toUpdate == null) {
+        toUpdate = source.TransformedCopy(transform.GetLeapMatrix());
+      }
+    }
   }
 }

--- a/Assets/LeapMotion/Scripts/LeapServiceProvider.cs
+++ b/Assets/LeapMotion/Scripts/LeapServiceProvider.cs
@@ -172,8 +172,7 @@ namespace Leap.Unity {
 
     protected virtual void FixedUpdate() {
       //TODO: Find suitable interpolation strategy for FixedUpdate
-      LeapTransform leapMat = transform.GetLeapMatrix();
-      _untransformedFixedFrame = leap_controller_.Frame().TransformedCopy(leapMat);
+      _untransformedFixedFrame = leap_controller_.Frame();
     }
 
     protected virtual void OnDestroy() {


### PR DESCRIPTION
Now the frame is re-transformed if the transform gets changed.  This should fix issues where the user moving the camera rig causes the hands to glitch or freak out.  It can also fix/improve  a potentially subtle bug when the user asks for a frame before it is available.  Now it will still return the old frame but it will be in the new and correct transform space. 

To test:
- [x] Verify that both graphical and physical hands still behave as expected.
- [x] Verify that when moving the root transform in Update causes no graphical or physical artifacts.
