### PR TITLE
Add root transform to Transition

### DIFF
--- a/Assets/LeapMotionModules/Attachments/Prefabs/Transition.prefab
+++ b/Assets/LeapMotionModules/Attachments/Prefabs/Transition.prefab
@@ -1,0 +1,167 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1001 &100100000
+Prefab:
+  m_ObjectHideFlags: 1
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications: []
+    m_RemovedComponents: []
+  m_ParentPrefab: {fileID: 0}
+  m_RootGameObject: {fileID: 1000012773167890}
+  m_IsPrefabParent: 1
+--- !u!1 &1000012773167890
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  serializedVersion: 4
+  m_Component:
+  - 4: {fileID: 4000012721778902}
+  - 114: {fileID: 114000012958230866}
+  m_Layer: 0
+  m_Name: Transition
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4000012721778902
+Transform:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000012773167890}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+--- !u!114 &114000012958230866
+MonoBehaviour:
+  m_ObjectHideFlags: 1
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 100100000}
+  m_GameObject: {fileID: 1000012773167890}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 42ec888eb3a604057baa929f141f9535, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  RootTransform: {fileID: 4000012721778902}
+  AnimatePosition: 0
+  OnPosition: {x: 0, y: 0, z: 0}
+  OffPosition: {x: 0, y: 0, z: 0}
+  PositionCurve:
+    serializedVersion: 2
+    m_Curve:
+    - time: -1
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    - time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    - time: 1
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  AnimateRotation: 0
+  OnRotation: {x: 0, y: 0, z: 0}
+  OffRotation: {x: 0, y: 0, z: 0}
+  RotationCurve:
+    serializedVersion: 2
+    m_Curve:
+    - time: -1
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    - time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    - time: 1
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  AnimateScale: 0
+  OnScale: {x: 1, y: 1, z: 1}
+  OffScale: {x: 1, y: 1, z: 1}
+  ScaleCurve:
+    serializedVersion: 2
+    m_Curve:
+    - time: -1
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    - time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    - time: 1
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  AnimateColor: 0
+  ColorShaderPropertyName: _Color
+  TransitionColor: {r: 0, g: 0, b: 0, a: 1}
+  ColorCurve:
+    serializedVersion: 2
+    m_Curve:
+    - time: -1
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    - time: 0
+      value: 0
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    - time: 1
+      value: 1
+      inSlope: 0
+      outSlope: 0
+      tangentMode: 0
+    m_PreInfinity: 2
+    m_PostInfinity: 2
+    m_RotationOrder: 4
+  Duration: 0.5
+  Simulate: 0
+  _onStart:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine, Version=0.0.0.0, Culture=neutral,
+      PublicKeyToken=null
+  _onAnimationStep:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: Leap.Unity.Attachments.AnimationStepEvent, Assembly-CSharp, Version=0.0.0.0,
+      Culture=neutral, PublicKeyToken=null
+  _onComplete:
+    m_PersistentCalls:
+      m_Calls: []
+    m_TypeName: UnityEngine.Events.UnityEvent, UnityEngine, Version=0.0.0.0, Culture=neutral,
+      PublicKeyToken=null

