### PR TITLE
Catching explosions for active interaction objects

### DIFF
--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
@@ -1,11 +1,8 @@
 ﻿
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Assertions;
 using Leap.Unity.Interaction.CApi;
-using LeapInternal;
 
 namespace Leap.Unity.Interaction {
 
@@ -146,6 +143,16 @@ namespace Leap.Unity.Interaction {
     }
 
     /// <summary>
+    /// Gets whether or not this InteractionBehaviour was teleported this frame or not.  Is set to true when
+    /// NotiftyTeleported is called, and reset to false once the interaction solve has completed.
+    /// </summary>
+    public bool WasTeleported {
+      get {
+        return _notifiedOfTeleport;
+      }
+    }
+
+    /// <summary>
     /// Adds a linear acceleration to the center of mass of this object.  Use this instead of Rigidbody.AddForce()
     /// </summary>
     public void AddLinearAcceleration(Vector3 acceleration) {
@@ -203,9 +210,8 @@ namespace Leap.Unity.Interaction {
 
     protected override void OnPreSolve() {
       base.OnPreSolve();
-
       _recievedVelocityUpdate = false;
-      _notifiedOfTeleport = false;
+      
       ++_dislocatedBrushCounter;
       _minHandDistance = float.MaxValue;
 
@@ -259,6 +265,7 @@ namespace Leap.Unity.Interaction {
       _accumulatedLinearAcceleration = Vector3.zero;
       _accumulatedAngularAcceleration = Vector3.zero;
       _minHandDistance = float.MaxValue;
+      _notifiedOfTeleport = false;
     }
 
     public override void GetInteractionShapeCreationInfo(out INTERACTION_CREATE_SHAPE_INFO createInfo, out INTERACTION_TRANSFORM createTransform) {

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/ActivityManager.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/ActivityManager.cs
@@ -98,7 +98,7 @@ namespace Leap.Unity.Interaction {
       if (_registeredBehaviours.TryGetValue(interactionBehaviour, out monitor)) {
         if (monitor == null) {
           if (_maxDepth == 1) {
-            monitor = new ActivityMonitorLite();
+            monitor = interactionBehaviour.gameObject.AddComponent<ActivityMonitorLite>();
           } else {
             monitor = interactionBehaviour.gameObject.AddComponent<ActivityMonitor>();
           }
@@ -134,9 +134,7 @@ namespace Leap.Unity.Interaction {
           _activeBehaviours.RemoveAt(_activeBehaviours.Count - 1);
 
           _registeredBehaviours[interactionBehaviour] = null;
-          if (monitor is UnityEngine.Object) {
-            UnityEngine.Object.Destroy(monitor as UnityEngine.Object);
-          }
+          UnityEngine.Object.Destroy(monitor);
 
           if (OnDeactivate != null) {
             OnDeactivate(interactionBehaviour);

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/ActivityMonitor.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/ActivityMonitor.cs
@@ -56,6 +56,10 @@ namespace Leap.Unity.Interaction {
         }
 
         if (didExplode) {
+          Debug.LogWarning("Explosion was detected!  Object " + gameObject + " has been reset to its previous state.  If this was " +
+                           "intentional movement, make sure you have called NotifyTeleported on the InteractionBehaviour, or raise " +
+                           "the explosion velocity threshold.");
+
           _rigidbody.velocity = _prevVelocity;
           _rigidbody.angularVelocity = _prevAngularVelocity;
           _rigidbody.position = _rigidbody.position + _rigidbody.velocity * Time.fixedDeltaTime;

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/ActivityMonitor.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/ActivityMonitor.cs
@@ -4,19 +4,23 @@ using Leap.Unity.RuntimeGizmos;
 namespace Leap.Unity.Interaction {
 
   public abstract class IActivityMonitor : MonoBehaviour {
+    public static GizmoType gizmoType = GizmoType.ActivityDepth;
+    public static float explosionVelocity = 100;
+    public static int hysteresisTimeout = 5;
+
     public abstract void Init(IInteractionBehaviour interactionBehaviour, ActivityManager manager);
     public abstract void Revive();
     public abstract void UpdateState();
 
     public int arrayIndex;
+
+    public enum GizmoType {
+      InteractionStatus,
+      ActivityDepth
+    }
   }
 
   public class ActivityMonitorLite : IActivityMonitor, IRuntimeGizmoComponent {
-    public static GizmoType gizmoType = GizmoType.ActivityDepth;
-
-    public const float EXPLOSION_VELOCITY = 100;
-    public const int HYSTERESIS_TIMEOUT = 5;
-
     protected Rigidbody _rigidbody;
     protected IInteractionBehaviour _interactionBehaviour;
     protected ActivityManager _manager;
@@ -43,7 +47,7 @@ namespace Leap.Unity.Interaction {
 
     public override void UpdateState() {
       if (_rigidbody.isKinematic) {
-        if ((_rigidbody.position - _prevPosition).sqrMagnitude / Time.fixedDeltaTime >= EXPLOSION_VELOCITY * EXPLOSION_VELOCITY) {
+        if ((_rigidbody.position - _prevPosition).sqrMagnitude / Time.fixedDeltaTime >= explosionVelocity * explosionVelocity) {
           _rigidbody.velocity = _prevVelocity;
           _rigidbody.angularVelocity = _prevAngularVelocity;
           _rigidbody.position = _rigidbody.position + _rigidbody.velocity * Time.fixedDeltaTime;
@@ -65,7 +69,7 @@ namespace Leap.Unity.Interaction {
         --_timeToLive;
         _timeToDie = 0;
       } else {
-        if (_interactionBehaviour.IsAbleToBeDeactivated() && ++_timeToDie >= HYSTERESIS_TIMEOUT) {
+        if (_interactionBehaviour.IsAbleToBeDeactivated() && ++_timeToDie >= hysteresisTimeout) {
           _manager.Deactivate(_interactionBehaviour);
         }
       }
@@ -88,11 +92,6 @@ namespace Leap.Unity.Interaction {
       }
 
       drawer.DrawColliders(gameObject);
-    }
-
-    public enum GizmoType {
-      InteractionStatus,
-      ActivityDepth
     }
   }
 

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/ActivityMonitor.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/ActivityMonitor.cs
@@ -27,6 +27,7 @@ namespace Leap.Unity.Interaction {
 
     // For explosion protection
     protected Vector3 _prevPosition;
+    protected Quaternion _prevRotation;
     protected Vector3 _prevVelocity;
     protected Vector3 _prevAngularVelocity;
 
@@ -62,12 +63,13 @@ namespace Leap.Unity.Interaction {
 
           _rigidbody.velocity = _prevVelocity;
           _rigidbody.angularVelocity = _prevAngularVelocity;
-          _rigidbody.position = _rigidbody.position + _rigidbody.velocity * Time.fixedDeltaTime;
-          _rigidbody.rotation = _rigidbody.rotation;
+          _rigidbody.position = _prevPosition + _rigidbody.velocity * Time.fixedDeltaTime;
+          _rigidbody.rotation = _prevRotation;
         }
       }
 
       _prevPosition = _rigidbody.position;
+      _prevRotation = _rigidbody.rotation;
       _prevVelocity = _rigidbody.velocity;
       _prevAngularVelocity = _rigidbody.angularVelocity;
 

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/ActivityMonitor.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/ActivityMonitor.cs
@@ -47,7 +47,15 @@ namespace Leap.Unity.Interaction {
 
     public override void UpdateState() {
       if (!_rigidbody.isKinematic) {
-        if ((_rigidbody.position - _prevPosition).sqrMagnitude / Time.fixedDeltaTime >= explosionVelocity * explosionVelocity) {
+        bool didExplode = (_rigidbody.position - _prevPosition).sqrMagnitude / Time.fixedDeltaTime >= explosionVelocity * explosionVelocity;
+
+        if (_interactionBehaviour is InteractionBehaviour) {
+          if ((_interactionBehaviour as InteractionBehaviour).WasTeleported) {
+            didExplode = false;
+          }
+        }
+
+        if (didExplode) {
           _rigidbody.velocity = _prevVelocity;
           _rigidbody.angularVelocity = _prevAngularVelocity;
           _rigidbody.position = _rigidbody.position + _rigidbody.velocity * Time.fixedDeltaTime;

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/ActivityMonitor.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/ActivityMonitor.cs
@@ -1,6 +1,5 @@
 ﻿using UnityEngine;
 using Leap.Unity.RuntimeGizmos;
-using System;
 
 namespace Leap.Unity.Interaction {
 

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/ActivityMonitor.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/ActivityMonitor.cs
@@ -5,8 +5,8 @@ namespace Leap.Unity.Interaction {
 
   public abstract class IActivityMonitor : MonoBehaviour {
     public static GizmoType gizmoType = GizmoType.ActivityDepth;
-    public static float explosionVelocity = 100;
-    public static int hysteresisTimeout = 5;
+    public static float explosionVelocity = 100;                   //In meters per second
+    public static int hysteresisTimeout = 5;                       //In fixed frames
 
     public abstract void Init(IInteractionBehaviour interactionBehaviour, ActivityManager manager);
     public abstract void Revive();
@@ -46,7 +46,7 @@ namespace Leap.Unity.Interaction {
     }
 
     public override void UpdateState() {
-      if (_rigidbody.isKinematic) {
+      if (!_rigidbody.isKinematic) {
         if ((_rigidbody.position - _prevPosition).sqrMagnitude / Time.fixedDeltaTime >= explosionVelocity * explosionVelocity) {
           _rigidbody.velocity = _prevVelocity;
           _rigidbody.angularVelocity = _prevAngularVelocity;

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/ActivityMonitor.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/ActivityMonitor.cs
@@ -4,43 +4,15 @@ using System;
 
 namespace Leap.Unity.Interaction {
 
-  public interface IActivityMonitor {
-    void Init(IInteractionBehaviour interactionBehaviour, ActivityManager manager);
-    void Revive();
-    void UpdateState();
+  public abstract class IActivityMonitor : MonoBehaviour {
+    public abstract void Init(IInteractionBehaviour interactionBehaviour, ActivityManager manager);
+    public abstract void Revive();
+    public abstract void UpdateState();
 
-    int arrayIndex { get; set; }
+    public int arrayIndex;
   }
 
-  public class ActivityMonitorLite : IActivityMonitor {
-    public const int HYSTERESIS_TIMEOUT = 5;
-
-    public int arrayIndex { get; set; }
-
-    private IInteractionBehaviour _interactionBehaviour;
-    private ActivityManager _manager;
-    private int _timeToLive = 1;
-
-    public void Init(IInteractionBehaviour interactionBehaviour, ActivityManager manager) {
-      _interactionBehaviour = interactionBehaviour;
-      _manager = manager;
-    }
-
-    public void Revive() {
-      _timeToLive = 1;
-    }
-
-    public void UpdateState() {
-      _timeToLive--;
-      if (_interactionBehaviour.IsAbleToBeDeactivated() && _timeToLive == -HYSTERESIS_TIMEOUT) {
-        _manager.Deactivate(_interactionBehaviour);
-      }
-    }
-  }
-
-  public class ActivityMonitor : MonoBehaviour, IActivityMonitor, IRuntimeGizmoComponent {
-    public const int HYSTERESIS_TIMEOUT = 5;
-
+  public class ActivityMonitorLite : IActivityMonitor, IRuntimeGizmoComponent {
     public enum GizmoType {
       InteractionStatus,
       ActivityDepth
@@ -48,42 +20,28 @@ namespace Leap.Unity.Interaction {
 
     public static GizmoType gizmoType = GizmoType.ActivityDepth;
 
-    // Caches index into ActivityManager array.
-    public int arrayIndex { get; set; }
+    public const int HYSTERESIS_TIMEOUT = 5;
 
-    private IInteractionBehaviour _interactionBehaviour;
-    private ActivityManager _manager;
-    private int _timeToLive = 0; // Converges to remaining allowed distance to hands across contact graph.
-    private int _timeToDie = 0;  // Timer after _timeToLive goes negative before deactivation.
+    protected Rigidbody _rigidbody;
+    protected IInteractionBehaviour _interactionBehaviour;
+    protected ActivityManager _manager;
 
-    public void Init(IInteractionBehaviour interactionBehaviour, ActivityManager manager) {
+    protected int _timeToLive = 1;
+    protected int _timeToDie = 0;  // Timer after _timeToLive goes negative before deactivation.
+
+    public override void Init(IInteractionBehaviour interactionBehaviour, ActivityManager manager) {
       _interactionBehaviour = interactionBehaviour;
       _manager = manager;
       Revive();
 
-      Rigidbody rigidbody = GetComponent<Rigidbody>();
-      bool wasSleeping = rigidbody.IsSleeping();
-
-      //We need to do this in order to force Unity to reconsider collision callbacks for this object
-      //Otherwise scripts added in the middle of a collision never recieve the Stay callbacks.
-      Collider singleCollider = GetComponentInChildren<Collider>();
-      if (singleCollider != null) {
-        Physics.IgnoreCollision(singleCollider, singleCollider, true);
-        Physics.IgnoreCollision(singleCollider, singleCollider, false);
-      }
-
-      if (wasSleeping) {
-        rigidbody.Sleep();
-      }
+      _rigidbody = GetComponent<Rigidbody>();
     }
 
-    public void Revive() {
-      // This has a contact graph distance of 0 from the hands.
-      _timeToLive = _manager.MaxDepth;
+    public override void Revive() {
+      _timeToLive = 1;
     }
 
-    public void UpdateState() {
-
+    public override void UpdateState() {
       // Grasped objects do not intersect the brush layer but are still touching hands.
       if (_interactionBehaviour.IsBeingGrasped) {
         Revive();
@@ -97,6 +55,46 @@ namespace Leap.Unity.Interaction {
         if (_interactionBehaviour.IsAbleToBeDeactivated() && ++_timeToDie >= HYSTERESIS_TIMEOUT) {
           _manager.Deactivate(_interactionBehaviour);
         }
+      }
+    }
+
+    public void OnDrawRuntimeGizmos(RuntimeGizmoDrawer drawer) {
+      switch (gizmoType) {
+        case GizmoType.InteractionStatus:
+          if (_interactionBehaviour.IsBeingGrasped) {
+            drawer.color = Color.green;
+          } else if (GetComponent<Rigidbody>().IsSleeping()) {
+            drawer.color = Color.gray;
+          } else {
+            drawer.color = Color.blue;
+          }
+          break;
+        case GizmoType.ActivityDepth:
+          drawer.color = Color.HSVToRGB(Mathf.Max(0, _timeToLive) / (_manager.MaxDepth * 2.0f), 1, 1);
+          break;
+      }
+
+      drawer.DrawColliders(gameObject);
+    }
+  }
+
+  public class ActivityMonitor : ActivityMonitorLite {
+
+    public override void Init(IInteractionBehaviour interactionBehaviour, ActivityManager manager) {
+      base.Init(interactionBehaviour, manager);
+
+      bool wasSleeping = _rigidbody.IsSleeping();
+
+      //We need to do this in order to force Unity to reconsider collision callbacks for this object
+      //Otherwise scripts added in the middle of a collision never recieve the Stay callbacks.
+      Collider singleCollider = GetComponentInChildren<Collider>();
+      if (singleCollider != null) {
+        Physics.IgnoreCollision(singleCollider, singleCollider, true);
+        Physics.IgnoreCollision(singleCollider, singleCollider, false);
+      }
+
+      if (wasSleeping) {
+        _rigidbody.Sleep();
       }
     }
 
@@ -147,25 +145,6 @@ namespace Leap.Unity.Interaction {
       } else if (neighbor._timeToLive < nextTime) {
         neighbor._timeToLive = nextTime;
       }
-    }
-
-    public void OnDrawRuntimeGizmos(RuntimeGizmoDrawer drawer) {
-      switch (gizmoType) {
-        case GizmoType.InteractionStatus:
-          if (_interactionBehaviour.IsBeingGrasped) {
-            drawer.color = Color.green;
-          } else if (GetComponent<Rigidbody>().IsSleeping()) {
-            drawer.color = Color.gray;
-          } else {
-            drawer.color = Color.blue;
-          }
-          break;
-        case GizmoType.ActivityDepth:
-          drawer.color = Color.HSVToRGB(Mathf.Max(0, _timeToLive) / (_manager.MaxDepth * 2.0f), 1, 1);
-          break;
-      }
-
-      drawer.DrawColliders(gameObject);
     }
   }
 }


### PR DESCRIPTION
 - Activity monitor is now always a component (still split into lite and non-lite though)
 - Teleportation information is now surfaces for InteractionBehaviour
 - Activity monitor now checks for explosions and resets the state of the rigidbody if one is detected

@ajohnston33 