### PR TITLE
Interaction engine fixes

### DIFF
--- a/Assets/LeapMotionModules/InteractionEngine/Examples/Scenes/ExampleScene.unity
+++ b/Assets/LeapMotionModules/InteractionEngine/Examples/Scenes/ExampleScene.unity
@@ -13,7 +13,7 @@ SceneSettings:
 --- !u!104 &2
 RenderSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 6
+  serializedVersion: 7
   m_Fog: 0
   m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   m_FogMode: 3
@@ -37,12 +37,12 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.44154438, g: 0.49037057, b: 0.57033986, a: 1}
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 6
+  serializedVersion: 7
   m_GIWorkflowMode: 0
-  m_LightmapsMode: 1
   m_GISettings:
     serializedVersion: 2
     m_BounceScale: 1
@@ -53,17 +53,22 @@ LightmapSettings:
     m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 1
   m_LightmapEditorSettings:
-    serializedVersion: 3
+    serializedVersion: 4
     m_Resolution: 2
     m_BakeResolution: 40
     m_TextureWidth: 1024
     m_TextureHeight: 1024
+    m_AO: 0
     m_AOMaxDistance: 1
-    m_Padding: 2
     m_CompAOExponent: 0
+    m_CompAOExponentDirect: 0
+    m_Padding: 2
     m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
     m_TextureCompression: 1
+    m_DirectLightInLightProbes: 1
     m_FinalGather: 0
+    m_FinalGatherFiltering: 1
     m_FinalGatherRayCount: 1024
     m_ReflectionCompression: 2
   m_LightingDataAsset: {fileID: 0}
@@ -109,11 +114,11 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 2030233098}
   m_Father: {fileID: 2044671631}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &113913754
 GameObject:
   m_ObjectHideFlags: 0
@@ -139,10 +144,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 2, z: 2.05}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 682435271}
   m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!65 &113913756
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -234,10 +239,10 @@ Transform:
   m_LocalRotation: {x: 0.000000115202326, y: 0.7071067, z: 0.7071068, w: -0.00000011520231}
   m_LocalPosition: {x: -0.23, y: 0.291, z: -0.191}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: -90, y: 180, z: 0}
   m_Children: []
   m_Father: {fileID: 972296619}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: -90, y: 180, z: 0}
 --- !u!1 &313214632
 GameObject:
   m_ObjectHideFlags: 0
@@ -263,10 +268,10 @@ Transform:
   m_LocalRotation: {x: 0.43769792, y: -0.32756114, z: 0.59360814, w: 0.5905537}
   m_LocalPosition: {x: 0, y: 2, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 64.9386, y: 18.2648, z: 101.9766}
   m_Children: []
   m_Father: {fileID: 682435271}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 64.9386, y: 18.2648, z: 101.9766}
 --- !u!108 &313214634
 Light:
   m_ObjectHideFlags: 0
@@ -274,7 +279,7 @@ Light:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 313214632}
   m_Enabled: 1
-  serializedVersion: 6
+  serializedVersion: 7
   m_Type: 1
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_Intensity: 0.3
@@ -296,10 +301,10 @@ Light:
     serializedVersion: 2
     m_Bits: 4294967295
   m_Lightmapping: 4
+  m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
   m_ShadowRadius: 0
   m_ShadowAngle: 0
-  m_AreaSize: {x: 1, y: 1}
 --- !u!1 &335842739
 GameObject:
   m_ObjectHideFlags: 0
@@ -328,11 +333,11 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -0.27, y: -0.1, z: 0.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1596465887}
   m_Father: {fileID: 1473219678}
   m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &335842741
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -671,13 +676,15 @@ MeshRenderer:
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 84471ff3383f8d34bb14cc52f05e2948, type: 2}
   m_SubsetIndices: 
   m_StaticBatchRoot: {fileID: 0}
-  m_UseLightProbes: 1
-  m_ReflectionProbeUsage: 1
   m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
@@ -716,10 +723,10 @@ Transform:
   m_LocalRotation: {x: -0.0000002425134, y: -0.9919059, z: -0.12697531, w: 0.000001978079}
   m_LocalPosition: {x: 0, y: -0.085999966, z: -1.0339999}
   m_LocalScale: {x: 4.8187037, y: 0.20000008, z: 2.04702}
-  m_LocalEulerAnglesHint: {x: -14.5897, y: -179.9998, z: 0}
   m_Children: []
   m_Father: {fileID: 682435271}
   m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: -14.5897, y: -179.9998, z: 0}
 --- !u!1 &560681034
 GameObject:
   m_ObjectHideFlags: 0
@@ -832,6 +839,14 @@ Prefab:
       propertyPath: _brushDisableDistance
       value: 0.017
       objectReference: {fileID: 0}
+    - target: {fileID: 5484986, guid: 79ca92ca2850488418cefdb0f66d02e3, type: 2}
+      propertyPath: m_IsKinematic
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5484986, guid: 79ca92ca2850488418cefdb0f66d02e3, type: 2}
+      propertyPath: m_UseGravity
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 79ca92ca2850488418cefdb0f66d02e3, type: 2}
   m_IsPrefabParent: 0
@@ -866,13 +881,15 @@ MeshRenderer:
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 84471ff3383f8d34bb14cc52f05e2948, type: 2}
   m_SubsetIndices: 
   m_StaticBatchRoot: {fileID: 0}
-  m_UseLightProbes: 1
-  m_ReflectionProbeUsage: 1
   m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
@@ -911,10 +928,10 @@ Transform:
   m_LocalRotation: {x: -0.09229594, y: -0.7010566, z: -0.0922957, w: 0.7010582}
   m_LocalPosition: {x: -1.4659998, y: -0.085999966, z: 0}
   m_LocalScale: {x: 4, y: 0.20000005, z: 2}
