### PR TITLE
Turn on CanDuplicate for cardboard scene

### DIFF
--- a/Assets/LeapMotionModules/Android/Cardboard/Scenes/Leap_Hands_Demo_HMD.unity
+++ b/Assets/LeapMotionModules/Android/Cardboard/Scenes/Leap_Hands_Demo_HMD.unity
@@ -1822,7 +1822,7 @@ MonoBehaviour:
     modelList: []
     modelsCheckedOut: []
     IsEnabled: 1
-    CanDuplicate: 0
+    CanDuplicate: 1
   - GroupName: Physics_Hands
     _handPool: {fileID: 0}
     LeftModel: {fileID: 170358230}
@@ -1832,7 +1832,7 @@ MonoBehaviour:
     modelList: []
     modelsCheckedOut: []
     IsEnabled: 1
-    CanDuplicate: 0
+    CanDuplicate: 1
 --- !u!114 &612653287
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Turn on CanDuplicate for the OrionHMD cardboard scene for now to fix the reinitialization issue.