### PR TITLE
Fixing activation and waking bugs

### DIFF
--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/Editor/InteractionManagerEditor.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/Editor/InteractionManagerEditor.cs
@@ -88,11 +88,11 @@ namespace Leap.Unity.Interaction {
     private void providerDectorator(SerializedProperty prop) {
       var manager = target as InteractionManager;
 
-      if (Physics.defaultContactOffset > manager.RecomendedContactOffsetMaximum) {
+      if (Physics.defaultContactOffset > manager.RecommendedContactOffsetMaximum) {
         GUILayout.BeginHorizontal();
-        EditorGUILayout.HelpBox("The current default contact offset is " + Physics.defaultContactOffset + ", which is greater than the recomended value " + manager.RecomendedContactOffsetMaximum, MessageType.Warning);
+        EditorGUILayout.HelpBox("The current default contact offset is " + Physics.defaultContactOffset + ", which is greater than the recomended value " + manager.RecommendedContactOffsetMaximum, MessageType.Warning);
         if (GUILayout.Button("Auto-fix")) {
-          Physics.defaultContactOffset = manager.RecomendedContactOffsetMaximum;
+          Physics.defaultContactOffset = manager.RecommendedContactOffsetMaximum;
         }
         GUILayout.EndHorizontal();
       }

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/Editor/InteractionManagerEditor.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/Editor/InteractionManagerEditor.cs
@@ -86,11 +86,13 @@ namespace Leap.Unity.Interaction {
     }
 
     private void providerDectorator(SerializedProperty prop) {
-      if (Physics.defaultContactOffset > InteractionManager.RECOMENDED_CONTACT_OFFSET_MAXIMUM) {
+      var manager = target as InteractionManager;
+
+      if (Physics.defaultContactOffset > manager.RecomendedContactOffsetMaximum) {
         GUILayout.BeginHorizontal();
-        EditorGUILayout.HelpBox("The current default contact offset is " + Physics.defaultContactOffset + ", which is greater than the recomended value.", MessageType.Warning);
+        EditorGUILayout.HelpBox("The current default contact offset is " + Physics.defaultContactOffset + ", which is greater than the recomended value " + manager.RecomendedContactOffsetMaximum, MessageType.Warning);
         if (GUILayout.Button("Auto-fix")) {
-          Physics.defaultContactOffset = InteractionManager.RECOMENDED_CONTACT_OFFSET_MAXIMUM;
+          Physics.defaultContactOffset = manager.RecomendedContactOffsetMaximum;
         }
         GUILayout.EndHorizontal();
       }

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/Editor/InteractionManagerEditor.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/Editor/InteractionManagerEditor.cs
@@ -86,9 +86,19 @@ namespace Leap.Unity.Interaction {
     }
 
     private void providerDectorator(SerializedProperty prop) {
+      if (Physics.defaultContactOffset > InteractionManager.RECOMENDED_CONTACT_OFFSET_MAXIMUM) {
+        GUILayout.BeginHorizontal();
+        EditorGUILayout.HelpBox("The current default contact offset is " + Physics.defaultContactOffset + ", which is greater than the recomended value.", MessageType.Warning);
+        if (GUILayout.Button("Auto-fix")) {
+          Physics.defaultContactOffset = InteractionManager.RECOMENDED_CONTACT_OFFSET_MAXIMUM;
+        }
+        GUILayout.EndHorizontal();
+      }
+
       if (_anyBehavioursUnregistered) {
+        GUILayout.BeginHorizontal();
         EditorGUILayout.HelpBox("Some Interaction Behaviours do not have their manager assigned!  Do you want to assign them to this manager?", MessageType.Warning);
-        if (GUILayout.Button("Assign To This Manager")) {
+        if (GUILayout.Button("Auto-fix")) {
           for (int i = 0; i < _interactionBehaviours.Length; i++) {
             var behaviour = _interactionBehaviours[i];
             if (behaviour.Manager == null) {
@@ -98,7 +108,7 @@ namespace Leap.Unity.Interaction {
           }
           _anyBehavioursUnregistered = false;
         }
-        GUILayout.Space(EditorGUIUtility.singleLineHeight);
+        GUILayout.EndHorizontal();
       }
     }
 

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
@@ -540,10 +540,18 @@ namespace Leap.Unity.Interaction {
     }
 
     protected virtual void revertRigidbodyState() {
-      _rigidbody.useGravity = _useGravity;
-      _rigidbody.isKinematic = _isKinematic;
-      _rigidbody.drag = _drag;
-      _rigidbody.angularDrag = _angularDrag;
+      if (_rigidbody.useGravity != _useGravity) {
+        _rigidbody.useGravity = _useGravity;
+      }
+      if (_rigidbody.isKinematic != _isKinematic) {
+        _rigidbody.isKinematic = _isKinematic;
+      }
+      if (_rigidbody.drag != _drag) {
+        _rigidbody.drag = _drag;
+      }
+      if (_rigidbody.angularDrag != _angularDrag) {
+        _rigidbody.angularDrag = _angularDrag;
+      }
     }
 
     protected INTERACTION_TRANSFORM getRigidbodyTransform() {

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/ActivityMonitor.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/ActivityMonitor.cs
@@ -59,12 +59,19 @@ namespace Leap.Unity.Interaction {
       _manager = manager;
       Revive();
 
+      Rigidbody rigidbody = GetComponent<Rigidbody>();
+      bool wasSleeping = rigidbody.IsSleeping();
+
       //We need to do this in order to force Unity to reconsider collision callbacks for this object
       //Otherwise scripts added in the middle of a collision never recieve the Stay callbacks.
       Collider singleCollider = GetComponentInChildren<Collider>();
       if (singleCollider != null) {
         Physics.IgnoreCollision(singleCollider, singleCollider, true);
         Physics.IgnoreCollision(singleCollider, singleCollider, false);
+      }
+
+      if (wasSleeping) {
+        rigidbody.Sleep();
       }
     }
 

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
@@ -109,6 +109,8 @@ namespace Leap.Unity.Interaction {
     #endregion
 
     #region INTERNAL FIELDS
+    public const float RECOMENDED_CONTACT_OFFSET_MAXIMUM = 0.001f; //One milimeter
+
     protected INTERACTION_SCENE _scene;
     private bool _hasSceneBeenCreated = false;
     private bool _enableGraspingLast = false;

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
@@ -109,7 +109,7 @@ namespace Leap.Unity.Interaction {
     #endregion
 
     #region INTERNAL FIELDS
-    public const float RECOMENDED_CONTACT_OFFSET_MAXIMUM = 0.001f; //One milimeter
+    public const float RECOMENDED_CONTACT_OFFSET_MAXIMUM = 0.001f; //One millimeter
 
     protected INTERACTION_SCENE _scene;
     private bool _hasSceneBeenCreated = false;

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
@@ -130,6 +130,7 @@ namespace Leap.Unity.Interaction {
     protected Dictionary<int, InteractionHand> _idToInteractionHand = new Dictionary<int, InteractionHand>();
     protected List<IInteractionBehaviour> _graspedBehaviours = new List<IInteractionBehaviour>();
 
+    private float _cachedSimulationScale = -1;
     //A temp list that is recycled.  Used to remove items from _handIdToIeHand.
     private List<int> _handIdsToRemove = new List<int>();
     //A temp list that is recycled.  Used as the argument to OnHandsHold.
@@ -164,11 +165,19 @@ namespace Leap.Unity.Interaction {
 
     public float SimulationScale {
       get {
-        if (_leapProvider != null) {
-          return _leapProvider.transform.lossyScale.x;
+#if UNITY_EDITOR
+        if (Application.isPlaying) {
+          return _cachedSimulationScale;
         } else {
-          return 1;
+          if (_leapProvider != null) {
+            return _leapProvider.transform.lossyScale.x;
+          } else {
+            return 1;
+          }
         }
+#else
+        return _cachedSimulationScale;
+#endif
       }
     }
 
@@ -538,6 +547,8 @@ namespace Leap.Unity.Interaction {
       _shapeDescriptionPool = new ShapeDescriptionPool(_scene);
 
       Assert.AreEqual(_instanceHandleToBehaviour.Count, 0, "There should not be any instances before the creation step.");
+
+      _cachedSimulationScale = _leapProvider.transform.lossyScale.x;
 
       _activityManager.BrushLayer = InteractionBrushLayer;
       _activityManager.OverlapRadius = _activationRadius;

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
@@ -109,7 +109,12 @@ namespace Leap.Unity.Interaction {
     #endregion
 
     #region INTERNAL FIELDS
-    public const float RECOMENDED_CONTACT_OFFSET_MAXIMUM = 0.001f; //One millimeter
+    private const float UNSCALED_RECOMENDED_CONTACT_OFFSET_MAXIMUM = 0.001f; //One millimeter
+    public float RecomendedContactOffsetMaximum {
+      get {
+        return UNSCALED_RECOMENDED_CONTACT_OFFSET_MAXIMUM * SimulationScale;
+      }
+    }
 
     protected INTERACTION_SCENE _scene;
     private bool _hasSceneBeenCreated = false;
@@ -125,7 +130,6 @@ namespace Leap.Unity.Interaction {
     protected Dictionary<int, InteractionHand> _idToInteractionHand = new Dictionary<int, InteractionHand>();
     protected List<IInteractionBehaviour> _graspedBehaviours = new List<IInteractionBehaviour>();
 
-    private float _cachedSimulationScale = 1;
     //A temp list that is recycled.  Used to remove items from _handIdToIeHand.
     private List<int> _handIdsToRemove = new List<int>();
     //A temp list that is recycled.  Used as the argument to OnHandsHold.
@@ -160,7 +164,11 @@ namespace Leap.Unity.Interaction {
 
     public float SimulationScale {
       get {
-        return _cachedSimulationScale;
+        if (_leapProvider != null) {
+          return _leapProvider.transform.lossyScale.x;
+        } else {
+          return 1;
+        }
       }
     }
 

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
@@ -109,10 +109,10 @@ namespace Leap.Unity.Interaction {
     #endregion
 
     #region INTERNAL FIELDS
-    private const float UNSCALED_RECOMENDED_CONTACT_OFFSET_MAXIMUM = 0.001f; //One millimeter
-    public float RecomendedContactOffsetMaximum {
+    private const float UNSCALED_RECOMMENDED_CONTACT_OFFSET_MAXIMUM = 0.001f; //One millimeter
+    public float RecommendedContactOffsetMaximum {
       get {
-        return UNSCALED_RECOMENDED_CONTACT_OFFSET_MAXIMUM * SimulationScale;
+        return UNSCALED_RECOMMENDED_CONTACT_OFFSET_MAXIMUM * SimulationScale;
       }
     }
 

--- a/ProjectSettings/DynamicsManager.asset
+++ b/ProjectSettings/DynamicsManager.asset
@@ -8,8 +8,9 @@ PhysicsManager:
   m_DefaultMaterial: {fileID: 0}
   m_BounceThreshold: 0.05
   m_SleepThreshold: 0.005
-  m_DefaultContactOffset: 0.01
+  m_DefaultContactOffset: 0.001
   m_SolverIterationCount: 20
+  m_SolverVelocityIterations: 1
   m_QueriesHitTriggers: 1
   m_EnableAdaptiveForce: 0
   m_LayerCollisionMatrix: ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff


### PR DESCRIPTION
 - InteractionBehaviour will no longer wake it's rigidbody when being deactivated.
 - ActivityMonitor will no longer wake it's rigidbody when it is activated
 - InteractionManager now displays a warning when the contact offset is greater than the recommended value.
 - Updated global project settings to use recommended contact offset
 - Actually calculate simulation scale (was just always 1)
 - Scale recommended value by simulation scale correctly

@ajohnston33 
