### PR TITLE
Fix interaction tests

### DIFF
--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/ControllerImplementations/ThrowingControllerSlidingWindow.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/ControllerImplementations/ThrowingControllerSlidingWindow.cs
@@ -56,6 +56,12 @@ namespace Leap.Unity.Interaction {
     }
 
     public override void OnThrow(Hand throwingHand) {
+      if (_velocityQueue.Count < 2) {
+        _obj.rigidbody.velocity = Vector3.zero;
+        _obj.rigidbody.angularVelocity = Vector3.zero;
+        return;
+      }
+
       float windowEnd = Time.fixedTime - _windowDelay;
       float windowStart = windowEnd - _windowLength;
 

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
@@ -508,18 +508,22 @@ namespace Leap.Unity.Interaction {
 
     protected void updateLayer() {
       int layer;
-      if (_controllers.LayerController != null) {
-        if (_contactMode != ContactMode.NORMAL) {
-          layer = _controllers.LayerController.InteractionNoClipLayer;
+      if (IsRegisteredWithManager) {
+        if (_controllers.LayerController != null) {
+          if (_contactMode != ContactMode.NORMAL) {
+            layer = _controllers.LayerController.InteractionNoClipLayer;
+          } else {
+            layer = _controllers.LayerController.InteractionLayer;
+          }
         } else {
-          layer = _controllers.LayerController.InteractionLayer;
+          if (_contactMode != ContactMode.NORMAL) {
+            layer = _manager.InteractionNoClipLayer;
+          } else {
+            layer = _manager.InteractionLayer;
+          }
         }
       } else {
-        if (_contactMode != ContactMode.NORMAL) {
-          layer = _manager.InteractionNoClipLayer;
-        } else {
-          layer = _manager.InteractionLayer;
-        }
+        layer = LayerMask.NameToLayer("Default");
       }
 
       if (gameObject.layer != layer) {

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/InteractionBrushBone.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/InteractionBrushBone.cs
@@ -1,6 +1,8 @@
 ﻿using UnityEngine;
 using Leap.Unity.Interaction;
+#if UNITY_EDITOR
 using UnityEditor;
+#endif
 
 namespace Leap.Unity.Interaction {
   public class InteractionBrushBone : MonoBehaviour {

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
@@ -828,7 +828,10 @@ namespace Leap.Unity.Interaction {
                     try {
                       interactionHand.GraspObject(interactionBehaviour, isUserGrasp: false);
 
-                      dispatchOnHandsHolding(hands, interactionBehaviour, isPhysics: true);
+                      //the grasp callback might have caused the object to become ungrasped
+                      if (interactionHand.graspedObject == interactionBehaviour) {
+                        dispatchOnHandsHolding(hands, interactionBehaviour, isPhysics: true);
+                      }
                     } catch (Exception e) {
                       _activityManager.NotifyMisbehaving(interactionBehaviour);
                       Debug.LogException(e);

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
@@ -795,6 +795,10 @@ namespace Leap.Unity.Interaction {
               //This also dispatched InteractionObject.OnHandRegainedTracking()
               interactionHand.RegainTracking(hand);
 
+              if (interactionHand.graspedObject == null) {
+                continue;
+              }
+
               // NotifyHandRegainedTracking() did not throw, continue on to NotifyHandsHoldPhysics().
               dispatchOnHandsHolding(hands, interactionHand.graspedObject, isPhysics: true);
             } catch (Exception e) {

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
@@ -352,10 +352,14 @@ namespace Leap.Unity.Interaction {
 
       foreach (var interactionHand in _idToInteractionHand.Values) {
         if (interactionHand.graspedObject == graspedObject) {
-          if (_graspingEnabled) {
-            InteractionC.OverrideHandResult(ref _scene, (uint)interactionHand.hand.Id, ref result);
+          if (interactionHand.isUntracked) {
+            interactionHand.MarkTimeout();
+          } else {
+            if (_graspingEnabled) {
+              InteractionC.OverrideHandResult(ref _scene, (uint)interactionHand.hand.Id, ref result);
+            }
+            interactionHand.ReleaseObject();
           }
-          interactionHand.ReleaseObject();
         }
       }
 

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
@@ -829,7 +829,7 @@ namespace Leap.Unity.Interaction {
                       interactionHand.GraspObject(interactionBehaviour, isUserGrasp: false);
 
                       //the grasp callback might have caused the object to become ungrasped
-                      if (interactionHand.graspedObject == interactionBehaviour) {
+                      if (interactionHand.graspedObject == interactionBehaviour && interactionBehaviour != null) {
                         dispatchOnHandsHolding(hands, interactionBehaviour, isPhysics: true);
                       }
                     } catch (Exception e) {

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
@@ -829,6 +829,7 @@ namespace Leap.Unity.Interaction {
                       interactionHand.GraspObject(interactionBehaviour, isUserGrasp: false);
 
                       //the grasp callback might have caused the object to become ungrasped
+                      //the component might have also destroyed itself!
                       if (interactionHand.graspedObject == interactionBehaviour && interactionBehaviour != null) {
                         dispatchOnHandsHolding(hands, interactionBehaviour, isPhysics: true);
                       }

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
@@ -394,6 +394,9 @@ namespace Leap.Unity.Interaction {
         throw new InvalidOperationException("Cannot grasp " + interactionBehaviour + " because it is not registered with this manager.");
       }
 
+      //Ensure behaviour is active already
+      _activityManager.Activate(interactionBehaviour);
+
       if (!interactionBehaviour.IsBeingGrasped) {
         _graspedBehaviours.Add(interactionBehaviour);
       }
@@ -425,7 +428,11 @@ namespace Leap.Unity.Interaction {
         foreach (var interactionHand in _idToInteractionHand.Values) {
           if (interactionHand.graspedObject == interactionBehaviour) {
             try {
-              interactionHand.ReleaseObject();
+              if (interactionHand.isUntracked) {
+                interactionHand.MarkTimeout();
+              } else {
+                interactionHand.ReleaseObject();
+              }
             } catch (Exception e) {
               //Only log to console
               //We want to continue so we can destroy the shape and dispatch OnUnregister

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/Validation/InteractionManagerValidation.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/Validation/InteractionManagerValidation.cs
@@ -28,8 +28,10 @@ namespace Leap.Unity.Interaction {
         int id = pair.Key;
         var interactionHand = pair.Value;
 
-        Assert.AreEqual(id, interactionHand.hand.Id,
-                        "Id should always map to a hand of the same Id.");
+        if (interactionHand.hand != null) {
+          Assert.AreEqual(id, interactionHand.hand.Id,
+                          "Id should always map to a hand of the same Id.");
+        }
 
         interactionHand.Validate();
       }
@@ -97,22 +99,22 @@ namespace Leap.Unity.Interaction {
 
           Assert.IsTrue(graspedObject.IsBeingGraspedByHand(hand.Id),
                         "Grasped object must always report as being grasped by this hand.");
-        }
 
-        if (isUntracked) {
-          Assert.IsNotNull(graspedObject,
-                           "If untracked, must also always be grasping an object.");
+          if (isUntracked) {
+            Assert.IsNotNull(graspedObject,
+                             "If untracked, must also always be grasping an object.");
 
-          Assert.AreNotEqual(graspedObject.UntrackedHandCount, 0,
-                             "If untracked, grasped object must report at least one untracked hand.");
+            Assert.AreNotEqual(graspedObject.UntrackedHandCount, 0,
+                               "If untracked, grasped object must report at least one untracked hand.");
 
-          Assert.IsTrue(graspedObject.UntrackedGraspingHands.Contains(hand.Id),
-                        "If untracked, grasped object must report to be grasped by an untracked hand of this id.");
-        }
+            Assert.IsTrue(graspedObject.UntrackedGraspingHands.Contains(hand.Id),
+                          "If untracked, grasped object must report to be grasped by an untracked hand of this id.");
+          }
 
-        if (isUserGrasp) {
-          Assert.IsNotNull(graspedObject,
-                           "If a user grasp is taking place, we must always be grasping an object.");
+          if (isUserGrasp) {
+            Assert.IsNotNull(graspedObject,
+                             "If a user grasp is taking place, we must always be grasping an object.");
+          }
         }
       }
     }

--- a/Assets/LeapMotionModules/Playback/Scripts/PlaybackRecorder.cs
+++ b/Assets/LeapMotionModules/Playback/Scripts/PlaybackRecorder.cs
@@ -57,10 +57,10 @@ namespace Leap.Unity.Playback {
           string path = AssetDatabase.GenerateUniqueAssetPath(_unityAssetSavePath + ".asset");
           AssetDatabase.CreateAsset(finishedRecording, path);
           AssetDatabase.SaveAssets();
+          break;
 #else
               throw new Exception("Cannot save unity assets outside of Unity Editor");
 #endif
-          break;
         default:
           break;
       }

--- a/Assets/LeapMotionTests/InteractionEngine/Scripts/SadisticInteractionBehaviour.cs
+++ b/Assets/LeapMotionTests/InteractionEngine/Scripts/SadisticInteractionBehaviour.cs
@@ -1,5 +1,4 @@
 ﻿using UnityEngine;
-using System;
 using Leap.Unity.Interaction.CApi;
 
 namespace Leap.Unity.Interaction.Testing {

--- a/Assets/LeapMotionTests/InteractionEngine/Scripts/SadisticTest.cs
+++ b/Assets/LeapMotionTests/InteractionEngine/Scripts/SadisticTest.cs
@@ -100,8 +100,8 @@ namespace Leap.Unity.Interaction.Testing {
           return;
         }
 
-        Debug.LogError(getEnumMessage("Expected callbacks:", expectedCallbacks));
-        Debug.LogError(getEnumMessage("Recieved callbacks:", allCallbacksRecieved));
+        Debug.LogError(getEnumMessage("Expected callbacks: " + expectedCallbacks, expectedCallbacks));
+        Debug.LogError(getEnumMessage("Recieved callbacks: " + allCallbacksRecieved, allCallbacksRecieved));
 
         IntegrationTest.Fail("Could not find an interaction behaviour that recieved all expected callbacks");
       }
@@ -113,7 +113,7 @@ namespace Leap.Unity.Interaction.Testing {
       string[] callbackNames = Enum.GetNames(callbackType);
 
       for (int i = 0; i < callbackValues.Length; i++) {
-        if ((callbackValues[i] & (int)expectedCallbacks) != 0) {
+        if ((callbackValues[i] & (int)values) != 0) {
           message += "\n" + callbackNames[i];
         }
       }

--- a/Assets/LeapMotionTests/InteractionEngine/Scripts/SadisticTestManager.cs
+++ b/Assets/LeapMotionTests/InteractionEngine/Scripts/SadisticTestManager.cs
@@ -1,5 +1,7 @@
 ﻿using UnityEngine;
+#if UNITY_EDITOR
 using UnityEditor;
+#endif
 using UnityTest;
 using System;
 using Leap.Unity.Attributes;
@@ -60,6 +62,7 @@ namespace Leap.Unity.Interaction.Testing {
       }
     }
 
+#if UNITY_EDITOR
     [ContextMenu("Update tests")]
     public void UpdateChildrenTests() {
       Transform[] transforms = GetComponentsInChildren<Transform>(true);
@@ -119,6 +122,7 @@ namespace Leap.Unity.Interaction.Testing {
         test.actionDelay = _actionDelay;
       }
     }
+#endif
 
     public enum SpawnObjectsTime {
       AtStart,


### PR DESCRIPTION
 - ThrowingControllerSlidingWindow now handles cases where a throw takes less than 2 frames
 - Interaction Behaviours now return themselves to the default layer upon unregister
 - Unregistering an object that is suspended now dispatches the proper callbacks 
 - Forcing a grasp of an object that is registered but not active now activates the object
 - Added some null checks to validation
 - Added some null checks to the manager to catch cases where objects suddenly decide to kill themselves

@ajohnston33 

To test:
 - [ ] Make sure all tests pass :D