### PR TITLE
Small ie usability changes

### DIFF
--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/ActivityMonitor.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/ActivityMonitor.cs
@@ -4,7 +4,7 @@ using Leap.Unity.RuntimeGizmos;
 namespace Leap.Unity.Interaction {
 
   public abstract class IActivityMonitor : MonoBehaviour {
-    public static GizmoType gizmoType = GizmoType.ActivityDepth;
+    public static GizmoType gizmoType = GizmoType.InteractionStatus;
     public static float explosionVelocity = 100;                   //In meters per second
     public static int hysteresisTimeout = 5;                       //In fixed frames
 

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
@@ -90,10 +90,6 @@ namespace Leap.Unity.Interaction {
     [SerializeField]
     protected bool _automaticValidation = false;
 
-    [Tooltip("Allows simulation to be disabled without destroying the scene in any way.")]
-    [SerializeField]
-    protected bool _pauseSimulation = false;
-
     [Tooltip("Shows the debug visualization coming from the internal Interaction plugin.")]
     [SerializeField]
     protected bool _showDebugLines = false;
@@ -619,10 +615,8 @@ namespace Leap.Unity.Interaction {
       if (OnPrePhysicalUpdate != null) {
         OnPrePhysicalUpdate();
       }
-
-      if (!_pauseSimulation) {
-        simulateFrame(frame);
-      }
+      
+      simulateFrame(frame);
 
       if (OnPostPhysicalUpdate != null) {
         OnPostPhysicalUpdate();
@@ -646,10 +640,6 @@ namespace Leap.Unity.Interaction {
     }
 
     protected virtual void LateUpdate() {
-      if (_pauseSimulation) {
-        return;
-      }
-
       Frame frame = _leapProvider.CurrentFrame;
 
       dispatchOnHandsHoldingAll(frame, isPhysics: false);


### PR DESCRIPTION
 - Made sure monitor gizmos are on Interaction Status by default, instead of the more unintuitive activity depth.
 - Removed the 'pause simulation' toggle because it was not useful in any way.

@ajohnston33 