-  m_LocalEulerAnglesHint: {x: -15, y: -89.9999, z: 0}
   m_Children: []
   m_Father: {fileID: 682435271}
   m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: -15, y: -89.9999, z: 0}
 --- !u!1 &682435270
 GameObject:
   m_ObjectHideFlags: 0
@@ -941,7 +958,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 313214633}
   - {fileID: 1892441709}
@@ -956,6 +972,7 @@ Transform:
   - {fileID: 2047243206}
   m_Father: {fileID: 0}
   m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &682435272
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1019,10 +1036,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 6, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 1158366230}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!23 &776879991
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -1033,13 +1050,15 @@ MeshRenderer:
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 82b99f8d501079d4b8821249d80c2c42, type: 2}
   m_SubsetIndices: 
   m_StaticBatchRoot: {fileID: 0}
-  m_UseLightProbes: 1
-  m_ReflectionProbeUsage: 1
   m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
@@ -1085,13 +1104,15 @@ MeshRenderer:
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 84471ff3383f8d34bb14cc52f05e2948, type: 2}
   m_SubsetIndices: 
   m_StaticBatchRoot: {fileID: 0}
-  m_UseLightProbes: 1
-  m_ReflectionProbeUsage: 1
   m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
@@ -1130,10 +1151,10 @@ Transform:
   m_LocalRotation: {x: -0.09229592, y: 0.7010567, z: 0.092295736, w: 0.7010581}
   m_LocalPosition: {x: 1.466, y: -0.085999966, z: 0}
   m_LocalScale: {x: 4, y: 0.20000005, z: 2}
-  m_LocalEulerAnglesHint: {x: -15, y: 89.9999, z: 0}
   m_Children: []
   m_Father: {fileID: 682435271}
   m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: -15, y: 89.9999, z: 0}
 --- !u!1 &796518400
 GameObject:
   m_ObjectHideFlags: 0
@@ -1162,11 +1183,11 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1094789974}
   m_Father: {fileID: 1081703725}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &796518402
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1328,7 +1349,6 @@ Transform:
   m_LocalRotation: {x: 0.000000115202326, y: 0.7071067, z: 0.7071068, w: -0.00000011520231}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: -90, y: 180, z: 0}
   m_Children:
   - {fileID: 125884216}
   - {fileID: 1884541116}
@@ -1336,6 +1356,7 @@ Transform:
   - {fileID: 1251467164}
   m_Father: {fileID: 1094789974}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: -90, y: 180, z: 0}
 --- !u!1 &1036867071
 GameObject:
   m_ObjectHideFlags: 0
@@ -1361,10 +1382,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 2, z: -2.05}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 682435271}
   m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!65 &1036867073
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -1401,11 +1422,11 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 796518401}
   m_Father: {fileID: 0}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1094789973
 GameObject:
   m_ObjectHideFlags: 0
@@ -1431,11 +1452,11 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 972296619}
   m_Father: {fileID: 796518401}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1094789975
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1487,10 +1508,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: -0.5, z: 0}
   m_LocalScale: {x: 0.01, y: 1, z: 0.01}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 1596465887}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!23 &1132301672
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -1500,13 +1521,15 @@ MeshRenderer:
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
   m_SubsetIndices: 
   m_StaticBatchRoot: {fileID: 0}
-  m_UseLightProbes: 1
-  m_ReflectionProbeUsage: 1
   m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
@@ -1548,11 +1571,11 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 776879990}
   m_Father: {fileID: 1243484953}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!4 &1243484953
 Transform:
   m_ObjectHideFlags: 0
@@ -1562,11 +1585,11 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -0.032, y: 0.205, z: 0.4864}
   m_LocalScale: {x: 0.07800002, y: 0.078, z: 0.07800001}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1158366230}
   m_Father: {fileID: 1473219678}
   m_RootOrder: 11
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1243484954
 GameObject:
   m_ObjectHideFlags: 0
@@ -1670,10 +1693,10 @@ Transform:
   m_LocalRotation: {x: 0.000000115202326, y: 0.7071067, z: 0.7071068, w: -0.000000115202305}
   m_LocalPosition: {x: 0.23, y: 0.2909999, z: -0.19099991}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: -90, y: 180, z: 0}
   m_Children: []
   m_Father: {fileID: 972296619}
   m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: -90, y: 180, z: 0}
 --- !u!1 &1345401776
 GameObject:
   m_ObjectHideFlags: 0
@@ -1701,13 +1724,15 @@ MeshRenderer:
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 84471ff3383f8d34bb14cc52f05e2948, type: 2}
   m_SubsetIndices: 
   m_StaticBatchRoot: {fileID: 0}
-  m_UseLightProbes: 1
-  m_ReflectionProbeUsage: 1
   m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
@@ -1746,10 +1771,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: -0.34500003, z: 0}
   m_LocalScale: {x: 2, y: 0.2, z: 2}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 682435271}
   m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1348792347
 GameObject:
   m_ObjectHideFlags: 0
@@ -1776,10 +1801,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0.05, y: 0.05, z: 0.05}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 1596465887}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &1348792349
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -1796,13 +1821,15 @@ MeshRenderer:
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
   m_SubsetIndices: 
   m_StaticBatchRoot: {fileID: 0}
-  m_UseLightProbes: 1
-  m_ReflectionProbeUsage: 1
   m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
@@ -1838,10 +1865,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 2.5, y: 2, z: -0.05}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 682435271}
   m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!65 &1446639290
 BoxCollider:
   m_ObjectHideFlags: 0
@@ -1885,7 +1912,6 @@ MonoBehaviour:
   _dataSubfolder: InteractionEngine
   _contactEnabled: 1
   _graspingEnabled: 1
