### PR TITLE
Optimize detector gizmos

### DIFF
--- a/Assets/LeapMotion/Scripts/DetectionUtilities/AbstractHoldDetector.cs
+++ b/Assets/LeapMotion/Scripts/DetectionUtilities/AbstractHoldDetector.cs
@@ -180,16 +180,18 @@ namespace Leap.Unity {
         Vector3 centerPosition = _position;
         Quaternion circleRotation = _rotation;
         if (IsHolding) {
-          centerColor = Color.green;
+          centerColor = OnColor;
         } else {
-          centerColor = Color.red;
+          centerColor = OffColor;
         }
         Vector3 axis;
         float angle;
         circleRotation.ToAngleAxis(out angle, out axis);
         Utils.DrawCircle(centerPosition, Normal, Distance / 2, centerColor);
-        Debug.DrawLine(centerPosition, centerPosition + Direction * Distance / 2, Color.grey);
-        Debug.DrawLine(centerPosition, centerPosition + Normal * Distance / 2, Color.white);
+        Gizmos.color = NormalColor;
+        Gizmos.DrawLine(centerPosition, centerPosition + Direction * Distance / 2);
+        Gizmos.color = DirectionColor;
+        Gizmos.DrawLine(centerPosition, centerPosition + Normal * Distance / 2);
       }
     }
     #endif

--- a/Assets/LeapMotion/Scripts/DetectionUtilities/ExtendedFingerDetector.cs
+++ b/Assets/LeapMotion/Scripts/DetectionUtilities/ExtendedFingerDetector.cs
@@ -142,9 +142,9 @@ namespace Leap.Unity {
           if (matchFingerState(finger, state[f]) && 
              (extendedCount <= MaximumExtendedCount) && 
              (extendedCount >= MinimumExtendedCount)) {
-            Gizmos.color = Color.green;
+            Gizmos.color = OnColor;
           } else {
-            Gizmos.color = Color.red;
+            Gizmos.color = OffColor;
           }
           Gizmos.DrawWireSphere(finger.TipPosition.ToVector3(), finger.Width);
         }

--- a/Assets/LeapMotion/Scripts/DetectionUtilities/FingerDirectionDetector.cs
+++ b/Assets/LeapMotion/Scripts/DetectionUtilities/FingerDirectionDetector.cs
@@ -175,15 +175,16 @@ namespace Leap.Unity {
       if (ShowGizmos && HandModel != null) {
         Color innerColor;
         if (IsActive) {
-          innerColor = Color.green;
+          innerColor = OnColor;
         } else {
-          innerColor = Color.blue;
+          innerColor = OffColor;
         }
         Finger finger = HandModel.GetLeapHand().Fingers[selectedFingerOrdinal()];
         Vector3 fingerDirection = finger.Bone(Bone.BoneType.TYPE_DISTAL).Direction.ToVector3();
         Utils.DrawCone(finger.TipPosition.ToVector3(), fingerDirection, OnAngle, finger.Length, innerColor);
-        Utils.DrawCone(finger.TipPosition.ToVector3(), fingerDirection, OffAngle, finger.Length, Color.red);
-        Debug.DrawRay(finger.TipPosition.ToVector3(), selectedDirection(finger.TipPosition.ToVector3()), Color.grey);
+        Utils.DrawCone(finger.TipPosition.ToVector3(), fingerDirection, OffAngle, finger.Length, LimitColor);
+        Gizmos.color = DirectionColor;
+        Gizmos.DrawRay(finger.TipPosition.ToVector3(), selectedDirection(finger.TipPosition.ToVector3()));
       }
     }
   #endif

--- a/Assets/LeapMotion/Scripts/DetectionUtilities/PalmDirectionDetector.cs
+++ b/Assets/LeapMotion/Scripts/DetectionUtilities/PalmDirectionDetector.cs
@@ -150,14 +150,15 @@ namespace Leap.Unity {
       if(ShowGizmos && HandModel != null){
         Color centerColor;
         if (IsActive) {
-          centerColor = Color.green;
+          centerColor = OnColor;
         } else {
-          centerColor = Color.red;
+          centerColor = OffColor;
         }
         Hand hand = HandModel.GetLeapHand();
         Utils.DrawCone(hand.PalmPosition.ToVector3(), hand.PalmNormal.ToVector3(), OnAngle, hand.PalmWidth, centerColor, 8);
-        Utils.DrawCone(hand.PalmPosition.ToVector3(), hand.PalmNormal.ToVector3(), OffAngle, hand.PalmWidth, Color.blue, 8);
-        Debug.DrawRay(hand.PalmPosition.ToVector3(), selectedDirection(hand.PalmPosition.ToVector3()), Color.grey, 0, true);
+        Utils.DrawCone(hand.PalmPosition.ToVector3(), hand.PalmNormal.ToVector3(), OffAngle, hand.PalmWidth, LimitColor, 8);
+        Gizmos.color = DirectionColor;
+        Gizmos.DrawRay(hand.PalmPosition.ToVector3(), selectedDirection(hand.PalmPosition.ToVector3()));
       }
     }
     #endif

--- a/Assets/LeapMotion/Scripts/Utils/Utils.cs
+++ b/Assets/LeapMotion/Scripts/Utils/Utils.cs
@@ -38,7 +38,7 @@ namespace Leap.Unity {
                            float duration = 0, 
                            bool depthTest = true) {
       Vector3 planeA = Vector3.Slerp(normal, -normal, 0.5f);
-      DrawArc(360, center, planeA, normal, radius, color, quality, duration, depthTest);
+      DrawArc(360, center, planeA, normal, radius, color, quality);
     }
 
     /* Adapted from: Zarrax (http://math.stackexchange.com/users/3035/zarrax), Parametric Equation of a Circle in 3D Space?, 
@@ -49,10 +49,9 @@ namespace Leap.Unity {
                            Vector3 normal,
                            float radius, 
                            Color color, 
-                           int quality = 32, 
-                           float duration = 0, 
-                           bool depthTest = true) {
+                           int quality = 32) {
 
+      Gizmos.color = color;
       Vector3 right = Vector3.Cross(normal, forward).normalized;
       float deltaAngle = arc/quality;
       Vector3 thisPoint = center + forward * radius;
@@ -63,7 +62,7 @@ namespace Leap.Unity {
         nextPoint.x = center.x + radius * (cosAngle * forward.x + sinAngle * right.x);
         nextPoint.y = center.y + radius * (cosAngle * forward.y + sinAngle * right.y);
         nextPoint.z = center.z + radius * (cosAngle * forward.z + sinAngle * right.z);
-        Debug.DrawLine(thisPoint, nextPoint, color, duration, depthTest);
+        Gizmos.DrawLine(thisPoint, nextPoint);
         thisPoint = nextPoint;
       }
     }


### PR DESCRIPTION
Removes Debug.DrawLine from detector gizmo code. Also uses the standard colors defined in Detector rather than hardcoded colors.

(Not using RuntimeGizmos yet because circles and cones need some improvement first.)