### PR TITLE
Added angle for release condition

### DIFF
--- a/Assets/LeapMotionModules/InteractionEngine/InteractionMaterials/Default.asset
+++ b/Assets/LeapMotionModules/InteractionEngine/InteractionMaterials/Default.asset
@@ -16,6 +16,7 @@ MonoBehaviour:
   _physicMaterialMode: 1
   _replacementMaterial: {fileID: 0}
   _releaseDistance: 0.15
+  _releaseAngle: 45
   _warpingEnabled: 1
   _warpCurve:
     serializedVersion: 2

--- a/Assets/LeapMotionModules/InteractionEngine/InteractionMaterials/Default.asset
+++ b/Assets/LeapMotionModules/InteractionEngine/InteractionMaterials/Default.asset
@@ -16,7 +16,7 @@ MonoBehaviour:
   _physicMaterialMode: 1
   _replacementMaterial: {fileID: 0}
   _releaseDistance: 0.15
-  _releaseAngle: 45
+  _releaseAngle: 180
   _warpingEnabled: 1
   _warpCurve:
     serializedVersion: 2

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
@@ -211,7 +211,8 @@ namespace Leap.Unity.Interaction {
 
 #if UNITY_EDITOR
       if (_contactMode == ContactMode.GRASPED && UntrackedHandCount == 0 &&
-          Vector3.Distance(_solvedPosition, _warper.RigidbodyPosition) > _material.ReleaseDistance * _manager.SimulationScale) {
+          Vector3.Distance(_solvedPosition, _warper.RigidbodyPosition) > _material.ReleaseDistance * _manager.SimulationScale ||
+          Quaternion.Angle(_solvedRotation, _warper.RigidbodyRotation) > _material.ReleaseAngle) {
         _manager.ReleaseObject(this);
       }
 #endif

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionMaterial.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionMaterial.cs
@@ -62,6 +62,7 @@ namespace Leap.Unity.Interaction {
                                                              new Keyframe(0.02f, 0.0f, 0.0f, 0.0f));
 
     [Tooltip("How long it takes for the graphical anchor to return to the origin after a release.")]
+    [MinValue(0)]
     [SerializeField]
     protected float _graphicalReturnTime = 0.25f;
 

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionMaterial.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionMaterial.cs
@@ -4,6 +4,7 @@ using UnityEditor;
 #endif
 using System;
 using System.IO;
+using Leap.Unity.Attributes;
 
 namespace Leap.Unity.Interaction {
 
@@ -28,6 +29,7 @@ namespace Leap.Unity.Interaction {
     [SerializeField]
     protected bool _contactEnabled = true;
 
+    [MinValue(0)]
     [SerializeField]
     protected float _brushDisableDistance = 0.017f;
 
@@ -41,8 +43,14 @@ namespace Leap.Unity.Interaction {
 
     [Header("Grasp Settings")]
     [Tooltip("How far the object can get from the hand before it is released.")]
+    [MinValue(0)]
     [SerializeField]
     protected float _releaseDistance = 0.15f;
+
+    [Tooltip("How far the object can rotate out of the hand before it is released.  At 180 degrees release due to rotation is impossible.")]
+    [Range(0, 180)]
+    [SerializeField]
+    protected float _releaseAngle = 45;
 
     [Tooltip("Can objects using this material warp the graphical anchor through time to reduce percieved latency.")]
     [SerializeField]
@@ -112,6 +120,12 @@ namespace Leap.Unity.Interaction {
     public float ReleaseDistance {
       get {
         return _releaseDistance;
+      }
+    }
+
+    public float ReleaseAngle {
+      get {
+        return _releaseAngle;
       }
     }
 


### PR DESCRIPTION
Added angle to the release condition.  If the angle between the goal position and the actual position is too great, force the object to be released.  This is to help prevent weirdness when smacking objects against the floor, especially long plank-like objects.

@ajohnston33 