### PR TITLE
Shape pool improvements

### DIFF
--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/InteractionBehaviourBase.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/InteractionBehaviourBase.cs
@@ -205,8 +205,6 @@ namespace Leap.Unity.Interaction {
 
     public override sealed void NotifyInteractionShapeDestroyed() {
       _shapeInstanceHandle = new INTERACTION_SHAPE_INSTANCE_HANDLE();
-      _shapeDescriptionHandle = new INTERACTION_SHAPE_DESCRIPTION_HANDLE();
-      _hasShapeDescriptionBeenCreated = false;
       _hasShapeInstanceHandle = false;
 
       _baseCallGuard.Begin("OnInteractionShapeDestroyed");

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/InteractionBehaviourBase.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/InteractionBehaviourBase.cs
@@ -177,6 +177,12 @@ namespace Leap.Unity.Interaction {
         enabled = false;
       }
 
+      if (_hasShapeDescriptionBeenCreated) {
+        _manager.ShapePool.ReturnShape(_shapeDescriptionHandle);
+        _shapeDescriptionHandle = new INTERACTION_SHAPE_DESCRIPTION_HANDLE();
+        _hasShapeDescriptionBeenCreated = false;
+      }
+
       _baseCallGuard.Begin("OnUnregistered");
       OnUnregistered();
       _baseCallGuard.AssertBaseCalled();

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/Utility/ShapeDescriptionPool.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/Utility/ShapeDescriptionPool.cs
@@ -8,7 +8,7 @@ using Leap.Unity.Interaction.CApi;
 namespace Leap.Unity.Interaction {
 
   public class ShapeDescriptionPool {
-    public const int DECIMAL_PRECISION = 3;
+    public const int DECIMAL_CACHING_PRECISION = 1000;
 
     private INTERACTION_SCENE _scene;
 
@@ -69,11 +69,11 @@ namespace Leap.Unity.Interaction {
     /// Gets a handle to a sphere shape description of the given radius
     /// </summary>
     public INTERACTION_SHAPE_DESCRIPTION_HANDLE GetSphere(float radius) {
-      float roundedRadius = (float)Math.Round(radius, DECIMAL_PRECISION);
+      float roundedRadius = (int)(radius * DECIMAL_CACHING_PRECISION);
 
       INTERACTION_SHAPE_DESCRIPTION_HANDLE handle;
       if (!_sphereDescMap.TryGetValue(roundedRadius, out handle)) {
-        IntPtr spherePtr = allocateSphere(roundedRadius);
+        IntPtr spherePtr = allocateSphere(radius);
         InteractionC.AddShapeDescription(ref _scene, spherePtr, out handle);
         StructAllocator.CleanupAllocations();
 
@@ -89,13 +89,13 @@ namespace Leap.Unity.Interaction {
     /// </summary>
     public INTERACTION_SHAPE_DESCRIPTION_HANDLE GetOBB(Vector3 extents) {
       Vector3 roundedExtents = new Vector3();
-      roundedExtents.x = (float)Math.Round(extents.x, DECIMAL_PRECISION);
-      roundedExtents.y = (float)Math.Round(extents.y, DECIMAL_PRECISION);
-      roundedExtents.z = (float)Math.Round(extents.z, DECIMAL_PRECISION);
+      roundedExtents.x = (int)(extents.x * DECIMAL_CACHING_PRECISION);
+      roundedExtents.y = (int)(extents.y * DECIMAL_CACHING_PRECISION);
+      roundedExtents.z = (int)(extents.z * DECIMAL_CACHING_PRECISION);
 
       INTERACTION_SHAPE_DESCRIPTION_HANDLE handle;
       if (!_obbDescMap.TryGetValue(roundedExtents, out handle)) {
-        IntPtr obbPtr = allocateObb(roundedExtents);
+        IntPtr obbPtr = allocateObb(extents);
         InteractionC.AddShapeDescription(ref _scene, obbPtr, out handle);
         StructAllocator.CleanupAllocations();
 

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/Utility/ShapeDescriptionPool.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/Utility/ShapeDescriptionPool.cs
@@ -8,6 +8,8 @@ using Leap.Unity.Interaction.CApi;
 namespace Leap.Unity.Interaction {
 
   public class ShapeDescriptionPool {
+    public const int DECIMAL_PRECISION = 3;
+
     private INTERACTION_SCENE _scene;
 
     private Dictionary<float, INTERACTION_SHAPE_DESCRIPTION_HANDLE> _sphereDescMap;
@@ -67,13 +69,15 @@ namespace Leap.Unity.Interaction {
     /// Gets a handle to a sphere shape description of the given radius
     /// </summary>
     public INTERACTION_SHAPE_DESCRIPTION_HANDLE GetSphere(float radius) {
+      float roundedRadius = (float)Math.Round(radius, DECIMAL_PRECISION);
+
       INTERACTION_SHAPE_DESCRIPTION_HANDLE handle;
-      if (!_sphereDescMap.TryGetValue(radius, out handle)) {
-        IntPtr spherePtr = allocateSphere(radius);
+      if (!_sphereDescMap.TryGetValue(roundedRadius, out handle)) {
+        IntPtr spherePtr = allocateSphere(roundedRadius);
         InteractionC.AddShapeDescription(ref _scene, spherePtr, out handle);
         StructAllocator.CleanupAllocations();
 
-        _sphereDescMap[radius] = handle;
+        _sphereDescMap[roundedRadius] = handle;
         _allHandles[handle] = new ShapeInfo(isPersistent: true);
       }
 
@@ -84,13 +88,18 @@ namespace Leap.Unity.Interaction {
     /// Gets a handle to an OBB description of the given extents
     /// </summary>
     public INTERACTION_SHAPE_DESCRIPTION_HANDLE GetOBB(Vector3 extents) {
+      Vector3 roundedExtents = new Vector3();
+      roundedExtents.x = (float)Math.Round(extents.x, DECIMAL_PRECISION);
+      roundedExtents.y = (float)Math.Round(extents.y, DECIMAL_PRECISION);
+      roundedExtents.z = (float)Math.Round(extents.z, DECIMAL_PRECISION);
+
       INTERACTION_SHAPE_DESCRIPTION_HANDLE handle;
-      if (!_obbDescMap.TryGetValue(extents, out handle)) {
-        IntPtr obbPtr = allocateObb(extents);
+      if (!_obbDescMap.TryGetValue(roundedExtents, out handle)) {
+        IntPtr obbPtr = allocateObb(roundedExtents);
         InteractionC.AddShapeDescription(ref _scene, obbPtr, out handle);
         StructAllocator.CleanupAllocations();
 
-        _obbDescMap[extents] = handle;
+        _obbDescMap[roundedExtents] = handle;
         _allHandles[handle] = new ShapeInfo(isPersistent: true);
       }
 

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/Utility/ShapeDescriptionPool.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/Utility/ShapeDescriptionPool.cs
@@ -60,8 +60,8 @@ namespace Leap.Unity.Interaction {
       }
 
       if (!info.isPersistent) {
-        InteractionC.RemoveShapeDescription(ref _scene, ref handle);
         _allHandles.Remove(handle);
+        InteractionC.RemoveShapeDescription(ref _scene, ref handle);
       }
     }
 

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/Utility/ShapeDescriptionPool.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/Utility/ShapeDescriptionPool.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using UnityEngine.Assertions;
 using System;
 using System.Collections.Generic;
 using LeapInternal;
@@ -12,7 +13,16 @@ namespace Leap.Unity.Interaction {
     private Dictionary<float, INTERACTION_SHAPE_DESCRIPTION_HANDLE> _sphereDescMap;
     private Dictionary<Vector3, INTERACTION_SHAPE_DESCRIPTION_HANDLE> _obbDescMap;
     private Dictionary<Mesh, INTERACTION_SHAPE_DESCRIPTION_HANDLE> _meshDescMap;
-    private List<INTERACTION_SHAPE_DESCRIPTION_HANDLE> _allHandles;
+
+    private Dictionary<INTERACTION_SHAPE_DESCRIPTION_HANDLE, ShapeInfo> _allHandles;
+
+    public struct ShapeInfo {
+      public bool isPersistent;
+
+      public ShapeInfo(bool isPersistent) {
+        this.isPersistent = isPersistent;
+      }
+    }
 
     public ShapeDescriptionPool(INTERACTION_SCENE scene) {
       _scene = scene;
@@ -20,22 +30,37 @@ namespace Leap.Unity.Interaction {
       _sphereDescMap = new Dictionary<float, INTERACTION_SHAPE_DESCRIPTION_HANDLE>();
       _obbDescMap = new Dictionary<Vector3, INTERACTION_SHAPE_DESCRIPTION_HANDLE>();
       _meshDescMap = new Dictionary<Mesh, INTERACTION_SHAPE_DESCRIPTION_HANDLE>();
-      _allHandles = new List<INTERACTION_SHAPE_DESCRIPTION_HANDLE>();
+      _allHandles = new Dictionary<INTERACTION_SHAPE_DESCRIPTION_HANDLE, ShapeInfo>();
     }
 
     /// <summary>
     /// Removes and destroys all descriptions from the internal scene.
     /// </summary>
     public void RemoveAllShapes() {
-      for (int i = 0; i < _allHandles.Count; i++) {
-        INTERACTION_SHAPE_DESCRIPTION_HANDLE handle = _allHandles[i];
-        InteractionC.RemoveShapeDescription(ref _scene, ref handle);
+      foreach (var handle in _allHandles.Keys) {
+        var localHandle = handle;
+        InteractionC.RemoveShapeDescription(ref _scene, ref localHandle);
       }
 
       _allHandles.Clear();
       _sphereDescMap.Clear();
       _obbDescMap.Clear();
       _meshDescMap.Clear();
+    }
+
+    /// <summary>
+    /// Returns a shape handle into the pool. 
+    /// </summary>
+    public void ReturnShape(INTERACTION_SHAPE_DESCRIPTION_HANDLE handle) {
+      ShapeInfo info;
+      if (!_allHandles.TryGetValue(handle, out info)) {
+        throw new InvalidOperationException("Tried to return a handle that was not allocated.");
+      }
+
+      if (!info.isPersistent) {
+        InteractionC.RemoveShapeDescription(ref _scene, ref handle);
+        _allHandles.Remove(handle);
+      }
     }
 
     /// <summary>
@@ -49,7 +74,7 @@ namespace Leap.Unity.Interaction {
         StructAllocator.CleanupAllocations();
 
         _sphereDescMap[radius] = handle;
-        _allHandles.Add(handle);
+        _allHandles[handle] = new ShapeInfo(isPersistent: true);
       }
 
       return handle;
@@ -66,7 +91,7 @@ namespace Leap.Unity.Interaction {
         StructAllocator.CleanupAllocations();
 
         _obbDescMap[extents] = handle;
-        _allHandles.Add(handle);
+        _allHandles[handle] = new ShapeInfo(isPersistent: true);
       }
 
       return handle;
@@ -80,7 +105,7 @@ namespace Leap.Unity.Interaction {
       IntPtr capsulePtr = allocateCapsule(p0, p1, radius);
       InteractionC.AddShapeDescription(ref _scene, capsulePtr, out handle);
       StructAllocator.CleanupAllocations();
-      _allHandles.Add(handle);
+      _allHandles[handle] = new ShapeInfo(isPersistent: false);
       return handle;
     }
 
@@ -98,7 +123,7 @@ namespace Leap.Unity.Interaction {
         StructAllocator.CleanupAllocations();
 
         _meshDescMap[meshCollider.sharedMesh] = handle;
-        _allHandles.Add(handle);
+        _allHandles[handle] = new ShapeInfo(isPersistent: false);
       }
 
       return handle;
@@ -117,7 +142,7 @@ namespace Leap.Unity.Interaction {
       InteractionC.AddShapeDescription(ref _scene, meshPtr, out handle);
       StructAllocator.CleanupAllocations();
 
-      _allHandles.Add(handle);
+      _allHandles[handle] = new ShapeInfo(isPersistent: false);
 
       return handle;
     }
@@ -157,7 +182,7 @@ namespace Leap.Unity.Interaction {
 
       // Try optimized encodings for a single collider.  Everything else is a compound.
       if (_tempColliderList.Count == 1) {
-        if(getCollisionSingleInternal(parentObject, ref handle)) {
+        if (getCollisionSingleInternal(parentObject, ref handle)) {
           return handle;
         }
       }
@@ -183,7 +208,7 @@ namespace Leap.Unity.Interaction {
         // Transform to apply to collision shape.
         Matrix4x4 localToParentRelative = inverseParentRelativePose * collider.transform.localToWorldMatrix;
 
-          // Values used to construct INTERACTION_TRANSFORM.
+        // Values used to construct INTERACTION_TRANSFORM.
         Vector3 parentRelativePos = Vector3.zero;
         Quaternion parentRelativeRot = Quaternion.identity;
 
@@ -214,14 +239,14 @@ namespace Leap.Unity.Interaction {
             shapePtr = allocateObb(extents);
           } else if (collider is CapsuleCollider) {
             CapsuleCollider capsuleCollider = collider as CapsuleCollider;
-            if((uint)capsuleCollider.direction >= 3u)
+            if ((uint)capsuleCollider.direction >= 3u)
               throw new InvalidOperationException("Unexpected capsule direction " + capsuleCollider.direction);
 
             parentRelativePos = localToParentRelative.MultiplyPoint(capsuleCollider.center);
 
-            Vector3 primaryAxis = new Vector3((capsuleCollider.direction==0)?1:0, (capsuleCollider.direction==1)?1:0, (capsuleCollider.direction==2)?1:0);
+            Vector3 primaryAxis = new Vector3((capsuleCollider.direction == 0) ? 1 : 0, (capsuleCollider.direction == 1) ? 1 : 0, (capsuleCollider.direction == 2) ? 1 : 0);
             float primaryAxisScale = scaleAlongLocalToParentAxes[capsuleCollider.direction];
-            float perpendicularScale = Mathf.Max(scaleAlongLocalToParentAxes[(capsuleCollider.direction + 1)%3], scaleAlongLocalToParentAxes[(capsuleCollider.direction + 2)%3]);
+            float perpendicularScale = Mathf.Max(scaleAlongLocalToParentAxes[(capsuleCollider.direction + 1) % 3], scaleAlongLocalToParentAxes[(capsuleCollider.direction + 2) % 3]);
 
             float scaledHeight = capsuleCollider.height * primaryAxisScale;
             float scaledRadius = capsuleCollider.radius * perpendicularScale;
@@ -229,8 +254,7 @@ namespace Leap.Unity.Interaction {
 
             Vector3 p0 = primaryAxis * interiorExtent;
             shapePtr = allocateCapsule(p0, -p0, scaledRadius);
-          }
-          else {
+          } else {
             throw new InvalidOperationException("Unsupported collider type " + collider.GetType());
           }
         }
@@ -248,7 +272,7 @@ namespace Leap.Unity.Interaction {
       StructAllocator.CleanupAllocations();
 
       _tempColliderList.Clear();
-      _allHandles.Add(handle);
+      _allHandles[handle] = new ShapeInfo(isPersistent: false);
 
       return handle;
     }
@@ -328,7 +352,7 @@ namespace Leap.Unity.Interaction {
     private IntPtr allocateConvex(MeshCollider meshCollider, Matrix4x4 localToParentRelative) {
 
       if (meshCollider.sharedMesh == null) { throw new NotImplementedException("MeshCollider missing sharedMesh."); }
-      if (meshCollider.convex == false)    { throw new NotImplementedException("MeshCollider must be convex."); }
+      if (meshCollider.convex == false) { throw new NotImplementedException("MeshCollider must be convex."); }
 
       Mesh mesh = meshCollider.sharedMesh;
 

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/Utility/ShapeDescriptionPool.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/Utility/ShapeDescriptionPool.cs
@@ -19,10 +19,10 @@ namespace Leap.Unity.Interaction {
     private Dictionary<INTERACTION_SHAPE_DESCRIPTION_HANDLE, ShapeInfo> _allHandles;
 
     public struct ShapeInfo {
-      public bool isPersistent;
+      public bool isCached;
 
-      public ShapeInfo(bool isPersistent) {
-        this.isPersistent = isPersistent;
+      public ShapeInfo(bool isCached) {
+        this.isCached = isCached;
       }
     }
 
@@ -59,7 +59,7 @@ namespace Leap.Unity.Interaction {
         throw new InvalidOperationException("Tried to return a handle that was not allocated.");
       }
 
-      if (!info.isPersistent) {
+      if (!info.isCached) {
         _allHandles.Remove(handle);
         InteractionC.RemoveShapeDescription(ref _scene, ref handle);
       }
@@ -78,7 +78,7 @@ namespace Leap.Unity.Interaction {
         StructAllocator.CleanupAllocations();
 
         _sphereDescMap[roundedRadius] = handle;
-        _allHandles[handle] = new ShapeInfo(isPersistent: true);
+        _allHandles[handle] = new ShapeInfo(isCached: true);
       }
 
       return handle;
@@ -100,7 +100,7 @@ namespace Leap.Unity.Interaction {
         StructAllocator.CleanupAllocations();
 
         _obbDescMap[roundedExtents] = handle;
-        _allHandles[handle] = new ShapeInfo(isPersistent: true);
+        _allHandles[handle] = new ShapeInfo(isCached: true);
       }
 
       return handle;
@@ -114,7 +114,7 @@ namespace Leap.Unity.Interaction {
       IntPtr capsulePtr = allocateCapsule(p0, p1, radius);
       InteractionC.AddShapeDescription(ref _scene, capsulePtr, out handle);
       StructAllocator.CleanupAllocations();
-      _allHandles[handle] = new ShapeInfo(isPersistent: false);
+      _allHandles[handle] = new ShapeInfo(isCached: false);
       return handle;
     }
 
@@ -132,7 +132,7 @@ namespace Leap.Unity.Interaction {
         StructAllocator.CleanupAllocations();
 
         _meshDescMap[meshCollider.sharedMesh] = handle;
-        _allHandles[handle] = new ShapeInfo(isPersistent: false);
+        _allHandles[handle] = new ShapeInfo(isCached: false);
       }
 
       return handle;
@@ -151,7 +151,7 @@ namespace Leap.Unity.Interaction {
       InteractionC.AddShapeDescription(ref _scene, meshPtr, out handle);
       StructAllocator.CleanupAllocations();
 
-      _allHandles[handle] = new ShapeInfo(isPersistent: false);
+      _allHandles[handle] = new ShapeInfo(isCached: false);
 
       return handle;
     }
@@ -281,7 +281,7 @@ namespace Leap.Unity.Interaction {
       StructAllocator.CleanupAllocations();
 
       _tempColliderList.Clear();
-      _allHandles[handle] = new ShapeInfo(isPersistent: false);
+      _allHandles[handle] = new ShapeInfo(isCached: false);
 
       return handle;
     }


### PR DESCRIPTION
 - Interaction Behaviours no longer throw away their descriptions when they are deactivated.
 - Shape pool allows specific descriptions to be returned.  If the description is a primitive, it is not returned and instead sticks around for re-use.  In the future we can add features that time out descriptions over time if we want.
 - Shape pool does *not* pool meshes, capsules, or compound colliders still.  It will always construct a new description for any object of this type.  The difference is that these descriptions are now cleaned up when the object is unregistered.
 - Shape pool now rounds the values used for caching primitives to prevent floating point error from wrecking face

@ajohnston33 