### PR TITLE
Interaction Engine Fixing Sticky Release, C# side.

### DIFF
--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
@@ -521,12 +521,6 @@ namespace Leap.Unity.Interaction {
     }
 
     protected void updateLayer() {
-      if (!IsRegisteredWithManager) {
-        // Adrian, why was this check here?
-//        Debug.LogError("Calling updateLayer after unregistration.");
-        return;
-      }
-
       int layer;
       if (_controllers.LayerController != null) {
         if (_contactMode != ContactMode.NORMAL) {

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
@@ -190,7 +190,9 @@ namespace Leap.Unity.Interaction {
       base.OnUnregistered();
 
       Assert.IsTrue(UntrackedHandCount == 0);
-      _contactMode = ContactMode.NORMAL;
+
+      // Ditch this object in the layer that doesn't collide with brushes in case they are still embedded.
+      _contactMode = ContactMode.SOFT;
       updateLayer();
 
       _warper.Dispose();
@@ -255,6 +257,7 @@ namespace Leap.Unity.Interaction {
       //Reset so we can accumulate for the next frame
       _accumulatedLinearAcceleration = Vector3.zero;
       _accumulatedAngularAcceleration = Vector3.zero;
+      _minHandDistance = float.MaxValue;
     }
 
     public override void GetInteractionShapeCreationInfo(out INTERACTION_CREATE_SHAPE_INFO createInfo, out INTERACTION_TRANSFORM createTransform) {
@@ -321,7 +324,9 @@ namespace Leap.Unity.Interaction {
         _recievedVelocityUpdate = true;
       }
 
-      _minHandDistance = (results.resultFlags & ShapeInstanceResultFlags.MaxHand) == 0 ? float.MaxValue : results.minHandDistance;
+      if ((results.resultFlags & ShapeInstanceResultFlags.MaxHand) != 0) {
+        _minHandDistance = results.minHandDistance;
+      }
 
       updateContactMode();
     }
@@ -429,7 +434,10 @@ namespace Leap.Unity.Interaction {
       }
 
       revertRigidbodyState();
-      _materialReplacer.RevertMaterials();
+
+      // Transition to soft contact when exiting grasp.  This is because the fingers
+      // are probably embedded.
+      _dislocatedBrushCounter = 0;
       updateContactMode();
     }
     #endregion
@@ -513,23 +521,25 @@ namespace Leap.Unity.Interaction {
     }
 
     protected void updateLayer() {
+      if (!IsRegisteredWithManager) {
+        // Adrian, why was this check here?
+//        Debug.LogError("Calling updateLayer after unregistration.");
+        return;
+      }
+
       int layer;
-      if (IsRegisteredWithManager) {
-        if (_controllers.LayerController != null) {
-          if (_contactMode != ContactMode.NORMAL) {
-            layer = _controllers.LayerController.InteractionNoClipLayer;
-          } else {
-            layer = _controllers.LayerController.InteractionLayer;
-          }
+      if (_controllers.LayerController != null) {
+        if (_contactMode != ContactMode.NORMAL) {
+          layer = _controllers.LayerController.InteractionNoClipLayer;
         } else {
-          if (_contactMode != ContactMode.NORMAL) {
-            layer = _manager.InteractionNoClipLayer;
-          } else {
-            layer = _manager.InteractionLayer;
-          }
+          layer = _controllers.LayerController.InteractionLayer;
         }
       } else {
-        layer = LayerMask.NameToLayer("Default");
+        if (_contactMode != ContactMode.NORMAL) {
+          layer = _manager.InteractionNoClipLayer;
+        } else {
+          layer = _manager.InteractionLayer;
+        }
       }
 
       if (gameObject.layer != layer) {

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
@@ -314,7 +314,7 @@ namespace Leap.Unity.Interaction {
     }
 
     /// <summary>
-    /// Gets or sets the max activation depth.
+    /// Enables the display of proximity information from the library.
     /// </summary>
     public bool ShowDebugLines {
       get {
@@ -327,7 +327,7 @@ namespace Leap.Unity.Interaction {
     }
 
     /// <summary>
-    /// Gets or sets the max activation depth.
+    /// Enables the display of debug text from the library.
     /// </summary>
     public bool ShowDebugOutput {
       get {

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
@@ -313,6 +313,32 @@ namespace Leap.Unity.Interaction {
       }
     }
 
+    /// <summary>
+    /// Gets or sets the max activation depth.
+    /// </summary>
+    public bool ShowDebugLines {
+      get {
+        return _showDebugLines;
+      }
+      set {
+        _showDebugLines = value;
+        applyDebugSettings();
+      }
+    }
+
+    /// <summary>
+    /// Gets or sets the max activation depth.
+    /// </summary>
+    public bool ShowDebugOutput {
+      get {
+        return _showDebugOutput;
+      }
+      set {
+        _showDebugOutput = value;
+        applyDebugSettings();
+      }
+    }
+
     /// Force an update of the internal scene info.  This should be called if gravity has changed.
     /// </summary>
     public void UpdateSceneInfo() {

--- a/Assets/LeapMotionTests/InteractionEngine/Scenes/Tests.unity
+++ b/Assets/LeapMotionTests/InteractionEngine/Scenes/Tests.unity
@@ -447,7 +447,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &142727094
 Transform:
   m_ObjectHideFlags: 0
@@ -504,7 +504,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &167001308
 Transform:
   m_ObjectHideFlags: 0
@@ -808,7 +808,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &202844947
 Transform:
   m_ObjectHideFlags: 0
@@ -865,7 +865,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &203415486
 Transform:
   m_ObjectHideFlags: 0
@@ -964,6 +964,85 @@ MonoBehaviour:
   action: 512
   actionDelay: 0.5
   activationDepth: 1
+--- !u!1 &223795949
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 223795950}
+  - 33: {fileID: 223795953}
+  - 65: {fileID: 223795952}
+  - 23: {fileID: 223795951}
+  m_Layer: 0
+  m_Name: Platform
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 4294967295
+  m_IsActive: 1
+--- !u!4 &223795950
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 223795949}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: -0.345, z: 0}
+  m_LocalScale: {x: 2, y: 0.2, z: 2}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 1207110110}
+  m_RootOrder: 4
+--- !u!23 &223795951
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 223795949}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 2100000, guid: 84471ff3383f8d34bb14cc52f05e2948, type: 2}
+  m_SubsetIndices: 
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 1
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedWireframeHidden: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+--- !u!65 &223795952
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 223795949}
+  m_Material: {fileID: 13400000, guid: 37b1f9135ed80e5438922256002328c6, type: 2}
+  m_IsTrigger: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!33 &223795953
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 223795949}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
 --- !u!1 &232311453
 GameObject:
   m_ObjectHideFlags: 0
@@ -979,7 +1058,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &232311454
 Transform:
   m_ObjectHideFlags: 0
@@ -1487,7 +1566,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &376348603
 Transform:
   m_ObjectHideFlags: 0
@@ -1544,7 +1623,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &415467064
 Transform:
   m_ObjectHideFlags: 0
@@ -2124,7 +2203,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &575726605
 Transform:
   m_ObjectHideFlags: 0
@@ -2181,7 +2260,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &622376201
 Transform:
   m_ObjectHideFlags: 0
@@ -2238,7 +2317,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &635579674
 Transform:
   m_ObjectHideFlags: 0
@@ -3451,7 +3530,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &992720474
 Transform:
   m_ObjectHideFlags: 0
@@ -3508,7 +3587,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1004810724
 Transform:
   m_ObjectHideFlags: 0
@@ -4082,7 +4161,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &1202966043
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4223,6 +4302,7 @@ Transform:
   - {fileID: 1517705229}
   - {fileID: 1327637835}
   - {fileID: 1466856494}
+  - {fileID: 223795950}
   m_Father: {fileID: 0}
   m_RootOrder: 1
 --- !u!1 &1224814737
@@ -4707,10 +4787,9 @@ GameObject:
   m_Component:
   - 4: {fileID: 1327637835}
   - 33: {fileID: 1327637838}
-  - 65: {fileID: 1327637837}
   - 23: {fileID: 1327637836}
   m_Layer: 0
-  m_Name: Platform
+  m_Name: PlatformTarget
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -4723,8 +4802,8 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1327637834}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: -0.34500003, z: 0}
-  m_LocalScale: {x: 2, y: 0.2, z: 2}
+  m_LocalPosition: {x: 0, y: -0.3449, z: 0.31}
+  m_LocalScale: {x: 0.2, y: 0.2, z: 0.2}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 1207110110}
@@ -4742,7 +4821,7 @@ MeshRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_Materials:
-  - {fileID: 2100000, guid: 84471ff3383f8d34bb14cc52f05e2948, type: 2}
+  - {fileID: 2100000, guid: 75ac83db1cec6459382f15d263a76c5f, type: 2}
   m_SubsetIndices: 
   m_StaticBatchRoot: {fileID: 0}
   m_ProbeAnchor: {fileID: 0}
