### PR TITLE
Frames were not being nulled when they changed

### DIFF
--- a/Assets/LeapMotion/Scripts/LeapServiceProvider.cs
+++ b/Assets/LeapMotion/Scripts/LeapServiceProvider.cs
@@ -168,11 +168,16 @@ namespace Leap.Unity {
       } else {
         _untransformedUpdateFrame = leap_controller_.Frame();
       }
+
+      //Null out transformed frame because it is now stale
+      //It will be recalculated if it is needed
+      _transformedUpdateFrame = null;
     }
 
     protected virtual void FixedUpdate() {
       //TODO: Find suitable interpolation strategy for FixedUpdate
       _untransformedFixedFrame = leap_controller_.Frame();
+      _transformedFixedFrame = null;
     }
 
     protected virtual void OnDestroy() {


### PR DESCRIPTION
Transformed frames were not being set to null when new frames were calculated, resulting in stale frames staying around for way too long if the transform did not move.  They are now nulled out, forcing them to be recalculated in the correct situations.

- [x] Make sure VR and AR scenes still work as expected
- [x] Make sure Desktop scene works properly now
- [x] Make sure that moving the transform still does not cause glitching