### PR TITLE
Improved support for vr setups outside Unity itegration

### DIFF
--- a/Assets/LeapMotion/Scenes/Leap_Hands_Demo_VR.unity
+++ b/Assets/LeapMotion/Scenes/Leap_Hands_Demo_VR.unity
@@ -13,7 +13,7 @@ SceneSettings:
 --- !u!104 &2
 RenderSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 7
+  serializedVersion: 6
   m_Fog: 0
   m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   m_FogMode: 3
@@ -37,12 +37,12 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44692546, g: 0.49678695, b: 0.5750854, a: 1}
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 7
+  serializedVersion: 6
   m_GIWorkflowMode: 0
+  m_LightmapsMode: 1
   m_GISettings:
     serializedVersion: 2
     m_BounceScale: 1
@@ -53,22 +53,17 @@ LightmapSettings:
     m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 1
   m_LightmapEditorSettings:
-    serializedVersion: 4
+    serializedVersion: 3
     m_Resolution: 2
     m_BakeResolution: 40
     m_TextureWidth: 1024
     m_TextureHeight: 1024
-    m_AO: 0
     m_AOMaxDistance: 1
-    m_CompAOExponent: 0
-    m_CompAOExponentDirect: 0
     m_Padding: 2
+    m_CompAOExponent: 0
     m_LightmapParameters: {fileID: 0}
-    m_LightmapsBakeMode: 1
     m_TextureCompression: 1
-    m_DirectLightInLightProbes: 1
     m_FinalGather: 0
-    m_FinalGatherFiltering: 1
     m_FinalGatherRayCount: 1024
     m_ReflectionCompression: 2
   m_LightingDataAsset: {fileID: 0}
@@ -202,11 +197,11 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1928180894}
   m_Father: {fileID: 1805543667}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &266907293
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1869,6 +1864,7 @@ Transform:
   m_LocalRotation: {x: 0.000000115202326, y: -0.7071067, z: -0.7071068, w: -0.00000011520231}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: -89.980194, y: 180, z: 0}
   m_Children:
   - {fileID: 967018927}
   - {fileID: 869913656}
@@ -1876,7 +1872,6 @@ Transform:
   - {fileID: 44000905}
   m_Father: {fileID: 1928180894}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: -89.980194, y: 180, z: 0}
 --- !u!1 &1805543666
 GameObject:
   m_ObjectHideFlags: 0
@@ -1901,11 +1896,11 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 266907292}
   m_Father: {fileID: 0}
   m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1928180893
 GameObject:
   m_ObjectHideFlags: 0
@@ -1931,11 +1926,11 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1576743646}
   m_Father: {fileID: 266907292}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1928180895
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1949,6 +1944,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   provider: {fileID: 72891527}
+  _headTransform: {fileID: 266907292}
+  _trackingAnchor: {fileID: 1805543667}
   recenter: 114
   tweenImageWarping: 0
   tweenRotationalWarping: 1
@@ -2024,7 +2021,7 @@ Light:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1966885502}
   m_Enabled: 1
-  serializedVersion: 7
+  serializedVersion: 6
   m_Type: 1
   m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
   m_Intensity: 1
@@ -2046,10 +2043,10 @@ Light:
     serializedVersion: 2
     m_Bits: 4294967295
   m_Lightmapping: 4
-  m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
   m_ShadowRadius: 0
   m_ShadowAngle: 0
+  m_AreaSize: {x: 1, y: 1}
 --- !u!4 &1966885504
 Transform:
   m_ObjectHideFlags: 0