@@ -4758,18 +4837,6 @@ MeshRenderer:
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
   m_SortingOrder: 0
---- !u!65 &1327637837
-BoxCollider:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1327637834}
-  m_Material: {fileID: 13400000, guid: 37b1f9135ed80e5438922256002328c6, type: 2}
-  m_IsTrigger: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Size: {x: 1, y: 1, z: 1}
-  m_Center: {x: 0, y: 0, z: 0}
 --- !u!33 &1327637838
 MeshFilter:
   m_ObjectHideFlags: 0
@@ -5506,7 +5573,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1512340762
 Transform:
   m_ObjectHideFlags: 0
@@ -5683,7 +5750,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1543239900
 Transform:
   m_ObjectHideFlags: 0
@@ -5740,7 +5807,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1543318637
 Transform:
   m_ObjectHideFlags: 0
@@ -5968,7 +6035,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1554896904
 Transform:
   m_ObjectHideFlags: 0
@@ -6143,7 +6210,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1600629473
 Transform:
   m_ObjectHideFlags: 0
@@ -6314,7 +6381,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1626811733
 Transform:
   m_ObjectHideFlags: 0
@@ -6713,7 +6780,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1771526018
 Transform:
   m_ObjectHideFlags: 0
@@ -6884,7 +6951,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1792233638
 Transform:
   m_ObjectHideFlags: 0
