### PR TITLE
VR Height offset for pinch utility

### DIFF
--- a/Assets/LeapMotionModules/PinchUtility/Examples/Scenes/PinchMovementDemo.unity
+++ b/Assets/LeapMotionModules/PinchUtility/Examples/Scenes/PinchMovementDemo.unity
@@ -1324,6 +1324,7 @@ GameObject:
   m_Component:
   - 4: {fileID: 1714544385}
   - 114: {fileID: 1714544384}
+  - 114: {fileID: 1714544386}
   m_Layer: 0
   m_Name: RTS Object
   m_TagString: Untagged
@@ -1363,6 +1364,22 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1714544386
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1714544383}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7663fe9f3b9b4204595fa76819c10d6d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _deviceOffsets:
+  - deviceName: Oculus
+    heightOffset: -0.1
+  - deviceName: Vive
+    heightOffset: 1
 --- !u!1001 &1759863750
 Prefab:
   m_ObjectHideFlags: 0

--- a/Assets/LeapMotionModules/PinchUtility/Examples/Scenes/PinchMovementDemo.unity
+++ b/Assets/LeapMotionModules/PinchUtility/Examples/Scenes/PinchMovementDemo.unity
@@ -1378,7 +1378,7 @@ MonoBehaviour:
   _deviceOffsets:
   - deviceName: Oculus
     heightOffset: -0.1
-  - deviceName: Vive
+  - deviceName: OpenVR
     heightOffset: 1
 --- !u!1001 &1759863750
 Prefab:

--- a/Assets/LeapMotionModules/PinchUtility/Examples/Scripts/VRHeightOffset.cs
+++ b/Assets/LeapMotionModules/PinchUtility/Examples/Scripts/VRHeightOffset.cs
@@ -20,14 +20,18 @@ public class VRHeightOffset : MonoBehaviour {
 
   void Reset() {
     _deviceOffsets = new DeviceHeightPair[2];
-    _deviceOffsets[0] = new DeviceHeightPair("Oculus", -0.1f);
-    _deviceOffsets[1] = new DeviceHeightPair("Vive", 1.0f);
+    _deviceOffsets[0] = new DeviceHeightPair("oculus", -0.1f);
+    _deviceOffsets[1] = new DeviceHeightPair("OpenVR", 1.0f);
   }
 
   void Start() {
     if (VRDevice.isPresent && VRSettings.enabled && _deviceOffsets != null) {
+#if UNITY_5_4_OR_NEWER
       string deviceName = VRSettings.loadedDeviceName;
-      var deviceHeightPair = _deviceOffsets.FirstOrDefault(d => d.deviceName == deviceName);
+#else
+      string deviceName = VRDevice.family;
+#endif
+      var deviceHeightPair = _deviceOffsets.FirstOrDefault(d => deviceName.ToLower().Contains(d.deviceName.ToLower()));
       if (deviceHeightPair != null) {
         transform.Translate(Vector3.up * deviceHeightPair.heightOffset);
       }

--- a/Assets/LeapMotionModules/PinchUtility/Examples/Scripts/VRHeightOffset.cs
+++ b/Assets/LeapMotionModules/PinchUtility/Examples/Scripts/VRHeightOffset.cs
@@ -1,0 +1,37 @@
+﻿using UnityEngine;
+using UnityEngine.VR;
+using System;
+using System.Linq;
+
+public class VRHeightOffset : MonoBehaviour {
+
+  [Serializable]
+  public class DeviceHeightPair {
+    public string deviceName;
+    public float heightOffset;
+
+    public DeviceHeightPair(string deviceName, float heightOffset) {
+      this.deviceName = deviceName;
+      this.heightOffset = heightOffset;
+    }
+  }
+
+  public DeviceHeightPair[] _deviceOffsets;
+
+  void Reset() {
+    _deviceOffsets = new DeviceHeightPair[2];
+    _deviceOffsets[0] = new DeviceHeightPair("Oculus", -0.1f);
+    _deviceOffsets[1] = new DeviceHeightPair("Vive", 1.0f);
+  }
+
+  void Start() {
+    if (VRDevice.isPresent && VRSettings.enabled && _deviceOffsets != null) {
+      string deviceName = VRSettings.loadedDeviceName;
+      var deviceHeightPair = _deviceOffsets.FirstOrDefault(d => d.deviceName == deviceName);
+      if (deviceHeightPair != null) {
+        transform.Translate(Vector3.up * deviceHeightPair.heightOffset);
+      }
+    }
+  }
+
+}

--- a/Assets/LeapMotionModules/PinchUtility/Examples/Scripts/VRHeightOffset.cs.meta
+++ b/Assets/LeapMotionModules/PinchUtility/Examples/Scripts/VRHeightOffset.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 7663fe9f3b9b4204595fa76819c10d6d
+timeCreated: 1462492126
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Offsets the cube by a meter when using the vive, includes a re-usable component for height based offset per vr device

- [x] Verify that it still works properly for Oculus
- [x] Verify that it is at a good height when using OpenVR