@@ -2059,7 +2056,7 @@ Transform:
   m_LocalRotation: {x: 0.40821794, y: -0.23456973, z: 0.109381676, w: 0.87542605}
   m_LocalPosition: {x: 0, y: 3, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/LeapMotion/Scripts/VR/Editor/LeapTemporalWarpingEditor.cs
+++ b/Assets/LeapMotion/Scripts/VR/Editor/LeapTemporalWarpingEditor.cs
@@ -13,7 +13,15 @@ namespace Leap.Unity {
                                 "unlockHold",
                                 "moreRewind",
                                 "lessRewind");
+
+      specifyCustomDecorator("provider", warningDecorator);
+    }
+
+    private void warningDecorator(SerializedProperty prop) {
+      if (!PlayerSettings.virtualRealitySupported) {
+        EditorGUILayout.HelpBox("Unity VR Disabled.  ManualyUpdateTemporalWarping must be called right after " +
+                                "the Head transform has been updated.", MessageType.Warning);
+      }
     }
   }
 }
-  

--- a/Assets/LeapMotion/Scripts/VR/EyeType.cs
+++ b/Assets/LeapMotion/Scripts/VR/EyeType.cs
@@ -1,41 +1,42 @@
 ﻿using UnityEngine;
+using UnityEngine.VR;
 #if UNITY_EDITOR
 using UnityEditor;
 #endif
 using System;
 
