### PR TITLE
Useability and toggling for IE contact/grasping and dynamically spawn…

### DIFF
--- a/Assets/LeapMotionModules/InteractionEngine/Examples/Scenes/ExampleScene.unity
+++ b/Assets/LeapMotionModules/InteractionEngine/Examples/Scenes/ExampleScene.unity
@@ -132,6 +132,11 @@ Prefab:
       propertyPath: _debugTextView
       value: 
       objectReference: {fileID: 2071161178}
+    - target: {fileID: 11435054, guid: a2e4c6a003fcd1a43b91889103145982, type: 2}
+      propertyPath: _defaultInteractionMaterial
+      value: 
+      objectReference: {fileID: 11400000, guid: 2b36778cd97232c459902ea9b77fd3ec,
+        type: 2}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: a2e4c6a003fcd1a43b91889103145982, type: 2}
   m_IsPrefabParent: 0

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
@@ -469,7 +469,7 @@ namespace Leap.Unity.Interaction {
         }
         else {
           Debug.LogWarning("No InteractionMaterial specified; will use the default InteractionMaterial as specified by the InteractionManager.");
-          _material = _manager.defaultInteractionMaterial;
+          _material = _manager.DefaultInteractionMaterial;
         }
       }
     }

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
@@ -452,6 +452,28 @@ namespace Leap.Unity.Interaction {
 
     #region UNITY CALLBACKS
 
+    protected override void Awake() {
+      base.Awake();
+      CheckMaterial();
+    }
+
+    protected override void Reset() {
+      base.Reset();
+      CheckMaterial();
+    }
+
+    private void CheckMaterial() {
+      if (_material == null) {
+        if (_manager == null) {
+          return;
+        }
+        else {
+          Debug.LogWarning("No InteractionMaterial specified; will use the default InteractionMaterial as specified by the InteractionManager.");
+          _material = _manager.defaultInteractionMaterial;
+        }
+      }
+    }
+
 #if UNITY_EDITOR
     private void OnCollisionEnter(Collision collision) {
       GameObject otherObj = collision.collider.gameObject;

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/InteractionBehaviourBase.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/InteractionBehaviourBase.cs
@@ -450,7 +450,16 @@ namespace Leap.Unity.Interaction {
     #endregion
 
     #region UNITY MESSAGES
+
+    protected virtual void Awake() {
+      FindInteractionManager();
+    }
+
     protected virtual void Reset() {
+      FindInteractionManager();
+    }
+
+    private void FindInteractionManager() {
       if (_manager == null) {
         //If manager is null, first check our parents for one, then search the whole scene
         _manager = GetComponentInParent<InteractionManager>();

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
@@ -42,6 +42,10 @@ namespace Leap.Unity.Interaction {
     protected string _ldatPath = "InteractionEngine/IE.ldat";
 
     [Header("Interaction Settings")]
+    [Tooltip("The default Interaction Material to use for Interaction Behaviours if none is specified, or for Interaction Behaviours created via scripting.")]
+    public InteractionMaterial defaultInteractionMaterial;
+
+    [Header("Interaction Settings")]
     [Tooltip("Allow the Interaction Engine to modify object velocities when pushing.")]
     [SerializeField]
     protected bool _contactEnabled = true;
@@ -201,20 +205,33 @@ namespace Leap.Unity.Interaction {
     }
 
     /// <summary>
-    /// Gets whether or not the Interaction Engine can modify object velocities when pushing.
+    /// Gets or sets whether or not the Interaction Engine can modify object velocities when pushing.
     /// </summary>
     public bool ContactEnabled {
       get {
         return _contactEnabled;
       }
+      set {
+        if (_contactEnabled != value) {
+          _contactEnabled = value;
+          UpdateSceneInfo();
+          Physics.IgnoreLayerCollision(_brushLayer, _interactionLayer, !_contactEnabled);
+        }
+      }
     }
 
     /// <summary>
-    /// Gets whether or not the Interaction plugin to modify object positions by grasping.
+    /// Gets or sets whether or not the Interaction Engine can modify object positions by grasping.
     /// </summary>
     public bool GraspingEnabled {
       get {
         return _graspingEnabled;
+      }
+      set {
+        if (_graspingEnabled != value) {
+          _graspingEnabled = value;
+          UpdateSceneInfo();
+        }
       }
     }
 

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
@@ -43,6 +43,7 @@ namespace Leap.Unity.Interaction {
 
     [Header("Interaction Settings")]
     [Tooltip("The default Interaction Material to use for Interaction Behaviours if none is specified, or for Interaction Behaviours created via scripting.")]
+    [SerializeField]
     protected InteractionMaterial _defaultInteractionMaterial;
 
     [Tooltip("Allow the Interaction Engine to modify object velocities when pushing.")]

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
@@ -43,9 +43,8 @@ namespace Leap.Unity.Interaction {
 
     [Header("Interaction Settings")]
     [Tooltip("The default Interaction Material to use for Interaction Behaviours if none is specified, or for Interaction Behaviours created via scripting.")]
-    public InteractionMaterial defaultInteractionMaterial;
+    protected InteractionMaterial _defaultInteractionMaterial;
 
-    [Header("Interaction Settings")]
     [Tooltip("Allow the Interaction Engine to modify object velocities when pushing.")]
     [SerializeField]
     protected bool _contactEnabled = true;
@@ -201,6 +200,18 @@ namespace Leap.Unity.Interaction {
     public ReadonlyList<IInteractionBehaviour> GraspedObjects {
       get {
         return _graspedBehaviours;
+      }
+    }
+
+    /// <summary>
+    /// Gets or sets the default InteractionMaterial used when InteractionBehaviours are spawned without a material explicitly assigned.
+    /// </summary>
+    public InteractionMaterial DefaultInteractionMaterial {
+      get {
+        return _defaultInteractionMaterial;
+      }
+      set {
+        _defaultInteractionMaterial = value;
       }
     }
 

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs.meta
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs.meta
@@ -1,10 +1,14 @@
 fileFormatVersion: 2
 guid: 99abcac5e6e214041876299e0504c871
-timeCreated: 1464315124
-licenseType: Pro
+timeCreated: 1469053206
+licenseType: Free
 MonoImporter:
   serializedVersion: 2
-  defaultReferences: []
+  defaultReferences:
+  - _leapProvider: {instanceID: 0}
+  - _defaultInteractionMaterial: {fileID: 11400000, guid: 2b36778cd97232c459902ea9b77fd3ec,
+      type: 2}
+  - _debugTextView: {instanceID: 0}
   executionOrder: 0
   icon: {instanceID: 0}
   userData: 


### PR DESCRIPTION
…ing InteractionBehaviours.

Toggling: Just added appropriate setters for ContactEnabled and GraspingEnabled.

Spawning InteractionBehaviours: Spawning InteractionBehaviours onto objects from a script is not fun because you get lots of errors about missing an attached InteractionManager and InteractionMaterial even if you set them right after creating the behaviour. This solves that problem by adding a default InteractionMaterial setting to the InteractionManager and also has InteractionBehaviours try to find a manager on-load if it doesn't have one.