--- a/Assets/LeapMotionModules/Attachments/Prefabs/Transition.prefab.meta
+++ b/Assets/LeapMotionModules/Attachments/Prefabs/Transition.prefab.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6fcd05e9de26ca64495cfa7ee77fa403
+timeCreated: 1471281080
+licenseType: Free
+NativeFormatImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapMotionModules/Attachments/Scripts/AttachmentController.cs
+++ b/Assets/LeapMotionModules/Attachments/Scripts/AttachmentController.cs
@@ -49,7 +49,7 @@ namespace Leap.Unity.Attachments {
      *  @since 4.1.1
      */
     [Tooltip("The transition to play when this attachment controller activates or deactivates")]
-    public Transition Transition;
+    public ITransition Transition;
 
     /**
      * Activates the attachment's child object.

--- a/Assets/LeapMotionModules/Attachments/Scripts/AttachmentController.cs
+++ b/Assets/LeapMotionModules/Attachments/Scripts/AttachmentController.cs
@@ -35,14 +35,6 @@ namespace Leap.Unity.Attachments {
       }
     }
     private bool _isActive = false;
-    /**
-    * Activate child objects when the attachment is enabled.
-    * When true, attached objects are enabled and activated when the 
-    * hand appears.
-    * @since 4.1.3
-    */
-    [Tooltip("Activate child objects automatically without playing a transition")]
-    public bool ActivateOnEnable = false;
 
     /**
     * Deactivate child objects when the attachment is disabled.
@@ -68,7 +60,7 @@ namespace Leap.Unity.Attachments {
       IsActive = true;
       ChangeChildState();
       if (Transition != null && doTransition) {
-        Transition.OnComplete.AddListener(ChangeChildState);
+        Transition.OnComplete.AddListener(FinishInTransition);
         Transition.TransitionIn();
       }
     }
@@ -80,16 +72,33 @@ namespace Leap.Unity.Attachments {
      */
     public virtual void Deactivate(bool doTransition = true) {
       IsActive = false;
-      if(Transition != null) {
-        if (doTransition) {
-          Transition.OnComplete.AddListener(ChangeChildState);
+      if(Transition != null && doTransition) {
+          Transition.OnComplete.AddListener(FinishOutTransition);
           Transition.TransitionOut();
-        } else {
-          ChangeChildState();
-        }
       } else {
         ChangeChildState();
       }
+    }
+
+    /**
+    * Performs post-transition tasks after an "in" transition.
+    * @since 4.1.4
+    */
+    protected virtual void FinishInTransition() {
+      if (Transition != null) {
+        Transition.OnComplete.RemoveListener(FinishInTransition);
+      }
+    }
+
+    /**
+    * Performs post-transition tasks after an "out" transition.
+    * @since 4.1.4
+    */
+    protected virtual void FinishOutTransition() {
+      if (Transition != null) {
+        Transition.OnComplete.RemoveListener(FinishOutTransition);
+      }
+      ChangeChildState();
     }
 
     /**
@@ -97,9 +106,6 @@ namespace Leap.Unity.Attachments {
      *  @since 4.1.1
      */
     protected virtual void ChangeChildState(){
-      if(Transition != null){
-        Transition.OnComplete.RemoveListener(ChangeChildState);
-      }
       Transform[] children = GetComponentsInChildren<Transform>(true);
       for(int g = 0; g < children.Length; g++){
         if ( children[g].gameObject.GetInstanceID() != gameObject.GetInstanceID() ) {
@@ -113,9 +119,5 @@ namespace Leap.Unity.Attachments {
         Deactivate(false);
     }
 
-    private void OnEnable() {
-      if (ActivateOnEnable)
-        Activate(false);
-     }
   }
 }

--- a/Assets/LeapMotionModules/Attachments/Scripts/ITransition.cs
+++ b/Assets/LeapMotionModules/Attachments/Scripts/ITransition.cs
@@ -1,0 +1,34 @@
+﻿using UnityEngine;
+using UnityEngine.Events;
+
+namespace Leap.Unity.Attachments {
+  /**
+  * Defines the interface used by AttachmentController to play transitions
+  * when it activates and deactivates attachments. This interface is implemented
+  * by the Transition class.
+  * 
+  * When implementing your own transition class, TransitionIn() and TransitionOut()
+  * must invoke the OnStart event when the transition begins, the OnAnimationStep
+  * event as the transition proceeds, and the OnComplete event when the transition
+  * is finished.  
+  * @since 4.1.4
+  */
+  public abstract class ITransition : MonoBehaviour {
+    public abstract void TransitionIn();
+    public abstract void TransitionOut();
+    public abstract UnityEvent OnStart { get; set; }
+    public abstract AnimationStepEvent OnAnimationStep { get; set; }
+    public abstract UnityEvent OnComplete { get; set; }
+  }
+
+  /**
+  * An event class that is dispatched by a Transition for each animation
+  * step during a transition. The event occurs once per frame for the duration of
+  * a transition.
+  * The event parameter provides the current interpolation value between -1 and 0 for an
+  * in transition and between 0 and +1 for an out transition..
+  * @since 4.1.4
+  */
+  [System.Serializable]
+  public class AnimationStepEvent : UnityEvent<float> { }
+}

--- a/Assets/LeapMotionModules/Attachments/Scripts/ITransition.cs.meta
+++ b/Assets/LeapMotionModules/Attachments/Scripts/ITransition.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: d5750f2aa116fab4ea4ec2db1d57515f
+timeCreated: 1471046106
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapMotionModules/Attachments/Scripts/Transition.cs
+++ b/Assets/LeapMotionModules/Attachments/Scripts/Transition.cs
@@ -29,6 +29,8 @@ namespace Leap.Unity.Attachments{
   [ExecuteInEditMode]
   public class Transition : MonoBehaviour {
 
+    public Transform RootTransform;
+
     /**
     * Specifies whether to animate position.
     * The position of the Transition game object is animated. Any child objects maintain their
@@ -232,12 +234,16 @@ namespace Leap.Unity.Attachments{
 #if UNITY_EDITOR
     private void Update() {
       if (!EditorApplication.isPlaying) {
+        if (RootTransform == null)
+          RootTransform = transform;
         updateTransition(Simulate);
       }
     }
   #endif
   
     private void Awake(){
+      if (RootTransform == null)
+        RootTransform = transform;
       materialProperties = new MaterialPropertyBlock();
       updateTransition(0.0f);
     }
@@ -247,7 +253,7 @@ namespace Leap.Unity.Attachments{
     * @since 4.1.4
     */
     public void TransitionIn(){
-      if (isActiveAndEnabled) {
+      if (isActiveAndEnabled && gameObject.activeInHierarchy) {
         OnStart.Invoke();
         StopAllCoroutines();
         StartCoroutine(transitionIn());
@@ -259,7 +265,7 @@ namespace Leap.Unity.Attachments{
     * @since 4.1.4
     */
     public void TransitionOut(){
-      if (isActiveAndEnabled) {
+      if (isActiveAndEnabled && gameObject.activeInHierarchy) {
         OnStart.Invoke();
         StopAllCoroutines();
         StartCoroutine(transitionOut());
@@ -314,7 +320,7 @@ namespace Leap.Unity.Attachments{
     * @since 4.1.4
     */
     protected virtual void doAnimatePosition(float interpolationPoint) {
-      transform.localPosition = Vector3.Lerp(OnPosition, OffPosition, PositionCurve.Evaluate(interpolationPoint));
+      RootTransform.transform.localPosition = Vector3.Lerp(OnPosition, OffPosition, PositionCurve.Evaluate(interpolationPoint));
     }
 
     /**
@@ -322,7 +328,7 @@ namespace Leap.Unity.Attachments{
     * @since 4.1.4
     */
     protected virtual void doAnimateRotation(float interpolationPoint) {
-      transform.localRotation = Quaternion.Lerp(OnRotationQuaternion, OffRotationQuaternion, RotationCurve.Evaluate(interpolationPoint));
+      RootTransform.transform.localRotation = Quaternion.Lerp(OnRotationQuaternion, OffRotationQuaternion, RotationCurve.Evaluate(interpolationPoint));
     }
 
     /**
@@ -330,7 +336,7 @@ namespace Leap.Unity.Attachments{
     * @since 4.1.4
     */
     protected virtual void doAnimateScale(float interpolationPoint) {
-      transform.localScale = Vector3.Lerp(OnScale, OffScale, ScaleCurve.Evaluate(interpolationPoint));
+      RootTransform.transform.localScale = Vector3.Lerp(OnScale, OffScale, ScaleCurve.Evaluate(interpolationPoint));
     }
 
     /**
@@ -339,7 +345,7 @@ namespace Leap.Unity.Attachments{
     */
     protected virtual void doAnimateColor(float interpolationPoint) {
       float influence = ColorCurve.Evaluate(interpolationPoint);
-      Transform[] children = GetComponentsInChildren<Transform>(true);
+      Transform[] children = RootTransform.gameObject.GetComponentsInChildren<Transform>(true);
       for (int g = 0; g < children.Length; g++) {
         Renderer renderer = children[g].gameObject.GetComponent<Renderer>();
         if (renderer != null) {

--- a/Assets/LeapMotionModules/Attachments/Scripts/Transition.cs
+++ b/Assets/LeapMotionModules/Attachments/Scripts/Transition.cs
@@ -27,7 +27,7 @@ namespace Leap.Unity.Attachments{
   * @since 4.1.4
   */
   [ExecuteInEditMode]
-  public class Transition : MonoBehaviour {
+  public class Transition : ITransition {
 
     public Transform RootTransform;
 
@@ -213,7 +213,12 @@ namespace Leap.Unity.Attachments{
     * @since 4.1.4
     */
     [Tooltip("Dispatched when a transition begins")]
-    public UnityEvent OnStart;
+    [SerializeField]
+    private UnityEvent _onStart;
+    public override UnityEvent OnStart {
+      get { return _onStart; }
+      set { _onStart = value; }
+    }
 
     /**
     * Dispatched for each animation step before the transition does its own update.
@@ -222,14 +227,24 @@ namespace Leap.Unity.Attachments{
     * @since 4.1.4
     */
     [Tooltip("Dispatched each frame during a transition")]
-    public AnimationStepEvent OnAnimationStep;
+    [SerializeField]
+    private AnimationStepEvent _onAnimationStep;
+    public override AnimationStepEvent OnAnimationStep {
+      get { return _onAnimationStep; }
+      set { _onAnimationStep = value; }
+    }
 
     /**
     * Dispatched when a transition is complete.
     * @since 4.1.4
     */
     [Tooltip("Dispatched when a transition is finished")]
-    public UnityEvent OnComplete;
+    [SerializeField]
+    private UnityEvent _onComplete;
+    public override UnityEvent OnComplete {
+      get { return _onComplete; }
+      set { _onComplete = value; }
+    }
 
 #if UNITY_EDITOR
     private void Update() {
@@ -252,7 +267,7 @@ namespace Leap.Unity.Attachments{
     * Play the transition from off to on.
     * @since 4.1.4
     */
-    public void TransitionIn() {
+    public override void TransitionIn() {
       if (gameObject.activeInHierarchy) {
         OnStart.Invoke();
         StopAllCoroutines();
@@ -264,7 +279,7 @@ namespace Leap.Unity.Attachments{
     * Play the transition from on to off.
     * @since 4.1.4
     */
-    public void TransitionOut(){
+    public override void TransitionOut(){
       if (gameObject.activeInHierarchy) {
         OnStart.Invoke();
         StopAllCoroutines();
@@ -358,14 +373,4 @@ namespace Leap.Unity.Attachments{
     }
   }
 
-  /**
-   * An event class that is dispatched by a Transition for each animation
-   * step during a transition. The event occurs once per frame for the duration of
-   * a transition.
-   * The event parameter provides the current interpolation value between -1 and 0 for an
-   * in transition and between 0 and +1 for an out transition..
-   * @since 4.1.4
-   */
-  [System.Serializable]
-  public class AnimationStepEvent : UnityEvent<float> { }
 }

--- a/Assets/LeapMotionModules/Attachments/Scripts/Transition.cs
+++ b/Assets/LeapMotionModules/Attachments/Scripts/Transition.cs
@@ -252,11 +252,11 @@ namespace Leap.Unity.Attachments{
     * Play the transition from off to on.
     * @since 4.1.4
     */
-    public void TransitionIn(){
-      if (isActiveAndEnabled && gameObject.activeInHierarchy) {
+    public void TransitionIn() {
+      if (gameObject.activeInHierarchy) {
         OnStart.Invoke();
         StopAllCoroutines();
-        StartCoroutine(transitionIn());
+        StartCoroutine(doTransitionIn());
       }
     }
 
@@ -265,10 +265,10 @@ namespace Leap.Unity.Attachments{
     * @since 4.1.4
     */
     public void TransitionOut(){
-      if (isActiveAndEnabled && gameObject.activeInHierarchy) {
+      if (gameObject.activeInHierarchy) {
         OnStart.Invoke();
         StopAllCoroutines();
-        StartCoroutine(transitionOut());
+        StartCoroutine(doTransitionOut());
       }
     }
 
@@ -276,7 +276,7 @@ namespace Leap.Unity.Attachments{
     * A coroutine that updates the transition state when playing the "in" transition.
     * @since 4.1.4
     */
-    protected IEnumerator transitionIn(){
+    protected IEnumerator doTransitionIn(){
       float start = Time.time;
       do {
         progress = (Time.time - start)/Duration;
@@ -292,7 +292,7 @@ namespace Leap.Unity.Attachments{
     * A coroutine that updates the transition state when playing the "out" transition.
     * @since 4.1.4
     */
-    protected IEnumerator transitionOut(){
+    protected IEnumerator doTransitionOut(){
       float start = Time.time;
       do {
         progress = (Time.time - start)/Duration;


### PR DESCRIPTION
Added a Root transform setting to the Transition object, which defaults to the current game object's transform. This allows you to place the transition anywhere in the hierarchy.

Also removed the ActivateOnEnable setting from the AttachmentController. It was unnecessary and potentially confusing.

Added ITransition as base class of Transition, so that Transition classes can be replaced with a different implementation.

Added Transition prefab.