-namespace Leap.Unity{
+namespace Leap.Unity {
   [System.Serializable]
   public class EyeType {
     private const string TARGET_EYE_PROPERTY_NAME = "m_TargetEye";
     private const int TARGET_EYE_LEFT_INDEX = 1;
     private const int TARGET_EYE_RIGHT_INDEX = 2;
     private const int TARGET_EYE_CENTER_INDEX = 3;
-  
-    public enum OrderType{
+
+    public enum OrderType {
       LEFT = TARGET_EYE_LEFT_INDEX,
       RIGHT = TARGET_EYE_RIGHT_INDEX,
       CENTER = TARGET_EYE_CENTER_INDEX
     }
-  
+
     [SerializeField]
     private OrderType _orderType = OrderType.LEFT;
-  
+
     private bool _isOnFirst = false;
     private bool _hasBegun = false;
-  
+
     public OrderType Type {
       get {
         return _orderType;
       }
     }
-  
+
     public bool IsLeftEye {
       get {
         if (!_hasBegun) {
           throw new Exception("Cannot call IsLeftEye or IsRightEye before BeginCamera has been called!");
         }
-  
+
         switch (_orderType) {
           case OrderType.LEFT: return true;
           case OrderType.RIGHT: return false;
@@ -44,28 +45,33 @@ namespace Leap.Unity{
         }
       }
     }
-  
+
     public bool IsRightEye {
       get {
         return !IsLeftEye;
       }
     }
-  
+
     public EyeType(OrderType type) {
       _orderType = type;
     }
-  
-  #if UNITY_EDITOR
+
+#if UNITY_EDITOR
     public void UpdateOrderGivenComponent(Component component) {
       if (Application.isPlaying) {
         return;
       }
-  
+
+      //Allow the user to specify themselves if VR is disabled
+      if (!VRSettings.enabled || !PlayerSettings.virtualRealitySupported) {
+        return;
+      }
+
       Camera camera = component.GetComponent<Camera>();
       if (camera == null) {
         camera = component.gameObject.AddComponent<Camera>();
       }
-  
+
       SerializedObject obj = new SerializedObject(camera);
       SerializedProperty targetEyeProp = obj.FindProperty(TARGET_EYE_PROPERTY_NAME);
       OrderType newOrder = (OrderType)targetEyeProp.intValue;
@@ -74,8 +80,8 @@ namespace Leap.Unity{
         EditorUtility.SetDirty(component);
       }
     }
-  #endif
-  
+#endif
+
     public void BeginCamera() {
       if (!_hasBegun) {
         _isOnFirst = true;
@@ -84,7 +90,7 @@ namespace Leap.Unity{
         _isOnFirst = !_isOnFirst;
       }
     }
-  
+
     public void Reset() {
       _hasBegun = false;
     }

--- a/Assets/LeapMotion/Scripts/VR/LeapVRCameraControl.cs
+++ b/Assets/LeapMotion/Scripts/VR/LeapVRCameraControl.cs
@@ -117,14 +117,12 @@ namespace Leap.Unity {
     }
 
     public struct CameraParams {
-      public readonly Transform TrackingAnchor;
       public readonly Transform CenterEyeTransform;
       public readonly Matrix4x4 ProjectionMatrix;
       public readonly int Width;
       public readonly int Height;
 
       public CameraParams(Camera camera) {
-        TrackingAnchor = camera.transform.parent;
         CenterEyeTransform = camera.transform;
         ProjectionMatrix = camera.projectionMatrix;
 

--- a/Assets/LeapMotion/Scripts/VR/LeapVRTemporalWarping.cs
+++ b/Assets/LeapMotion/Scripts/VR/LeapVRTemporalWarping.cs
@@ -263,7 +263,7 @@ namespace Leap.Unity {
     }
 
     protected void Update() {
-      if (Input.GetKeyDown(recenter)) {
+      if (Input.GetKeyDown(recenter) && VRSettings.enabled && VRDevice.isPresent) {
         InputTracking.Recenter();
       }
 

--- a/Assets/LeapMotion/Scripts/VR/LeapVRTemporalWarping.cs
+++ b/Assets/LeapMotion/Scripts/VR/LeapVRTemporalWarping.cs
@@ -213,11 +213,6 @@ namespace Leap.Unity {
       if (_headTransform == null) {
         _headTransform = transform.parent;
       }
-      if (_trackingAnchor == null) {
-        if (_headTransform != null) {
-          _trackingAnchor = _headTransform.parent;
-        }
-      }
     }
 
     protected void Start() {

--- a/Assets/LeapMotion/Scripts/VR/LeapVRTemporalWarping.cs
+++ b/Assets/LeapMotion/Scripts/VR/LeapVRTemporalWarping.cs
@@ -192,6 +192,10 @@ namespace Leap.Unity {
       return false;
     }
 
+    /// <summary>
+    /// Use this method when not using Unity default VR integration.  This method should be called directly after
+    /// the head transform has been updated using your input tracking solution.
+    /// </summary>
     public void ManualyUpdateTemporalWarping() {
       if (_trackingAnchor == null) {
         updateHistory(_headTransform.position, _headTransform.rotation);

--- a/Assets/LeapMotion/Scripts/VR/LeapVRTemporalWarping.cs
+++ b/Assets/LeapMotion/Scripts/VR/LeapVRTemporalWarping.cs
@@ -202,6 +202,7 @@ namespace Leap.Unity {
       }
     }
 
+#if UNITY_EDITOR
     protected void Reset() {
       _headTransform = transform.parent;
       if (_headTransform != null) {
@@ -213,7 +214,12 @@ namespace Leap.Unity {
       if (_headTransform == null) {
         _headTransform = transform.parent;
       }
+
+      if (_headTransform != null && UnityEditor.PlayerSettings.virtualRealitySupported) {
+        _trackingAnchor = _headTransform.parent;
+      }
     }
+#endif
 
     protected void Start() {
       if (provider.IsConnected()) {


### PR DESCRIPTION
All scripts still work the same way when Unity VR Integration is enabled, but functionality should still be possible even when it is disabled.

- Removed the 'tracking anchor' field from the camera parameters, as it was not generic enough
- Added HeadTransform and TrackingAnchor to LeapVRTemporalWarping.  These are auto-detected when VR is enabled.  
- LeapVRTemporalWarping does not automatically update time warping if UnityVR is disabled.  Instead the developer must call 'ManualyUpdateTemporalWarping' directly after they have updated the head transform.
- EyeType no longer auto-updates the value if UnityVR is disabled.  This allows developers to set it themselves when VR is disabled.

To test:
- [x] Verify that all scenes still function as expected and that temporal warping is not misbehaving.
- [x] Verify that when VR is disabled that you can freely change the order type on VR Camera Control.
- [x] Verify that when VR is disabled that a warning appears on the Temporal Warping component.