-  _untrackedTimeout: 0.5
   _depthUntilSphericalInside: 0.023
   _autoGenerateLayers: 1
   _templateLayer:
@@ -1908,7 +1934,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1855907103}
   - {fileID: 666693219}
@@ -1924,6 +1949,7 @@ Transform:
   - {fileID: 1243484953}
   m_Father: {fileID: 0}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1491160528
 GameObject:
   m_ObjectHideFlags: 0
@@ -1949,10 +1975,10 @@ Transform:
   m_LocalRotation: {x: 0.000000115202326, y: 0.7071067, z: 0.7071068, w: -0.000000115202305}
   m_LocalPosition: {x: 0.23, y: 0.29099995, z: -0.19099995}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: -90, y: 180, z: 0}
   m_Children: []
   m_Father: {fileID: 972296619}
   m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: -90, y: 180, z: 0}
 --- !u!114 &1491160530
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2112,12 +2138,12 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1348792348}
   - {fileID: 1132301671}
   m_Father: {fileID: 335842740}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1632350860
 Prefab:
   m_ObjectHideFlags: 0
@@ -2525,10 +2551,10 @@ Transform:
   m_LocalRotation: {x: 0.000000115202326, y: 0.7071067, z: 0.7071068, w: -0.00000011520231}
   m_LocalPosition: {x: 0.23, y: 0.291, z: -0.191}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: -90, y: 180, z: 0}
   m_Children: []
   m_Father: {fileID: 972296619}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: -90, y: 180, z: 0}
 --- !u!1 &1892441708
 GameObject:
   m_ObjectHideFlags: 0
@@ -2554,10 +2580,10 @@ Transform:
   m_LocalRotation: {x: -0.042339254, y: -0.74973154, z: 0.36331177, w: 0.55146587}
   m_LocalPosition: {x: 0, y: 2, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 29.8727, y: -98.4739, z: 32.3656}
   m_Children: []
   m_Father: {fileID: 682435271}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 29.8727, y: -98.4739, z: 32.3656}
 --- !u!108 &1892441710
 Light:
   m_ObjectHideFlags: 0
@@ -2565,7 +2591,7 @@ Light:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1892441708}
   m_Enabled: 1
-  serializedVersion: 6
+  serializedVersion: 7
   m_Type: 1
   m_Color: {r: 0.025951583, g: 0.45710555, b: 0.88235295, a: 1}
   m_Intensity: 0.11
@@ -2587,10 +2613,10 @@ Light:
     serializedVersion: 2
     m_Bits: 4294967295
   m_Lightmapping: 4
+  m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
   m_ShadowRadius: 0
   m_ShadowAngle: 0
-  m_AreaSize: {x: 1, y: 1}
 --- !u!1 &2021251535
 GameObject:
   m_ObjectHideFlags: 0
@@ -2618,13 +2644,15 @@ MeshRenderer:
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 84471ff3383f8d34bb14cc52f05e2948, type: 2}
   m_SubsetIndices: 
   m_StaticBatchRoot: {fileID: 0}
-  m_UseLightProbes: 1
-  m_ReflectionProbeUsage: 1
   m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
@@ -2663,10 +2691,10 @@ Transform:
   m_LocalRotation: {x: -0.17793992, y: 0, z: 0, w: 0.9840414}
   m_LocalPosition: {x: 0, y: -0.082, z: 1.333}
   m_LocalScale: {x: 4.8094406, y: 0.20000005, z: 1.4925663}
-  m_LocalEulerAnglesHint: {x: -20.4996, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 682435271}
   m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: -20.4996, y: 0, z: 0}
 --- !u!1 &2030233097
 GameObject:
   m_ObjectHideFlags: 0
@@ -2693,10 +2721,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 2, y: 0.5, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 8097723}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!23 &2030233099
 MeshRenderer:
   m_ObjectHideFlags: 0
@@ -2707,13 +2735,15 @@ MeshRenderer:
   m_Enabled: 1
   m_CastShadows: 1
   m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
   m_Materials:
   - {fileID: 2100000, guid: 82b99f8d501079d4b8821249d80c2c42, type: 2}
   m_SubsetIndices: 
   m_StaticBatchRoot: {fileID: 0}
-  m_UseLightProbes: 1
-  m_ReflectionProbeUsage: 1
   m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
   m_ScaleInLightmap: 1
   m_PreserveUVs: 1
   m_IgnoreNormalsForChartDetection: 0
@@ -2741,11 +2771,11 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -0.035, y: -0.0386, z: 0.5056}
   m_LocalScale: {x: 0.08, y: 0.08, z: 0.08}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 8097723}
   m_Father: {fileID: 1473219678}
   m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2044671632
 GameObject:
   m_ObjectHideFlags: 0
@@ -2926,10 +2956,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: -2.5, y: 2, z: -0.05}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 682435271}
   m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!65 &2047243207
 BoxCollider:
   m_ObjectHideFlags: 0

--- a/Assets/LeapMotionModules/InteractionEngine/InteractionMaterials/Default.asset
+++ b/Assets/LeapMotionModules/InteractionEngine/InteractionMaterials/Default.asset
@@ -15,7 +15,6 @@ MonoBehaviour:
   _brushDisableDistance: 0.017
   _graspingEnabled: 1
   _graspMethod: 0
-  _suspensionEnabled: 1
   _releaseDistance: 0.15
   _maxVelocity: 6
   _strengthByDistance:
@@ -55,6 +54,9 @@ MonoBehaviour:
     m_PreInfinity: 2
     m_PostInfinity: 2
     m_RotationOrder: 4
