### PR TITLE
Relaxing the requirement for a rigidbody component

### DIFF
--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/Editor/InteractionBehaviourBaseEditor.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/Editor/InteractionBehaviourBaseEditor.cs
@@ -34,9 +34,9 @@ namespace Leap.Unity.Interaction {
 
       Rigidbody rigidbody = _interactionBehaviour.GetComponent<Rigidbody>();
 
-      if (rigidbody == null) {
+      if (rigidbody == null && _interactionBehaviour.enabled) {
         using (new GUILayout.HorizontalScope()) {
-          EditorGUILayout.HelpBox("This component requires a Rigidbody", MessageType.Error);
+          EditorGUILayout.HelpBox("This component requires a Rigidbody to be enabled", MessageType.Error);
           if (GUILayout.Button("Auto-Fix")) {
             rigidbody = _interactionBehaviour.gameObject.AddComponent<Rigidbody>();
             rigidbody.interpolation = RigidbodyInterpolation.Interpolate;

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/Editor/InteractionBehaviourBaseEditor.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/Editor/InteractionBehaviourBaseEditor.cs
@@ -34,14 +34,16 @@ namespace Leap.Unity.Interaction {
 
       Rigidbody rigidbody = _interactionBehaviour.GetComponent<Rigidbody>();
 
-      if (rigidbody == null && _interactionBehaviour.enabled) {
-        using (new GUILayout.HorizontalScope()) {
-          EditorGUILayout.HelpBox("This component requires a Rigidbody to be enabled", MessageType.Error);
-          if (GUILayout.Button("Auto-Fix")) {
-            rigidbody = _interactionBehaviour.gameObject.AddComponent<Rigidbody>();
-            rigidbody.interpolation = RigidbodyInterpolation.Interpolate;
-            rigidbody.useGravity = true;
-            rigidbody.isKinematic = false;
+      if (rigidbody == null) {
+        if (_interactionBehaviour.enabled) {
+          using (new GUILayout.HorizontalScope()) {
+            EditorGUILayout.HelpBox("This component requires a Rigidbody to be enabled", MessageType.Error);
+            if (GUILayout.Button("Auto-Fix")) {
+              rigidbody = _interactionBehaviour.gameObject.AddComponent<Rigidbody>();
+              rigidbody.interpolation = RigidbodyInterpolation.Interpolate;
+              rigidbody.useGravity = true;
+              rigidbody.isKinematic = false;
+            }
           }
         }
       } else {

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
@@ -34,7 +34,6 @@ namespace Leap.Unity.Interaction {
   ///      properties of this behaviour instead of the properties on the Rigidbody component.
   /// </remarks>
   [SelectionBase]
-  [RequireComponent(typeof(Rigidbody))]
   public partial class InteractionBehaviour : InteractionBehaviourBase {
     protected enum ContactMode {
       NORMAL = 0,  // Influenced by brushes and not by soft contact.
@@ -447,12 +446,14 @@ namespace Leap.Unity.Interaction {
 
     protected override void Awake() {
       base.Awake();
+      CheckMaterial();
+    }
 
+    protected override void OnEnable() {
       _rigidbody = GetComponent<Rigidbody>();
       if (_rigidbody == null) {
-        //Should only happen if the user has done some trickery since there is a RequireComponent attribute
         enabled = false;
-        throw new InvalidOperationException("InteractionBehaviour must have a Rigidbody component attached to it.");
+        throw new InvalidOperationException("InteractionBehaviour must have a Rigidbody component attached to it to be enabled.");
       }
       _rigidbody.maxAngularVelocity = float.PositiveInfinity;
 
@@ -462,7 +463,7 @@ namespace Leap.Unity.Interaction {
       _drag = _rigidbody.drag;
       _angularDrag = _rigidbody.angularDrag;
 
-      CheckMaterial();
+      base.OnEnable();
     }
 
     protected override void Reset() {


### PR DESCRIPTION
Before, we were using the RequireComponent attribute on the InteractionBehaviourBase component.  This component enforced that an InteractionBehaviour must have a rigidbody component present at all times.  This can be annoying under certain conditions, like when the user wants to enable interaction at a later time by enabling the component and adding a rigidbody.

The constraint has been relaxed slightly.  It is now only necessary that a rigidbody exists when the component is *enabled*, instead of at all times.  This allows a user to place a disabled interaction behaviour component on an object without a rigidbody and enable it at a later time.

@nickjbenson 