### PR TITLE
Hierarchy Traversal UI Module Fix

### DIFF
--- a/Assets/LeapMotionModules/UIInput/Prefabs/LeapEventSystem.prefab
+++ b/Assets/LeapMotionModules/UIInput/Prefabs/LeapEventSystem.prefab
@@ -26,10 +26,10 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &11418986
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -130,7 +130,7 @@ MonoBehaviour:
     m_RotationOrder: 0
   PinchingThreshold: 30
   perFingerPointer: 0
-  EnvironmentPointer: 1
+  EnvironmentPointer: 0
   environmentPinch:
     m_PersistentCalls:
       m_Calls: []

--- a/Assets/LeapMotionModules/UIInput/Scripts/LeapInputModule.cs
+++ b/Assets/LeapMotionModules/UIInput/Scripts/LeapInputModule.cs
@@ -452,11 +452,22 @@ namespace Leap.Unity.InputModule {
 
                   if (PointEvents[whichPointer].pointerDrag) {
                     IDragHandler Dragger = PointEvents[whichPointer].pointerDrag.GetComponent<IDragHandler>();
-                    if (Dragger != null && !(Dragger is EventTrigger)) { //Hack: EventSystems intercepting Drag Events causing funkiness
-                      ExecuteEvents.Execute(PointEvents[whichPointer].pointerDrag, PointEvents[whichPointer], ExecuteEvents.beginDragHandler);
-                      PointEvents[whichPointer].dragging = true;
-                      currentGoing[whichPointer] = PointEvents[whichPointer].pointerDrag;
-                      DragBeginPosition[whichPointer] = PointEvents[whichPointer].position;
+                    if (Dragger != null) {
+                      if (Dragger is EventTrigger) { //Hack: EventSystems intercepting Drag Events causing funkiness
+                         PointEvents[whichPointer].pointerDrag = ExecuteEvents.GetEventHandler<IDragHandler>(PointEvents[whichPointer].pointerDrag.transform.parent.gameObject);
+                         Dragger = PointEvents[whichPointer].pointerDrag.GetComponent<IDragHandler>();
+                         if ((Dragger != null)&&!(Dragger is EventTrigger)) {
+                           ExecuteEvents.Execute(PointEvents[whichPointer].pointerDrag, PointEvents[whichPointer], ExecuteEvents.beginDragHandler);
+                           PointEvents[whichPointer].dragging = true;
+                           currentGoing[whichPointer] = PointEvents[whichPointer].pointerDrag;
+                           DragBeginPosition[whichPointer] = PointEvents[whichPointer].position;
+                         }
+                      } else {
+                        ExecuteEvents.Execute(PointEvents[whichPointer].pointerDrag, PointEvents[whichPointer], ExecuteEvents.beginDragHandler);
+                        PointEvents[whichPointer].dragging = true;
+                        currentGoing[whichPointer] = PointEvents[whichPointer].pointerDrag;
+                        DragBeginPosition[whichPointer] = PointEvents[whichPointer].position;
+                      }
                     }
                   }
                 }
@@ -483,7 +494,9 @@ namespace Leap.Unity.InputModule {
 
             if (currentGoing[whichPointer]) {
               ExecuteEvents.Execute(currentGoing[whichPointer], PointEvents[whichPointer], ExecuteEvents.endDragHandler);
-              ExecuteEvents.Execute(currentGoing[whichPointer], PointEvents[whichPointer], ExecuteEvents.pointerUpHandler);
+              if ((currentGo[whichPointer]) && (currentGoing[whichPointer] == currentGo[whichPointer])) {
+                ExecuteEvents.Execute(currentGoing[whichPointer], PointEvents[whichPointer], ExecuteEvents.pointerUpHandler);
+              }
               Debug.Log(currentGoing[whichPointer].name);
               if (currentOverGo[whichPointer] != null) {
                 ExecuteEvents.ExecuteHierarchy(currentOverGo[whichPointer], PointEvents[whichPointer], ExecuteEvents.dropHandler);


### PR DESCRIPTION
This should unbreak compatibility with default Scroll Views and allow users to press infinitely tall compressible buttons with ease (where even the text and image on the button have "RaycastTarget" enabled)...

This is still largely untested...