### PR TITLE
Correctly set layer upon register

### DIFF
--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviour.cs
@@ -190,6 +190,8 @@ namespace Leap.Unity.Interaction {
       _warper = new RigidbodyWarper(_manager, transform, _rigidbody, _material.GraphicalReturnTime);
 
       _childrenArray = GetComponentsInChildren<Transform>(true);
+
+      _contactMode = ContactMode.NORMAL;
       updateLayer();
     }
 


### PR DESCRIPTION
Make sure that soft contact mode is in Normal mode when registration happens.  It previously was not, resulting in no guarantee that the layer would be set correctly.

@ajohnston33 