### PR TITLE
Gizmo front buffer protection

### DIFF
--- a/Assets/LeapMotion/Scripts/Utils/RuntimeGizmoManager.cs
+++ b/Assets/LeapMotion/Scripts/Utils/RuntimeGizmoManager.cs
@@ -331,6 +331,7 @@ namespace Leap.Unity.RuntimeGizmos {
 
     private bool _isInWireMode = false;
     private Material _gizmoMaterial;
+    private int _operationCountOnGuard = -1;
 
     public Shader gizmoShader {
       get {
@@ -352,6 +353,29 @@ namespace Leap.Unity.RuntimeGizmos {
     }
 
     public Mesh cubeMesh, wireCubeMesh, sphereMesh, wireSphereMesh;
+
+    /// <summary>
+    /// Begins a draw-guard.  If any gizmos are drawn to this drawer an exception will be thrown at the end of the guard.
+    /// </summary>
+    public void BeginGuard() {
+      if (_operationCountOnGuard != -1) {
+        throw new Exception("Cannot lock this drawer because it is already locked.");
+      }
+      _operationCountOnGuard = _operations.Count;
+    }
+
+    /// <summary>
+    /// Ends a draw-guard.  If any gizmos were drawn to this drawer during the guard, an exception will be thrown.
+    /// </summary>
+    public void EndGuard() {
+      if (_operationCountOnGuard == -1) {
+        throw new Exception("Cannot unlock this drawer because it is already unlocked.");
+      }
+      if (_operations.Count != _operationCountOnGuard) {
+        throw new Exception("New gizmos were drawn to the front buffer!  Make sure to never keep a reference to a Drawer, always get a new one every time you want to start drawing.");
+      }
+      _operationCountOnGuard = -1;
+    }
 
     /// <summary>
     /// Causes all remaining gizmos drawing to be done in the local coordinate space of the given transform.

--- a/Assets/LeapMotion/Scripts/Utils/RuntimeGizmoManager.cs
+++ b/Assets/LeapMotion/Scripts/Utils/RuntimeGizmoManager.cs
@@ -41,6 +41,12 @@ namespace Leap.Unity.RuntimeGizmos {
     private bool _readyForSwap = false;
 
     /// <summary>
+    /// Subscribe to this event if you want to draw gizmos after rendering is complete.  Doing gizmo
+    /// rendering inside of the normal Camera.onPoseRender event will cause rendering artifacts.
+    /// </summary>
+    public static event Action<RuntimeGizmoDrawer> OnPostRenderGizmos;
+
+    /// <summary>
     /// Tries to get a gizmo drawer.  Will fail if there is no Gizmo manager in the 
     /// scene, or if it is disabled.
     /// 
@@ -175,6 +181,11 @@ namespace Leap.Unity.RuntimeGizmos {
 #endif
 
       if (_readyForSwap) {
+        if (OnPostRenderGizmos != null) {
+          _backDrawer.ResetMatrixAndColorState();
+          OnPostRenderGizmos(_backDrawer);
+        }
+
         RuntimeGizmoDrawer tempDrawer = _backDrawer;
         _backDrawer = _frontDrawer;
         _frontDrawer = tempDrawer;

--- a/Assets/LeapMotion/Scripts/Utils/RuntimeGizmoManager.cs
+++ b/Assets/LeapMotion/Scripts/Utils/RuntimeGizmoManager.cs
@@ -179,6 +179,12 @@ namespace Leap.Unity.RuntimeGizmos {
 
         _readyForSwap = false;
         _backDrawer.ClearAllGizmos();
+
+        //Guard the front drawer for rendering
+        _frontDrawer.BeginGuard();
+
+        //Unguard the back drawer to allow gizmos to be drawn to it
+        _backDrawer.EndGuard();
       }
 
       _frontDrawer.DrawAllGizmosToScreen();


### PR DESCRIPTION
Protect the front buffer with a guard while it is being used for rendering.  This allows us to catch issues where people are holding onto references to drawers.

To test:
 - [x] Everything should still work without errors normally
 - [x] When holding onto a reference to a drawer, you should get an error

@jselstad 