+  _suspensionEnabled: 1
+  _maxSuspensionTime: 1
+  _hideObjectOnSuspend: 1
   _warpingEnabled: 1
   _warpCurve:
     serializedVersion: 2

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/Editor/InteractionManagerEditor.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/Editor/InteractionManagerEditor.cs
@@ -13,6 +13,13 @@ namespace Leap.Unity.Interaction {
     protected override void OnEnable() {
       base.OnEnable();
 
+      specifyCustomDrawer("_dataSubfolder", disableWhenRunning);
+      specifyCustomDrawer("_contactEnabled", disableWhenRunning);
+      specifyCustomDrawer("_graspingEnabled", disableWhenRunning);
+      specifyCustomDrawer("_depthUntilSphericalInside", disableWhenRunning);
+      specifyCustomDrawer("_autoGenerateLayers", disableWhenRunning);
+      specifyCustomDrawer("_templateLayer", disableWhenRunning);
+
       specifyCustomDecorator("_leapProvider", providerDectorator);
 
       SerializedProperty autoGenerateLayerProperty = serializedObject.FindProperty("_autoGenerateLayers");
@@ -34,9 +41,15 @@ namespace Leap.Unity.Interaction {
       }
     }
 
+    private void disableWhenRunning(SerializedProperty property) {
+      EditorGUI.BeginDisabledGroup(EditorApplication.isPlaying);
+      EditorGUILayout.PropertyField(property);
+      EditorGUI.EndDisabledGroup();
+    }
+
     private void collisionLayerHelper(SerializedProperty prop) {
       InteractionManager manager = target as InteractionManager;
-      
+
       if (manager.InteractionBrushLayer == manager.InteractionLayer) {
         EditorGUILayout.HelpBox("Brush Layer cannot be the same as Interaction Layer", MessageType.Error);
         return;

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/Editor/InteractionManagerEditor.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/Editor/InteractionManagerEditor.cs
@@ -1,6 +1,4 @@
 ﻿using UnityEngine;
-using System.Linq;
-using System.Collections.Generic;
 using UnityEditor;
 
 namespace Leap.Unity.Interaction {
@@ -101,8 +99,8 @@ namespace Leap.Unity.Interaction {
 
         EditorGUILayout.LabelField("Info", EditorStyles.boldLabel);
         using (new EditorGUI.DisabledGroupScope(true)) {
-          EditorGUILayout.IntField("Registered Count", manager.RegisteredObjects.Count());
-          EditorGUILayout.IntField("Grasped Count", manager.GraspedObjects.Count());
+          EditorGUILayout.IntField("Registered Count", manager.RegisteredObjects.Count);
+          EditorGUILayout.IntField("Grasped Count", manager.GraspedObjects.Count);
         }
       }
     }

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/Editor/InteractionMaterialEditor.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/Editor/InteractionMaterialEditor.cs
@@ -38,7 +38,7 @@ namespace Leap.Unity.Interaction {
       specifyConditionalDrawing(() => graspMethod.intValue == (int)InteractionMaterial.GraspMethodEnum.Velocity,
                                 "_releaseDistance",
                                 "_maxVelocity",
-                                "_followStrength");
+                                "_strengthByDistance");
 
       specifyConditionalDrawing("_useCustomLayers", 
                                 "_interactionLayer", 

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/Editor/InteractionMaterialEditor.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/Editor/InteractionMaterialEditor.cs
@@ -17,12 +17,19 @@ namespace Leap.Unity.Interaction {
       specifyConditionalDrawing("_contactEnabled",
                                 "_brushDisableDistance");
 
+      specifyConditionalDrawing("_suspensionEnabled",
+                                "_maxSuspensionTime",
+                                "_hideObjectOnSuspend");
+
       specifyConditionalDrawing("_graspingEnabled",
                                 "_graspMethod",
-                                "_suspensionEnabled",
                                 "_releaseDistance",
                                 "_maxVelocity",
                                 "_strengthByDistance",
+                                "_throwingVelocityCurve",
+                                "_suspensionEnabled",
+                                "_maxSuspensionTime",
+                                "_hideObjectOnSuspend",
                                 "_warpingEnabled",
                                 "_warpCurve",
                                 "_graphicalReturnTime");

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
@@ -448,10 +448,10 @@ namespace Leap.Unity.Interaction {
       removeHandPointCollection(hand.Id);
     }
 
-    protected override void OnHandLostTracking(Hand oldHand, out bool allowSuspension) {
-      base.OnHandLostTracking(oldHand, out allowSuspension);
+    protected override void OnHandLostTracking(Hand oldHand, out float maxSuspensionTime) {
+      base.OnHandLostTracking(oldHand, out maxSuspensionTime);
 
-      allowSuspension = _material.SuspensionEnabled;
+      maxSuspensionTime = _material.SuspensionEnabled ? _material.MaxSuspensionTime : 0;
 
       updateState();
     }

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
@@ -360,7 +360,7 @@ namespace Leap.Unity.Interaction {
       }
     }
 
-    protected override void OnHandsHoldPhysics(List<Hand> hands) {
+    protected override void OnHandsHoldPhysics(ReadonlyList<Hand> hands) {
       base.OnHandsHoldPhysics(hands);
 
       float distanceToSolved = Vector3.Distance(_rigidbody.position, _solvedPosition);
@@ -420,7 +420,7 @@ namespace Leap.Unity.Interaction {
       _notifiedOfTeleport = false;
     }
 
-    protected override void OnHandsHoldGraphics(List<Hand> hands) {
+    protected override void OnHandsHoldGraphics(ReadonlyList<Hand> hands) {
       base.OnHandsHoldGraphics(hands);
 
       if (_graphicalAnchor != null && _material.WarpingEnabled) {
@@ -681,7 +681,7 @@ namespace Leap.Unity.Interaction {
       HandPointCollection.Return(collection);
     }
 
-    protected void getSolvedTransform(List<Hand> hands, out Vector3 newPosition, out Quaternion newRotation) {
+    protected void getSolvedTransform(ReadonlyList<Hand> hands, out Vector3 newPosition, out Quaternion newRotation) {
       KabschC.Reset(ref _kabsch);
 
       for (int h = 0; h < hands.Count; h++) {

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
@@ -639,7 +639,7 @@ namespace Leap.Unity.Interaction {
       //Renderers are visible if there are no grasping hands
       //or if there is at least one tracked grasping hand
       int trackedGraspingHandCount = GraspingHandCount - UntrackedHandCount;
-      bool shouldBeVisible = GraspingHandCount == 0 || trackedGraspingHandCount > 0;
+      bool shouldBeVisible = GraspingHandCount == 0 || trackedGraspingHandCount > 0 || !_material.HideObjectOnSuspend;
 
       if (_graphicalAnchor != null) {
         _graphicalAnchor.gameObject.SetActive(shouldBeVisible);

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/IInteractionBehaviour.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/IInteractionBehaviour.cs
@@ -122,13 +122,13 @@ namespace Leap.Unity.Interaction {
     /// Called by InteractionManager every frame that a Hand continues to grasp this object.  This callback
     /// is invoked both in FixedUpdate.
     /// </summary>
-    public abstract void NotifyHandsHoldPhysics(List<Hand> hands);
+    public abstract void NotifyHandsHoldPhysics(ReadonlyList<Hand> hands);
 
     /// <summary>
     /// Called by InteractionManager every frame that a Hand continues to grasp this object.  This callback
     /// is invoked both in LateUpdate.
     /// </summary>
-    public abstract void NotifyHandsHoldGraphics(List<Hand> hands);
+    public abstract void NotifyHandsHoldGraphics(ReadonlyList<Hand> hands);
 
     /// <summary>
     /// Called by InteractionManager when a Hand stops grasping this object.

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/IInteractionBehaviour.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/IInteractionBehaviour.cs
@@ -140,7 +140,7 @@ namespace Leap.Unity.Interaction {
     /// is not yet considered ungrasped, and OnHandRegainedTracking might be called in the future
     /// if the Hand becomes tracked again.
     /// </summary>
-    public abstract void NotifyHandLostTracking(Hand oldHand, out bool allowSuspension);
+    public abstract void NotifyHandLostTracking(Hand oldHand, out float maxSuspensionTime);
 
     /// <summary>
     /// Called by InteractionManager when a grasping Hand that had previously been untracked has

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/InteractionBehaviourBase.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/InteractionBehaviourBase.cs
@@ -252,7 +252,7 @@ namespace Leap.Unity.Interaction {
       }
     }
 
-    public override sealed void NotifyHandLostTracking(Hand oldHand, out bool allowSuspension) {
+    public override sealed void NotifyHandLostTracking(Hand oldHand, out float maxSuspensionTime) {
       Assert.AreNotEqual(_graspingIds.Count, 0, NoGraspingHandsMessage());
       Assert.IsTrue(_graspingIds.Contains(oldHand.Id), HandNotGraspingMessage(oldHand.Id));
       Assert.IsFalse(_untrackedIds.Contains(oldHand.Id), HandAlreadyUntrackedMessage(oldHand.Id));
@@ -260,7 +260,7 @@ namespace Leap.Unity.Interaction {
       _untrackedIds.Add(oldHand.Id);
 
       _baseCallGuard.Begin("OnHandLostTracking");
-      OnHandLostTracking(oldHand, out allowSuspension);
+      OnHandLostTracking(oldHand, out maxSuspensionTime);
       _baseCallGuard.AssertBaseCalled();
     }
 
@@ -402,8 +402,8 @@ namespace Leap.Unity.Interaction {
     /// is not yet considered ungrasped, and OnHandRegainedTracking might be called in the future
     /// if the Hand becomes tracked again.
     /// </summary>
-    protected virtual void OnHandLostTracking(Hand oldHand, out bool allowSuspension) {
-      allowSuspension = false;
+    protected virtual void OnHandLostTracking(Hand oldHand, out float maxSuspensionTime) {
+      maxSuspensionTime = 0;
       _baseCallGuard.NotifyBaseCalled("OnHandLostTracking");
     }
 

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/InteractionBehaviourBase.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/InteractionBehaviourBase.cs
@@ -223,13 +223,13 @@ namespace Leap.Unity.Interaction {
       }
     }
 
-    public override sealed void NotifyHandsHoldPhysics(List<Hand> hands) {
+    public override sealed void NotifyHandsHoldPhysics(ReadonlyList<Hand> hands) {
       _baseCallGuard.Begin("OnHandsHoldPhysics");
       OnHandsHoldPhysics(hands);
       _baseCallGuard.AssertBaseCalled();
     }
 
-    public override sealed void NotifyHandsHoldGraphics(List<Hand> hands) {
+    public override sealed void NotifyHandsHoldGraphics(ReadonlyList<Hand> hands) {
       _baseCallGuard.Begin("OnHandsHoldGraphics");
       OnHandsHoldGraphics(hands);
       _baseCallGuard.AssertBaseCalled();
@@ -376,14 +376,14 @@ namespace Leap.Unity.Interaction {
     /// <summary>
     /// Called every FixedUpdate that a Hand continues to grasp this object.
     /// </summary>
-    protected virtual void OnHandsHoldPhysics(List<Hand> hands) {
+    protected virtual void OnHandsHoldPhysics(ReadonlyList<Hand> hands) {
       _baseCallGuard.NotifyBaseCalled("OnHandsHoldPhysics");
     }
 
     /// <summary>
     /// Called every LateUpdate that a Hand continues to grasp this object.
     /// </summary>
-    protected virtual void OnHandsHoldGraphics(List<Hand> hands) {
+    protected virtual void OnHandsHoldGraphics(ReadonlyList<Hand> hands) {
       _baseCallGuard.NotifyBaseCalled("OnHandsHoldGraphics");
     }
 

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
@@ -153,7 +153,7 @@ namespace Leap.Unity.Interaction {
     /// <summary>
     /// Returns a collection of InteractionBehaviours that are currently registered with this manager.
     /// </summary>
-    public IEnumerable<IInteractionBehaviour> RegisteredObjects {
+    public ReadonlyList<IInteractionBehaviour> RegisteredObjects {
       get {
         return _registeredBehaviours;
       }
@@ -163,7 +163,7 @@ namespace Leap.Unity.Interaction {
     /// Returns a collection of InteractionBehaviours that are currently being grasped by
     /// at least one hand.
     /// </summary>
-    public IEnumerable<IInteractionBehaviour> GraspedObjects {
+    public ReadonlyList<IInteractionBehaviour> GraspedObjects {
       get {
         return _graspedBehaviours;
       }

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
@@ -170,28 +170,20 @@ namespace Leap.Unity.Interaction {
     }
 
     /// <summary>
-    /// Sets or Gets whether or not the Interaction Engine can modify object velocities when pushing.
+    /// Gets whether or not the Interaction Engine can modify object velocities when pushing.
     /// </summary>
     public bool ContactEnabled {
       get {
         return _contactEnabled;
       }
-      set {
-        _contactEnabled = value;
-        UpdateSceneInfo();
-      }
     }
 
     /// <summary>
-    /// Sets or Gets whether or not the Interaction plugin to modify object positions by grasping.
+    /// Gets whether or not the Interaction plugin to modify object positions by grasping.
     /// </summary>
     public bool GraspingEnabled {
       get {
         return _graspingEnabled;
-      }
-      set {
-        _graspingEnabled = value;
-        UpdateSceneInfo();
       }
     }
 

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
@@ -389,7 +389,7 @@ namespace Leap.Unity.Interaction {
         UpdateSceneInfo();
       }
 
-      if (_autoGenerateLayers) {
+      if (!Application.isPlaying && _autoGenerateLayers) {
         autoGenerateLayers();
       }
     }

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionMaterial.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionMaterial.cs
@@ -29,11 +29,7 @@ namespace Leap.Unity.Interaction {
     [SerializeField]
     protected GraspMethodEnum _graspMethod = GraspMethodEnum.Velocity;
 
-    [SerializeField]
-    protected bool _suspensionEnabled = true;
 
-    [SerializeField]
-    protected float _maxSuspensionTime = 1;
 
     [Tooltip("How far the object can get from the hand before it is released.")]
     [SerializeField]
@@ -54,6 +50,16 @@ namespace Leap.Unity.Interaction {
     protected AnimationCurve _throwingVelocityCurve = new AnimationCurve(new Keyframe(0.0f, 1.0f, 0.0f, 0.0f),
                                                                          new Keyframe(1.0f, 1.0f, 0.0f, 0.0f),
                                                                          new Keyframe(2.0f, 1.5f, 0.0f, 0.0f));
+
+    [Header("Suspension Settings")]
+    [SerializeField]
+    protected bool _suspensionEnabled = true;
+
+    [SerializeField]
+    protected float _maxSuspensionTime = 1;
+
+    [SerializeField]
+    protected bool _hideObjectOnSuspend = true;
 
     [Header("Warp Settings")]
     [SerializeField]
@@ -76,6 +82,14 @@ namespace Leap.Unity.Interaction {
 
     [SerializeField]
     protected SingleLayer _interactionNoClipLayer = 0;
+
+    protected virtual void OnValidate() {
+      _brushDisableDistance = Mathf.Max(0, _brushDisableDistance);
+      _releaseDistance = Mathf.Max(0, _releaseDistance);
+      _maxVelocity = Mathf.Max(0, _maxVelocity);
+      _maxSuspensionTime = Mathf.Max(0, _maxSuspensionTime);
+      _graphicalReturnTime = Mathf.Max(0, _graphicalReturnTime);
+    }
 
     public bool ContactEnabled {
       get {
@@ -101,18 +115,6 @@ namespace Leap.Unity.Interaction {
       }
     }
 
-    public bool SuspensionEnabled {
-      get {
-        return _suspensionEnabled;
-      }
-    }
-
-    public float MaxSuspensionTime {
-      get {
-        return _maxSuspensionTime;
-      }
-    }
-
     public float ReleaseDistance {
       get {
         return _releaseDistance;
@@ -134,6 +136,24 @@ namespace Leap.Unity.Interaction {
     public AnimationCurve ThrowingVelocityCurve {
       get {
         return _throwingVelocityCurve;
+      }
+    }
+
+    public bool SuspensionEnabled {
+      get {
+        return _suspensionEnabled;
+      }
+    }
+
+    public float MaxSuspensionTime {
+      get {
+        return _maxSuspensionTime;
+      }
+    }
+
+    public bool HideObjectOnSuspend {
+      get {
+        return _hideObjectOnSuspend;
       }
     }
 

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionMaterial.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionMaterial.cs
@@ -32,6 +32,9 @@ namespace Leap.Unity.Interaction {
     [SerializeField]
     protected bool _suspensionEnabled = true;
 
+    [SerializeField]
+    protected float _maxSuspensionTime = 1;
+
     [Tooltip("How far the object can get from the hand before it is released.")]
     [SerializeField]
     protected float _releaseDistance = 0.15f;
@@ -101,6 +104,12 @@ namespace Leap.Unity.Interaction {
     public bool SuspensionEnabled {
       get {
         return _suspensionEnabled;
+      }
+    }
+
+    public float MaxSuspensionTime {
+      get {
+        return _maxSuspensionTime;
       }
     }
 

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/Utility/ReadonlyList.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/Utility/ReadonlyList.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 
 public struct ReadonlyList<T> {
-  private List<T> _list;
+  private readonly List<T> _list;
 
   public ReadonlyList(List<T> list) {
     _list = list;

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/Utility/ReadonlyList.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/Utility/ReadonlyList.cs
@@ -1,22 +1,29 @@
 ﻿using UnityEngine;
 using System.Collections.Generic;
 
-public struct ReadonlyList<T> {
-  private readonly List<T> _list;
+namespace Leap.Unity.Interaction {
 
-  public ReadonlyList(List<T> list) {
-    _list = list;
-  }
+  public struct ReadonlyList<T> {
+    private readonly List<T> _list;
 
-  public int Count {
-    get {
-      return _list.Count;
+    public ReadonlyList(List<T> list) {
+      _list = list;
     }
-  }
 
-  public T this[int index] {
-    get {
-      return _list[index];
+    public int Count {
+      get {
+        return _list.Count;
+      }
+    }
+
+    public T this[int index] {
+      get {
+        return _list[index];
+      }
+    }
+
+    public static implicit operator ReadonlyList<T>(List<T> list) {
+      return new ReadonlyList<T>(list);
     }
   }
 }

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/Utility/ReadonlyList.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/Utility/ReadonlyList.cs
@@ -1,0 +1,22 @@
+﻿using UnityEngine;
+using System.Collections.Generic;
+
+public struct ReadonlyList<T> {
+  private List<T> _list;
+
+  public ReadonlyList(List<T> list) {
+    _list = list;
+  }
+
+  public int Count {
+    get {
+      return _list.Count;
+    }
+  }
+
+  public T this[int index] {
+    get {
+      return _list[index];
+    }
+  }
+}

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/Utility/ReadonlyList.cs.meta
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/Utility/ReadonlyList.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 68994284570146348bb696d0ac396425
+timeCreated: 1463524860
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/GraphicsSettings.asset
+++ b/ProjectSettings/GraphicsSettings.asset
@@ -3,16 +3,34 @@
 --- !u!30 &1
 GraphicsSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 5
+  serializedVersion: 6
   m_Deferred:
     m_Mode: 1
     m_Shader: {fileID: 69, guid: 0000000000000000f000000000000000, type: 0}
   m_DeferredReflections:
     m_Mode: 1
     m_Shader: {fileID: 74, guid: 0000000000000000f000000000000000, type: 0}
+  m_ScreenSpaceShadows:
+    m_Mode: 1
+    m_Shader: {fileID: 64, guid: 0000000000000000f000000000000000, type: 0}
   m_LegacyDeferred:
     m_Mode: 1
     m_Shader: {fileID: 63, guid: 0000000000000000f000000000000000, type: 0}
+  m_DepthNormals:
+    m_Mode: 1
+    m_Shader: {fileID: 62, guid: 0000000000000000f000000000000000, type: 0}
+  m_MotionVectors:
+    m_Mode: 1
+    m_Shader: {fileID: 75, guid: 0000000000000000f000000000000000, type: 0}
+  m_LightHalo:
+    m_Mode: 1
+    m_Shader: {fileID: 105, guid: 0000000000000000f000000000000000, type: 0}
+  m_LensFlare:
+    m_Mode: 1
+    m_Shader: {fileID: 102, guid: 0000000000000000f000000000000000, type: 0}
+  m_SpritesDefault:
+    m_Mode: 1
+    m_Shader: {fileID: 10753, guid: 0000000000000000f000000000000000, type: 0}
   m_AlwaysIncludedShaders:
   - {fileID: 7, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 15104, guid: 0000000000000000f000000000000000, type: 0}
@@ -21,8 +39,24 @@ GraphicsSettings:
   - {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 10782, guid: 0000000000000000f000000000000000, type: 0}
   m_PreloadedShaders: []
-  m_ShaderSettings:
-    useScreenSpaceShadows: 1
+  m_ShaderSettings_Tier1:
+    useCascadedShadowMaps: 1
+    useSinglePassStereoRendering: 0
+    standardShaderQuality: 2
+    useReflectionProbeBoxProjection: 1
+    useReflectionProbeBlending: 1
+  m_ShaderSettings_Tier2:
+    useCascadedShadowMaps: 1
+    useSinglePassStereoRendering: 0
+    standardShaderQuality: 2
+    useReflectionProbeBoxProjection: 1
+    useReflectionProbeBlending: 1
+  m_ShaderSettings_Tier3:
+    useCascadedShadowMaps: 1
+    useSinglePassStereoRendering: 0
+    standardShaderQuality: 2
+    useReflectionProbeBoxProjection: 1
+    useReflectionProbeBlending: 1
   m_BuildTargetShaderSettings: []
   m_LightmapStripping: 0
   m_FogStripping: 0

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -13,6 +13,7 @@ PlayerSettings:
   productName: LeapMotionCoreAssets
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
+  m_SplashScreenStyle: 0
   m_ShowUnitySplashScreen: 0
   m_VirtualRealitySplashScreen: {fileID: 0}
   defaultScreenWidth: 1024
@@ -24,7 +25,7 @@ PlayerSettings:
   m_ActiveColorSpace: 0
   m_MTRendering: 1
   m_MobileMTRendering: 0
-  m_Stereoscopic3D: 0
+  m_StackTraceTypes: 010000000100000001000000010000000100000001000000
   iosShowActivityIndicatorOnLoading: -1
   androidShowActivityIndicatorOnLoading: -1
   iosAppInBackgroundBehavior: 0
@@ -50,6 +51,7 @@ PlayerSettings:
   resizableWindow: 1
   useMacAppStoreValidation: 0
   gpuSkinning: 0
+  graphicsJobs: 0
   xboxPIXTextureCapture: 0
   xboxEnableAvatar: 0
   xboxEnableKinect: 0
@@ -93,9 +95,9 @@ PlayerSettings:
   bundleVersion: 1.0
   preloadedAssets: []
   metroEnableIndependentInputSource: 0
-  metroEnableLowLatencyPresentationAPI: 0
   xboxOneDisableKinectGpuReservation: 0
-  virtualRealitySupported: 1
+  singlePassStereoRendering: 0
+  protectGraphicsMemory: 0
   productGUID: 7095a052d2dfd6642a958de988530851
   AndroidBundleVersionCode: 1
   AndroidMinSdkVersion: 18
@@ -117,6 +119,8 @@ PlayerSettings:
     m_Bits: 238
   iPhoneSdkVersion: 988
   iPhoneTargetOSVersion: 22
+  tvOSSdkVersion: 0
+  tvOSTargetOSVersion: 900
   uIPrerenderedIcon: 0
   uIRequiresPersistentWiFi: 0
   uIRequiresFullScreen: 1
@@ -155,6 +159,7 @@ PlayerSettings:
   iOSLaunchScreeniPadSize: 100
   iOSLaunchScreeniPadCustomXibPath: 
   iOSDeviceRequirements: []
+  iOSURLSchemes: []
   AndroidTargetDevice: 0
   AndroidSplashScreenScale: 0
   androidSplashScreen: {fileID: 0}
@@ -196,7 +201,6 @@ PlayerSettings:
   wiiUSystemHeapSize: 128
   wiiUTVStartupScreen: {fileID: 0}
   wiiUGamePadStartupScreen: {fileID: 0}
-  wiiUDrcBufferDisabled: 0
   wiiUProfilerLibPath: 
   actionOnDotNetUnhandledException: 1
   enableInternalProfiler: 0
@@ -360,24 +364,6 @@ PlayerSettings:
   metroFTAFileTypes: []
   metroProtocolName: 
   metroCompilationOverrides: 1
-  blackberryDeviceAddress: 
-  blackberryDevicePassword: 
-  blackberryTokenPath: 
-  blackberryTokenExires: 
-  blackberryTokenAuthor: 
-  blackberryTokenAuthorId: 
-  blackberryCskPassword: 
-  blackberrySaveLogPath: 
-  blackberrySharedPermissions: 0
-  blackberryCameraPermissions: 0
-  blackberryGPSPermissions: 0
-  blackberryDeviceIDPermissions: 0
-  blackberryMicrophonePermissions: 0
-  blackberryGamepadSupport: 0
-  blackberryBuildId: 0
-  blackberryLandscapeSplashScreen: {fileID: 0}
-  blackberryPortraitSplashScreen: {fileID: 0}
-  blackberrySquareSplashScreen: {fileID: 0}
   tizenProductDescription: 
   tizenProductURL: 
   tizenSigningProfileName: 
@@ -457,12 +443,31 @@ PlayerSettings:
   WebGL::useEmbeddedResources: 0
   XboxOne::enus: 1
   stringPropertyNames:
+  - Analytics_ServiceEnabled::Analytics_ServiceEnabled
+  - Build_ServiceEnabled::Build_ServiceEnabled
+  - Collab_ServiceEnabled::Collab_ServiceEnabled
+  - ErrorHub_ServiceEnabled::ErrorHub_ServiceEnabled
+  - Game_Performance_ServiceEnabled::Game_Performance_ServiceEnabled
+  - Hub_ServiceEnabled::Hub_ServiceEnabled
+  - Purchasing_ServiceEnabled::Purchasing_ServiceEnabled
+  - UNet_ServiceEnabled::UNet_ServiceEnabled
+  - Unity_Ads_ServiceEnabled::Unity_Ads_ServiceEnabled
   - WebGL::emscriptenArgs
   - WebGL::template
   - additionalIl2CppArgs::additionalIl2CppArgs
+  Analytics_ServiceEnabled::Analytics_ServiceEnabled: False
+  Build_ServiceEnabled::Build_ServiceEnabled: False
+  Collab_ServiceEnabled::Collab_ServiceEnabled: False
+  ErrorHub_ServiceEnabled::ErrorHub_ServiceEnabled: False
+  Game_Performance_ServiceEnabled::Game_Performance_ServiceEnabled: False
+  Hub_ServiceEnabled::Hub_ServiceEnabled: False
+  Purchasing_ServiceEnabled::Purchasing_ServiceEnabled: False
+  UNet_ServiceEnabled::UNet_ServiceEnabled: False
+  Unity_Ads_ServiceEnabled::Unity_Ads_ServiceEnabled: False
   WebGL::emscriptenArgs: 
   WebGL::template: APPLICATION:Default
   additionalIl2CppArgs::additionalIl2CppArgs: 
+  vectorPropertyNames: []
   cloudProjectId: 
   projectName: 
   organizationId: 

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,2 +1,2 @@
-m_EditorVersion: 5.3.4p4
+m_EditorVersion: 5.4.0b17
 m_StandardAssetsVersion: 0


### PR DESCRIPTION
- Moved suspension time from manager to material
- Added field to allow suspended objects to not be hidden from view
- Improved the material editor
- Added extra validation to the generic editor to catch stale property names
- Removed the setters from the manager where setting things would break the scene
- Added a new struct called ReadonlyList<T> which wraps List<T> and only provides readonly access.
- Don't auto-generate layers when the game is playing
- Disable fields in the manager which should not be meddled with during runtime. 