@@ -6941,7 +7008,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1797730527
 Transform:
   m_ObjectHideFlags: 0
@@ -7232,7 +7299,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1845563827
 Transform:
   m_ObjectHideFlags: 0
@@ -7303,7 +7370,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   currentTest: {fileID: 0}
   _testPrefab: {fileID: 113452, guid: 17918aa090e11cb429326a59ee029545, type: 2}
-  _timeScale: 10
+  _timeScale: 0.03
 --- !u!4 &1849882204
 Transform:
   m_ObjectHideFlags: 0
@@ -7446,7 +7513,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &1872634071
 Transform:
   m_ObjectHideFlags: 0
@@ -8198,7 +8265,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &2050119045
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/LeapMotionTests/InteractionEngine/Scenes/Tests.unity
+++ b/Assets/LeapMotionTests/InteractionEngine/Scenes/Tests.unity
@@ -5361,8 +5361,8 @@ Camera:
   m_GameObject: {fileID: 1466856493}
   m_Enabled: 1
   serializedVersion: 2
-  m_ClearFlags: 1
-  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0.019607844}
+  m_ClearFlags: 2
+  m_BackGroundColor: {r: 0.17030708, g: 0.17556348, b: 0.18382353, a: 0.019607844}
   m_NormalizedViewPortRect:
     serializedVersion: 2
     x: 0
@@ -7370,7 +7370,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   currentTest: {fileID: 0}
   _testPrefab: {fileID: 113452, guid: 17918aa090e11cb429326a59ee029545, type: 2}
-  _timeScale: 0.03
+  _timeScale: 10
 --- !u!4 &1849882204
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/LeapMotionTests/InteractionEngine/Scripts/SadisticTest.cs
+++ b/Assets/LeapMotionTests/InteractionEngine/Scripts/SadisticTest.cs
@@ -3,6 +3,9 @@ using UnityEngine.Assertions;
 using UnityTest;
 using System;
 using System.Collections;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
 
 using Leap.Unity.Attributes;
 
@@ -112,7 +115,17 @@ namespace Leap.Unity.Interaction.Testing {
 
         IntegrationTest.Fail("Could not find an interaction behaviour that recieved all expected callbacks");
       }
+#if UNITY_EDITOR
+      else {
+        InteractionBrushBone[] bb = FindObjectsOfType(typeof(InteractionBrushBone)) as InteractionBrushBone[];
+        GameObject[] objs = new GameObject[bb.Length];
+         for(int i = 0; i < bb.Length; i++){
+              objs[i] = bb[i].gameObject;
+         }
+  		  Selection.objects = objs;
+      }
     }
+#endif
 
     private string getEnumMessage(string message, InteractionCallback values) {
       var callbackType = typeof(InteractionCallback);

--- a/Assets/LeapMotionTests/InteractionEngine/Scripts/SadisticTest.cs
+++ b/Assets/LeapMotionTests/InteractionEngine/Scripts/SadisticTest.cs
@@ -48,6 +48,8 @@ namespace Leap.Unity.Interaction.Testing {
       _testManager = GetComponentInParent<SadisticTestManager>();
 
       _manager.MaxActivationDepth = activationDepth;
+      _manager.ShowDebugLines = true;
+      _manager.ShowDebugOutput = true;
 
       current = this;
       allCallbacksRecieved = 0;

--- a/Assets/LeapMotionTests/InteractionEngine/Scripts/SadisticTest.cs
+++ b/Assets/LeapMotionTests/InteractionEngine/Scripts/SadisticTest.cs
@@ -117,6 +117,7 @@ namespace Leap.Unity.Interaction.Testing {
       }
 #if UNITY_EDITOR
       else {
+        // Show Gizmos for InteractionBrushBone.
         InteractionBrushBone[] bb = FindObjectsOfType(typeof(InteractionBrushBone)) as InteractionBrushBone[];
         GameObject[] objs = new GameObject[bb.Length];
          for(int i = 0; i < bb.Length; i++){


### PR DESCRIPTION
Transitions into soft contact when releasing an object, avoids unruly brush behavior.
Leaves objects in the layer they were using for soft contact when un-registering as that is safest.
Adds visualization the the coverage suite allowing it to be a debug tool.
There is a critical corresponding fix on the C++ this change pairs up with.