### PR TITLE
change interpolation delay to 20 for cardboard

### DIFF
--- a/Assets/LeapMotionModules/Android/Cardboard/Scenes/Leap_Hands_Demo_HMD.unity
+++ b/Assets/LeapMotionModules/Android/Cardboard/Scenes/Leap_Hands_Demo_HMD.unity
@@ -1698,7 +1698,7 @@ MonoBehaviour:
   _overrideDeviceType: 1
   _overrideDeviceTypeWith: 1
   _useInterpolation: 1
-  _interpolationDelay: 45
+  _interpolationDelay: 20
 --- !u!1001 &593869531
 Prefab:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
On cardboard we don't need a high delay because the tracking FPS is at the full 115.
According to Matt, 20 is the optimal value.