### PR TITLE
Useability changes and IE toggling (settable ContactEnabled, Brushing…

### DIFF
--- a/Assets/LeapMotionModules/InteractionEngine/Examples/InteractionEngineDemo.meta
+++ b/Assets/LeapMotionModules/InteractionEngine/Examples/InteractionEngineDemo.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: dc6beaade15b4bf48b38d24d5f3a88cd
+folderAsset: yes
+timeCreated: 1467242043
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapMotionModules/InteractionEngine/Examples/Scripts.meta
+++ b/Assets/LeapMotionModules/InteractionEngine/Examples/Scripts.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 89cb3967ee3d30342bbe8ce19fdc2d44
+folderAsset: yes
+timeCreated: 1467218492
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/Editor/InteractionManagerEditor.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/Editor/InteractionManagerEditor.cs
@@ -15,7 +15,6 @@ namespace Leap.Unity.Interaction {
       base.OnEnable();
 
       specifyCustomDrawer("_ldatPath", disableWhenRunning);
-      specifyCustomDrawer("_contactEnabled", disableWhenRunning);
       specifyCustomDrawer("_autoGenerateLayers", disableWhenRunning);
       specifyCustomDrawer("_templateLayer", disableWhenRunning);
 

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 using UnityEngine.Assertions;
 using Leap.Unity.Interaction.CApi;
 using LeapInternal;
+using UnityEditor;
 
 namespace Leap.Unity.Interaction {
 
@@ -121,6 +122,9 @@ namespace Leap.Unity.Interaction {
     public InteractionMaterial material {
       get {
         return _material;
+      }
+      set {
+        _material = value;
       }
     }
 
@@ -437,6 +441,23 @@ namespace Leap.Unity.Interaction {
     public override void NotifyBrushDislocated() {
       _dislocatedBrushCounter = 0;
       updateContactMode();
+    }
+
+    #endregion
+
+    #region UNITY EVENTS
+
+    protected override void Reset() {
+      base.Reset();
+      if (_material == null) {
+        if (_manager == null) {
+          return;
+        }
+        else {
+          Debug.LogWarning("No InteractionMaterial specified; will use the default InteractionMaterial as specified by the InteractionManager.");
+          _material = _manager.defaultInteractionMaterial;
+        }
+      }
     }
 
     #endregion

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/InteractionBehaviourBase.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/InteractionBehaviourBase.cs
@@ -450,6 +450,11 @@ namespace Leap.Unity.Interaction {
     #endregion
 
     #region UNITY MESSAGES
+
+    protected virtual void Awake() {
+      this.Reset();
+    }
+
     protected virtual void Reset() {
       if (_manager == null) {
         //If manager is null, first check our parents for one, then search the whole scene

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
@@ -42,6 +42,9 @@ namespace Leap.Unity.Interaction {
     protected string _ldatPath = "InteractionEngine/IE.ldat";
 
     [Header("Interaction Settings")]
+    [Tooltip("The default Interaction Material to use for Interaction Behaviours if none is specified, or for Interaction Behaviours created via scripting.")]
+    public InteractionMaterial defaultInteractionMaterial;
+
     [Tooltip("Allow the Interaction Engine to modify object velocities when pushing.")]
     [SerializeField]
     protected bool _contactEnabled = true;
@@ -49,6 +52,10 @@ namespace Leap.Unity.Interaction {
     [Tooltip("Allow the Interaction plugin to modify object positions by grasping.")]
     [SerializeField]
     protected bool _graspingEnabled = true;
+
+    [Tooltip("Allow the Interaction plugin to modify object velocities when grazing object edges.")]
+    [SerializeField]
+    protected bool _brushingEnabled = true;
 
     [Tooltip("Depth before collision response becomes as if holding a sphere.")]
     [SerializeField]
@@ -201,20 +208,45 @@ namespace Leap.Unity.Interaction {
     }
 
     /// <summary>
-    /// Gets whether or not the Interaction Engine can modify object velocities when pushing.
+    /// Gets or sets whether or not the Interaction Engine can modify object velocities when pushing.
     /// </summary>
     public bool ContactEnabled {
       get {
         return _contactEnabled;
       }
+      set {
+        if (_contactEnabled != value) {
+          _contactEnabled = value;
+          UpdateSceneInfo();
+        }
+      }
     }
 
     /// <summary>
-    /// Gets whether or not the Interaction plugin to modify object positions by grasping.
+    /// Gets or sets whether or not the Interaction Engine can modify object positions by grasping.
     /// </summary>
     public bool GraspingEnabled {
       get {
         return _graspingEnabled;
+      }
+      set {
+        if (_graspingEnabled != value) {
+          _graspingEnabled = value;
+          UpdateSceneInfo();
+        }
+      }
+    }
+
+    /// <summary>
+    /// Gets or sets whether or not the Interaction Engine should allow brush hands when grazing the edges of objects.
+    /// </summary>
+    public bool BrushingEnabled {
+      get {
+        return _brushingEnabled;
+      }
+      set {
+        _brushingEnabled = value;
+        Physics.IgnoreLayerCollision(_brushHandLayer, _interactionLayer, !_brushingEnabled); // Don't ignore brush layer collision if contact is enabled
       }
     }
 
@@ -606,8 +638,8 @@ namespace Leap.Unity.Interaction {
       }
 
       //After copy and set we specify the interactions between the brush and interaction objects
-      if (_contactEnabled) {
-        Physics.IgnoreLayerCollision(_brushLayer, _interactionLayer, false);
+      if (_brushingEnabled) {
+        Physics.IgnoreLayerCollision(_brushHandLayer, _interactionLayer, false);
       }
     }
 

--- a/ProjectSettings/DynamicsManager.asset
+++ b/ProjectSettings/DynamicsManager.asset
@@ -4,7 +4,7 @@
 PhysicsManager:
   m_ObjectHideFlags: 0
   serializedVersion: 2
-  m_Gravity: {x: 0, y: -9.81, z: 0}
+  m_Gravity: {x: 0, y: -4.905, z: 0}
   m_DefaultMaterial: {fileID: 0}
   m_BounceThreshold: 0.05
   m_SleepThreshold: 0.005
@@ -12,4 +12,4 @@ PhysicsManager:
   m_SolverIterationCount: 20
   m_QueriesHitTriggers: 1
   m_EnableAdaptiveForce: 0
-  m_LayerCollisionMatrix: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  m_LayerCollisionMatrix: fffefffffffefffffffefffffffffffffffefffffffeffffffffffffffffffffc8feffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -13,8 +13,8 @@ TagManager:
   - UI
   - 
   - 
-  - 
-  - 
+  - ButtonStopper
+  - Button
   - 
   - 
   - 


### PR DESCRIPTION
…Enabled, GraspingEnabled)

Setting Contact, Brush, or GraspingEnabled in Interaction Manager will appropriately call UpdateSceneInfo(), along with some brush logic changes to decouple it from Soft Contact, allows all three features to be toggled independently and dynamically at runtime.

The changes related to InteractionBehaviour allow smart defaults to happen if you do an AddComponent<InteractionBehaviour>() at runtime, relying on a public defaultInteractionMaterial field in InteractionManager to set a default InteractionMaterial and searching the scene for an appropriate InteractionManager for the behaviour as well. Otherwise you get an error, have to set the material and manager fields, call Reset(), and then re-enable the object (four/five lines per instantiation goes down to one with this change) in order to add an InteractionBehaviour component at runtime (ew!)