### PR TITLE
Fix for kinematic warping

### DIFF
--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
@@ -178,7 +178,7 @@ namespace Leap.Unity.Interaction {
       base.OnPostSolve();
 
       if (IsBeingGrasped) {
-        if (Vector3.Distance(_solvedPosition, _rigidbody.position) > _material.ReleaseDistance * _manager.SimulationScale) {
+        if (Vector3.Distance(_solvedPosition, _warper.RigidbodyPosition) > _material.ReleaseDistance * _manager.SimulationScale) {
           _manager.ReleaseObject(this);
         }
       } else {
@@ -560,8 +560,8 @@ namespace Leap.Unity.Interaction {
         interactionTransform.position = _solvedPosition.ToCVector();
         interactionTransform.rotation = _solvedRotation.ToCQuaternion();
       } else {
-        interactionTransform.position = _rigidbody.position.ToCVector();
-        interactionTransform.rotation = _rigidbody.rotation.ToCQuaternion();
+        interactionTransform.position = _warper.RigidbodyPosition.ToCVector();
+        interactionTransform.rotation = _warper.RigidbodyRotation.ToCQuaternion();
       }
 
       interactionTransform.wallTime = Time.fixedTime;
@@ -643,8 +643,8 @@ namespace Leap.Unity.Interaction {
             Vector3 bonePos = bone.NextJoint.ToVector3();
 
             //Do the solve such that the objects positions are matched to the new bone positions
-            LEAP_VECTOR point1 = (objectPos - _rigidbody.position).ToCVector();
-            LEAP_VECTOR point2 = (bonePos - _rigidbody.position).ToCVector();
+            LEAP_VECTOR point1 = (objectPos - _warper.RigidbodyPosition).ToCVector();
+            LEAP_VECTOR point2 = (bonePos - _warper.RigidbodyPosition).ToCVector();
 
             KabschC.AddPoint(ref _kabsch, ref point1, ref point2, 1.0f);
           }
@@ -662,8 +662,8 @@ namespace Leap.Unity.Interaction {
       Quaternion solvedRotation = leapRotation.ToQuaternion();
 
       //Calculate new transform using delta
-      newPosition = _rigidbody.position + solvedTranslation;
-      newRotation = solvedRotation * _rigidbody.rotation; ;
+      newPosition = _warper.RigidbodyPosition + solvedTranslation;
+      newRotation = solvedRotation * _warper.RigidbodyRotation;
     }
 
     protected class HandPointCollection {

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
@@ -325,7 +325,7 @@ namespace Leap.Unity.Interaction {
 
       updateState();
 
-      var newCollection = HandPointCollection.Create(_rigidbody);
+      var newCollection = HandPointCollection.Create(_warper);
       _handIdToPoints[hand.Id] = newCollection;
 
       newCollection.UpdateTransform();
@@ -671,7 +671,7 @@ namespace Leap.Unity.Interaction {
       //With a pool, likely there will only ever be 2 instances!
       private static Stack<HandPointCollection> _handPointCollectionPool = new Stack<HandPointCollection>();
 
-      private Rigidbody _rigidbody;
+      private RigidbodyWarper _warper;
       private Vector3[] _localPositions;
 
       private Matrix4x4 _transformMatrix;
@@ -679,7 +679,7 @@ namespace Leap.Unity.Interaction {
       private bool _hasInverse = false;
       private Matrix4x4 _inverseTransformMatrix;
 
-      public static HandPointCollection Create(Rigidbody rigidbody) {
+      public static HandPointCollection Create(RigidbodyWarper warper) {
         HandPointCollection collection;
         if (_handPointCollectionPool.Count != 0) {
           collection = _handPointCollectionPool.Pop();
@@ -687,7 +687,7 @@ namespace Leap.Unity.Interaction {
           collection = new HandPointCollection();
         }
 
-        collection.init(rigidbody);
+        collection.init(warper);
         return collection;
       }
 
@@ -700,18 +700,18 @@ namespace Leap.Unity.Interaction {
         _localPositions = new Vector3[NUM_FINGERS * NUM_BONES];
       }
 
-      private void init(Rigidbody rigidbody) {
-        _rigidbody = rigidbody;
+      private void init(RigidbodyWarper warper) {
+        _warper = warper;
       }
 
       private void reset() {
-        _rigidbody = null;
+        _warper = null;
         _hasInverse = false;
       }
 
       public void UpdateTransform() {
-        Vector3 interactionPosition = _rigidbody.position;
-        Quaternion interactionRotation = _rigidbody.rotation;
+        Vector3 interactionPosition = _warper.RigidbodyPosition;
+        Quaternion interactionRotation = _warper.RigidbodyRotation;
 
         _hasInverse = false;
         _transformMatrix = Matrix4x4.TRS(interactionPosition, interactionRotation, Vector3.one);

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
@@ -375,6 +375,11 @@ namespace Leap.Unity.Interaction {
             float deltaAngle;
             deltaRot.ToAngleAxis(out deltaAngle, out deltaAxis);
 
+            if (float.IsInfinity(deltaAxis.x)) {
+              deltaAxis = Vector3.zero;
+              deltaAngle = 0;
+            }
+
             Vector3 targetVelocity = deltaPos / Time.fixedDeltaTime;
             Vector3 targetAngularVelocity = deltaAxis * deltaAngle * Mathf.Deg2Rad / Time.fixedDeltaTime;
 
@@ -385,11 +390,6 @@ namespace Leap.Unity.Interaction {
 
               targetVelocity *= targetPercent;
               targetAngularVelocity *= targetPercent;
-            }
-
-            if (float.IsInfinity(targetAngularVelocity.x)) {
-              targetVelocity = Vector3.zero;
-              targetAngularVelocity = Vector3.zero;
             }
 
             float followStrength = _material.StrengthByDistance.Evaluate(distanceToSolved / _manager.SimulationScale);

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
@@ -389,6 +389,11 @@ namespace Leap.Unity.Interaction {
               targetAngularVelocity *= targetPercent;
             }
 
+            if (float.IsInfinity(targetAngularVelocity.x)) {
+              targetVelocity = Vector3.zero;
+              targetAngularVelocity = Vector3.zero;
+            }
+
             float followStrength = _material.StrengthByDistance.Evaluate(distanceToSolved / _manager.SimulationScale);
             _rigidbody.velocity = Vector3.Lerp(_rigidbody.velocity, targetVelocity, followStrength);
             _rigidbody.angularVelocity = Vector3.Lerp(_rigidbody.angularVelocity, targetAngularVelocity, followStrength);

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
@@ -328,8 +328,6 @@ namespace Leap.Unity.Interaction {
       var newCollection = HandPointCollection.Create(_warper);
       _handIdToPoints[hand.Id] = newCollection;
 
-      newCollection.UpdateTransform();
-
       for (int f = 0; f < NUM_FINGERS; f++) {
         Finger finger = hand.Fingers[f];
         Finger.FingerType fingerType = finger.Type;
@@ -674,8 +672,7 @@ namespace Leap.Unity.Interaction {
       //Without a pool, you might end up with 2 instances per object
       //With a pool, likely there will only ever be 2 instances!
       private static Stack<HandPointCollection> _handPointCollectionPool = new Stack<HandPointCollection>();
-
-      private RigidbodyWarper _warper;
+      
       private Vector3[] _localPositions;
       private Matrix4x4 _inverseTransformMatrix;
 
@@ -692,7 +689,6 @@ namespace Leap.Unity.Interaction {
       }
 
       public static void Return(HandPointCollection handPointCollection) {
-        handPointCollection.reset();
         _handPointCollectionPool.Push(handPointCollection);
       }
 
@@ -701,16 +697,8 @@ namespace Leap.Unity.Interaction {
       }
 
       private void init(RigidbodyWarper warper) {
-        _warper = warper;
-      }
-
-      private void reset() {
-        _warper = null;
-      }
-
-      public void UpdateTransform() {
-        Vector3 interactionPosition = _warper.RigidbodyPosition;
-        Quaternion interactionRotation = _warper.RigidbodyRotation;
+        Vector3 interactionPosition = warper.RigidbodyPosition;
+        Quaternion interactionRotation = warper.RigidbodyRotation;
         _inverseTransformMatrix = Matrix4x4.TRS(interactionPosition, interactionRotation, Vector3.one).inverse;
       }
 

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
@@ -497,6 +497,10 @@ namespace Leap.Unity.Interaction {
     }
 
     protected virtual void FixedUpdate() {
+      if (OnPhysicalUpdate != null) {
+        OnPhysicalUpdate();
+      }
+
       if (!_pauseSimulation) {
         simulateFrame(_leapProvider.CurrentFixedFrame);
       }
@@ -507,10 +511,6 @@ namespace Leap.Unity.Interaction {
 
       if (_showDebugOutput) {
         InteractionC.GetDebugStrings(ref _scene, _debugOutput);
-      }
-
-      if (OnPhysicalUpdate != null) {
-        OnPhysicalUpdate();
       }
     }
 

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
@@ -118,7 +118,8 @@ namespace Leap.Unity.Interaction {
 
     #region PUBLIC METHODS
     public Action OnGraphicalUpdate;
-    public Action OnPhysicalUpdate;
+    public Action OnPrePhysicalUpdate;
+    public Action OnPostPhysicalUpdate;
 
     /// <summary>
     /// Gets the current debug flags for this manager.
@@ -497,12 +498,16 @@ namespace Leap.Unity.Interaction {
     }
 
     protected virtual void FixedUpdate() {
-      if (OnPhysicalUpdate != null) {
-        OnPhysicalUpdate();
+      if (OnPrePhysicalUpdate != null) {
+        OnPrePhysicalUpdate();
       }
 
       if (!_pauseSimulation) {
         simulateFrame(_leapProvider.CurrentFixedFrame);
+      }
+
+      if (OnPostPhysicalUpdate != null) {
+        OnPostPhysicalUpdate();
       }
 
       if (_showDebugLines) {

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/Utility/RigidbodyWarper.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/Utility/RigidbodyWarper.cs
@@ -113,17 +113,19 @@ namespace Leap.Unity.Interaction {
       _mostRecentCallback = CallbackState.PhysicalNeedsUpdate;
 
       _manager.OnGraphicalUpdate += onGraphicalUpdate;
-      _manager.OnPhysicalUpdate += onPhysicalUpdate;
+      _manager.OnPrePhysicalUpdate += onPrePhysicalUpdate;
+      _manager.OnPostPhysicalUpdate += onPostPhysicalUpdate;
       _subscribed = true;
     }
 
     protected void unsubscribe() {
       _manager.OnGraphicalUpdate -= onGraphicalUpdate;
-      _manager.OnPhysicalUpdate -= onPhysicalUpdate;
+      _manager.OnPrePhysicalUpdate -= onPrePhysicalUpdate;
+      _manager.OnPostPhysicalUpdate -= onPostPhysicalUpdate;
       _subscribed = false;
     }
 
-    protected virtual void onPhysicalUpdate() {
+    protected virtual void onPrePhysicalUpdate() {
       updateRigidbodyValues();
 
       if (_mostRecentCallback == CallbackState.Graphical) {
@@ -131,6 +133,10 @@ namespace Leap.Unity.Interaction {
         _transform.rotation = _savedRotation;
       }
 
+      _mostRecentCallback = CallbackState.Physical;
+    }
+
+    protected virtual void onPostPhysicalUpdate() {
       _mostRecentCallback = CallbackState.PhysicalNeedsUpdate;
     }
 


### PR DESCRIPTION
Kinematic warping was broken because of some issues in execution order.  Added both pre and post physical solve callbacks to the manager to make it easier to get correct execution order.  Also made sure that InteractionBehaviour was using the transform given by the warper instead of the rigidbody in all locations.  Also improved and simplified Kabsch logic.

@ajohnston33 