### PR TITLE
Switch field order to make GroupName replace "Element0" in ModelGroup

### DIFF
--- a/Assets/LeapMotion/Scripts/HandPool.cs
+++ b/Assets/LeapMotion/Scripts/HandPool.cs
@@ -26,9 +26,9 @@ namespace Leap.Unity {
 
     [System.Serializable]
     public class ModelGroup {
+      public string GroupName;
       [HideInInspector]
       public HandPool _handPool;
-      public string GroupName;
 
       public IHandModel LeftModel;
       [HideInInspector]

--- a/Assets/LeapMotion/Scripts/HandPool.cs
+++ b/Assets/LeapMotion/Scripts/HandPool.cs
@@ -40,7 +40,7 @@ namespace Leap.Unity {
       public List<IHandModel> modelList;
       [HideInInspector]
       public List<IHandModel> modelsCheckedOut;
-      public bool IsEnabled;
+      public bool IsEnabled = true;
       public bool CanDuplicate;
 
       public IHandModel TryGetModel(Chirality chirality, ModelType modelType) {


### PR DESCRIPTION
- [x] Verify that ModelPool elements now show GroupName in Inspector