### PR TITLE
Add InteractionGraspDetector

### DIFF
--- a/Assets/LeapMotion/Scripts/DetectionUtilities/AbstractHoldDetector.cs
+++ b/Assets/LeapMotion/Scripts/DetectionUtilities/AbstractHoldDetector.cs
@@ -25,6 +25,7 @@ namespace Leap.Unity {
     *
     * If false, the Transform is not affected.
     */
+    [Tooltip("Whether to change the transform of the parent object.")]
     public bool ControlsTransform = true;
     /** Whether to draw the detector's Gizmos for debugging. (Not every detector provides gizmos.)
      * @since 4.1.2 

--- a/Assets/LeapMotion/Scripts/DetectionUtilities/AbstractHoldDetector.cs
+++ b/Assets/LeapMotion/Scripts/DetectionUtilities/AbstractHoldDetector.cs
@@ -26,6 +26,11 @@ namespace Leap.Unity {
     * If false, the Transform is not affected.
     */
     public bool ControlsTransform = true;
+    /** Whether to draw the detector's Gizmos for debugging. (Not every detector provides gizmos.)
+     * @since 4.1.2 
+     */
+    [Tooltip("Draw this detector's Gizmos, if any. (Gizmos must be on in Unity edtor, too.)")]
+    public bool ShowGizmos = true;
 
     protected int _lastUpdateFrame = -1;
 

--- a/Assets/LeapMotion/Scripts/DetectionUtilities/Detector.cs
+++ b/Assets/LeapMotion/Scripts/DetectionUtilities/Detector.cs
@@ -27,11 +27,6 @@ namespace Leap.Unity {
      */
     public bool IsActive{ get{ return _isActive;}}
     private bool _isActive = false;
-    /** Whether to draw the detector's Gizmos for debugging. (Not every detector provides gizmos.)
-     * @since 4.1.2 
-     */
-    [Tooltip("Draw this detector's Gizmos, if any. (Gizmos must be on in Unity edtor, too.)")]
-    public bool ShowGizmos = true;
     /** Dispatched when the detector activates (becomes true). 
      * @since 4.1.2
      */

--- a/Assets/LeapMotion/Scripts/DetectionUtilities/ExtendedFingerDetector.cs
+++ b/Assets/LeapMotion/Scripts/DetectionUtilities/ExtendedFingerDetector.cs
@@ -24,6 +24,7 @@ namespace Leap.Unity {
      * @since 4.1.2
      */
     [Tooltip("The interval in seconds at which to check this detector's conditions.")]
+    [MinValue(0)]
     public float Period = .1f; //seconds
 
     /**
@@ -36,20 +37,34 @@ namespace Leap.Unity {
     public IHandModel HandModel = null;
   
     /** The required thumb state. */
+    [Tooltip("Required state of the thumb.")]
     public PointingState Thumb = PointingState.Either;
     /** The required index finger state. */
+    [Tooltip("Required state of the index finger.")]
     public PointingState Index = PointingState.Either;
     /** The required middle finger state. */
+    [Tooltip("Required state of the middle finger.")]
     public PointingState Middle = PointingState.Either;
     /** The required ring finger state. */
+    [Tooltip("Required state of the ring finger.")]
     public PointingState Ring = PointingState.Either;
     /** The required pinky finger state. */
+    [Tooltip("Required state of the little finger.")]
     public PointingState Pinky = PointingState.Either;
 
+    /** How many fingers must be extended for the detector to activate. */
     [Range(0,5)]
+    [Tooltip("The minimum number of fingers extended.")]
     public int MinimumExtendedCount = 0;
+    /** The most fingers allowed to be extended for the detector to activate. */
     [Range(0, 5)]
+    [Tooltip("The maximum number of fingers extended.")]
     public int MaximumExtendedCount = 5;
+    /** Whether to draw the detector's Gizmos for debugging. (Not every detector provides gizmos.)
+     * @since 4.1.2 
+     */
+    [Tooltip("Draw this detector's Gizmos, if any. (Gizmos must be on in Unity edtor, too.)")]
+    public bool ShowGizmos = true;
 
     private IEnumerator watcherCoroutine;
 

--- a/Assets/LeapMotion/Scripts/DetectionUtilities/ExtendedFingerDetector.cs
+++ b/Assets/LeapMotion/Scripts/DetectionUtilities/ExtendedFingerDetector.cs
@@ -24,6 +24,7 @@ namespace Leap.Unity {
      * @since 4.1.2
      */
     [Tooltip("The interval in seconds at which to check this detector's conditions.")]
+    [Units("seconds")]
     [MinValue(0)]
     public float Period = .1f; //seconds
 
@@ -37,6 +38,7 @@ namespace Leap.Unity {
     public IHandModel HandModel = null;
   
     /** The required thumb state. */
+    [Header("Finger States")]
     [Tooltip("Required state of the thumb.")]
     public PointingState Thumb = PointingState.Either;
     /** The required index finger state. */
@@ -53,6 +55,7 @@ namespace Leap.Unity {
     public PointingState Pinky = PointingState.Either;
 
     /** How many fingers must be extended for the detector to activate. */
+    [Header("Min and Max Finger Counts")]
     [Range(0,5)]
     [Tooltip("The minimum number of fingers extended.")]
     public int MinimumExtendedCount = 0;
@@ -63,6 +66,7 @@ namespace Leap.Unity {
     /** Whether to draw the detector's Gizmos for debugging. (Not every detector provides gizmos.)
      * @since 4.1.2 
      */
+    [Header("")]
     [Tooltip("Draw this detector's Gizmos, if any. (Gizmos must be on in Unity edtor, too.)")]
     public bool ShowGizmos = true;
 

--- a/Assets/LeapMotion/Scripts/DetectionUtilities/FingerDirectionDetector.cs
+++ b/Assets/LeapMotion/Scripts/DetectionUtilities/FingerDirectionDetector.cs
@@ -25,6 +25,7 @@ namespace Leap.Unity {
      * @since 4.1.2
      */
     [Tooltip("The interval in seconds at which to check this detector's conditions.")]
+    [MinValue(0)]
     public float Period = .1f; //seconds
 
     /**
@@ -90,6 +91,11 @@ namespace Leap.Unity {
     [Tooltip("The angle in degrees from the target direction at which to turn off.")]
     [Range(0, 360)]
     public float OffAngle = 25f; //degrees
+    /** Whether to draw the detector's Gizmos for debugging. (Not every detector provides gizmos.)
+     * @since 4.1.2 
+     */
+    [Tooltip("Draw this detector's Gizmos, if any. (Gizmos must be on in Unity edtor, too.)")]
+    public bool ShowGizmos = true;
 
     private IEnumerator watcherCoroutine;
 

--- a/Assets/LeapMotion/Scripts/DetectionUtilities/FingerDirectionDetector.cs
+++ b/Assets/LeapMotion/Scripts/DetectionUtilities/FingerDirectionDetector.cs
@@ -24,6 +24,7 @@ namespace Leap.Unity {
      * The interval at which to check finger state.
      * @since 4.1.2
      */
+    [Units("seconds")]
     [Tooltip("The interval in seconds at which to check this detector's conditions.")]
     [MinValue(0)]
     public float Period = .1f; //seconds
@@ -44,13 +45,6 @@ namespace Leap.Unity {
     [Tooltip("The finger to observe.")]
     public Finger.FingerType FingerName = Finger.FingerType.TYPE_INDEX;
 
-    /**
-     * The target direction as interpreted by the PointingType setting.
-     * Ignored when Pointingtype is "AtTarget."
-     * @since 4.1.2
-     */
-    [Tooltip("The target direction.")]
-    public Vector3 PointingDirection = Vector3.forward;
 
     /**
      * Specifies how to interprete the direction specified by PointingDirection.
@@ -67,12 +61,24 @@ namespace Leap.Unity {
      * of (0, 1, 0) for absolute up, are often the most useful settings.
      * @since 4.1.2
      */
+    [Header("Direction Settings")]
     [Tooltip("How to treat the target direction.")]
     public PointingType PointingType = PointingType.RelativeToHorizon;
+
+    /**
+     * The target direction as interpreted by the PointingType setting.
+     * Ignored when Pointingtype is "AtTarget."
+     * @since 4.1.2
+     */
+    [Tooltip("The target direction.")]
+    [DisableIf("PointingType", isEqualTo: PointingType.AtTarget)]
+    public Vector3 PointingDirection = Vector3.forward;
+
     /**
      * The object to point at when the PointingType is "AtTarget." Ignored otherwise.
      */
     [Tooltip("A target object(optional). Use PointingType.AtTarget")]
+    [DisableIf("PointingType", isNotEqualTo: PointingType.AtTarget)]
     public Transform TargetObject = null;
     /**
      * The turn-on angle. The detector activates when the specified finger points within this
@@ -80,7 +86,7 @@ namespace Leap.Unity {
      * @since 4.1.2
      */
     [Tooltip("The angle in degrees from the target direction at which to turn on.")]
-    [Range(0, 360)]
+    [Range(0, 180)]
     public float OnAngle = 15f; //degrees
 
     /**
@@ -89,11 +95,12 @@ namespace Leap.Unity {
     * @since 4.1.2
     */
     [Tooltip("The angle in degrees from the target direction at which to turn off.")]
-    [Range(0, 360)]
+    [Range(0, 180)]
     public float OffAngle = 25f; //degrees
     /** Whether to draw the detector's Gizmos for debugging. (Not every detector provides gizmos.)
      * @since 4.1.2 
      */
+    [Header("")]
     [Tooltip("Draw this detector's Gizmos, if any. (Gizmos must be on in Unity edtor, too.)")]
     public bool ShowGizmos = true;
 

--- a/Assets/LeapMotion/Scripts/DetectionUtilities/PalmDirectionDetector.cs
+++ b/Assets/LeapMotion/Scripts/DetectionUtilities/PalmDirectionDetector.cs
@@ -27,6 +27,7 @@ namespace Leap.Unity {
      * The interval at which to check palm direction.
      * @since 4.1.2
      */
+    [Units("seconds")]
     [Tooltip("The interval in seconds at which to check this detector's conditions.")]
     [MinValue(0)]
     public float Period = .1f; //seconds
@@ -38,13 +39,6 @@ namespace Leap.Unity {
     [AutoFind(AutoFindLocations.Parents)]
     [Tooltip("The hand model to watch. Set automatically if detector is on a hand.")]
     public IHandModel HandModel = null;
-    /**
-     * The target direction as interpreted by the PointingType setting.
-     * Ignored when Pointingtype is "AtTarget."
-     * @since 4.1.2
-     */
-    [Tooltip("The target direction.")]
-    public Vector3 PointingDirection = Vector3.forward;
 
     /**
      * Specifies how to interprete the direction specified by PointingDirection.
@@ -61,21 +55,33 @@ namespace Leap.Unity {
      * of (0, 1, 0) for absolute up, are often the most useful settings.
      * @since 4.1.2
      */
+    [Header("Direction Settings")]
     [Tooltip("How to treat the target direction.")]
     public PointingType PointingType = PointingType.RelativeToHorizon;
+
+    /**
+    * The target direction as interpreted by the PointingType setting.
+    * Ignored when Pointingtype is "AtTarget."
+    * @since 4.1.2
+    */
+    [Tooltip("The target direction.")]
+    [DisableIf("PointingType", isEqualTo: PointingType.AtTarget)]
+    public Vector3 PointingDirection = Vector3.forward;
 
     /**
      * The object to point at when the PointingType is "AtTarget." Ignored otherwise.
      */
     [Tooltip("A target object(optional). Use PointingType.AtTarget")]
+    [DisableIf("PointingType", isNotEqualTo: PointingType.AtTarget)]
     public Transform TargetObject = null;
+
     /**
      * The turn-on angle. The detector activates when the palm points within this
      * many degrees of the target direction.
      * @since 4.1.2
      */
     [Tooltip("The angle in degrees from the target direction at which to turn on.")]
-    [Range(0, 360)]
+    [Range(0, 180)]
     public float OnAngle = 45; // degrees
 
     /**
@@ -84,11 +90,13 @@ namespace Leap.Unity {
     * @since 4.1.2
     */
     [Tooltip("The angle in degrees from the target direction at which to turn off.")]
-    [Range(0, 360)]
+    [Range(0, 180)]
     public float OffAngle = 65; //degrees
+
     /** Whether to draw the detector's Gizmos for debugging. (Not every detector provides gizmos.)
      * @since 4.1.2 
      */
+    [Header("")]
     [Tooltip("Draw this detector's Gizmos, if any. (Gizmos must be on in Unity edtor, too.)")]
     public bool ShowGizmos = true;
 
@@ -145,7 +153,9 @@ namespace Leap.Unity {
         case PointingType.RelativeToWorld:
           return PointingDirection;
         case PointingType.AtTarget:
-          return TargetObject.position - tipPosition;
+          if (TargetObject != null)
+            return TargetObject.position - tipPosition;
+          else return Vector3.zero;
         default:
           return PointingDirection;
       }

--- a/Assets/LeapMotion/Scripts/DetectionUtilities/PalmDirectionDetector.cs
+++ b/Assets/LeapMotion/Scripts/DetectionUtilities/PalmDirectionDetector.cs
@@ -28,6 +28,7 @@ namespace Leap.Unity {
      * @since 4.1.2
      */
     [Tooltip("The interval in seconds at which to check this detector's conditions.")]
+    [MinValue(0)]
     public float Period = .1f; //seconds
     /**
      * The IHandModel instance to observe. 
@@ -85,6 +86,11 @@ namespace Leap.Unity {
     [Tooltip("The angle in degrees from the target direction at which to turn off.")]
     [Range(0, 360)]
     public float OffAngle = 65; //degrees
+    /** Whether to draw the detector's Gizmos for debugging. (Not every detector provides gizmos.)
+     * @since 4.1.2 
+     */
+    [Tooltip("Draw this detector's Gizmos, if any. (Gizmos must be on in Unity edtor, too.)")]
+    public bool ShowGizmos = true;
 
     private IEnumerator watcherCoroutine;
 

--- a/Assets/LeapMotion/Scripts/DetectionUtilities/PinchDetector.cs
+++ b/Assets/LeapMotion/Scripts/DetectionUtilities/PinchDetector.cs
@@ -11,13 +11,18 @@ namespace Leap.Unity {
   public class PinchDetector : AbstractHoldDetector {
     protected const float MM_TO_M = 0.001f;
 
-
+    [Tooltip("The distance at which to enter the pinching state.")]
+    [Header("Distance Settings")]
     [MinValue(0)]
+    [Units("meters")]
     [FormerlySerializedAs("_activatePinchDist")]
     public float ActivateDistance = .03f; //meters
+    [Tooltip("The distance at which to leave the pinching state.")]
     [MinValue(0)]
+    [Units("meters")]
     [FormerlySerializedAs("_deactivatePinchDist")]
     public float DeactivateDistance = .04f; //meters
+
     public bool IsPinching { get { return this.IsHolding; } }
     public bool DidStartPinch { get { return this.DidStartHold; } }
     public bool DidEndPinch { get { return this.DidRelease; } }

--- a/Assets/LeapMotion/Scripts/DetectionUtilities/ProximityDetector.cs
+++ b/Assets/LeapMotion/Scripts/DetectionUtilities/ProximityDetector.cs
@@ -2,7 +2,7 @@
 using UnityEngine.Events;
 using System.Collections;
 using System.Collections.Generic;
-using Leap;
+using Leap.Unity.Attributes;
 
 namespace Leap.Unity{
 
@@ -13,18 +13,19 @@ namespace Leap.Unity{
    */
   public class ProximityDetector : Detector {
     /**
-     * The interval at which to check palm direction.
-     * @since 4.1.2
-     */
-    [Tooltip("The interval in seconds at which to check this detector's conditions.")]
-    public float Period = .1f; //seconds
-    /**
      * Dispatched when the proximity check succeeds.
      * The ProximityEvent object provides a reference to the proximate GameObject. 
      * @since 4.1.2
      */
     [Tooltip("Dispatched when close enough to a target.")]
     public ProximityEvent OnProximity;
+    /**
+     * The interval at which to check palm direction.
+     * @since 4.1.2
+     */
+    [MinValue(0)]
+    [Tooltip("The interval in seconds at which to check this detector's conditions.")]
+    public float Period = .1f; //seconds
 
     /**
      * The list of objects which can activate the detector by proximity.
@@ -72,9 +73,24 @@ namespace Leap.Unity{
      * @since 4.1.2
      */
     public GameObject CurrentObject { get { return _currentObj; } }
+    /** Whether to draw the detector's Gizmos for debugging. (Not every detector provides gizmos.)
+     * @since 4.1.2 
+     */
+    [Tooltip("Draw this detector's Gizmos, if any. (Gizmos must be on in Unity edtor, too.)")]
+    public bool ShowGizmos = true;
 
     private IEnumerator proximityWatcherCoroutine;
     private GameObject _currentObj = null;
+
+    protected virtual void OnValidate() {
+      OnDistance = Mathf.Max(0, OnDistance);
+      OffDistance = Mathf.Max(0, OffDistance);
+
+      //Activate value cannot be less than deactivate value
+      if (OffDistance < OnDistance) {
+        OffDistance = OnDistance;
+      }
+    }
 
     void Awake() {
       proximityWatcherCoroutine = proximityWatcher();
@@ -153,15 +169,17 @@ namespace Leap.Unity{
     }
 
     #if UNITY_EDITOR
-    void OnDrawGizmos(){
-      if(IsActive){
-        Gizmos.color = Color.green;
-      } else {
-        Gizmos.color = Color.red;
+    void OnDrawGizmos() {
+      if (ShowGizmos) {
+        if (IsActive) {
+          Gizmos.color = Color.green;
+        } else {
+          Gizmos.color = Color.red;
+        }
+        Gizmos.DrawWireSphere(transform.position, OnDistance);
+        Gizmos.color = Color.blue;
+        Gizmos.DrawWireSphere(transform.position, OffDistance);
       }
-      Gizmos.DrawWireSphere(transform.position, OnDistance);
-      Gizmos.color = Color.blue;
-      Gizmos.DrawWireSphere(transform.position, OffDistance);
     }
     #endif
   }

--- a/Assets/LeapMotion/Scripts/DetectionUtilities/ProximityDetector.cs
+++ b/Assets/LeapMotion/Scripts/DetectionUtilities/ProximityDetector.cs
@@ -23,6 +23,7 @@ namespace Leap.Unity{
      * The interval at which to check palm direction.
      * @since 4.1.2
      */
+    [Units("seconds")]
     [MinValue(0)]
     [Tooltip("The interval in seconds at which to check this detector's conditions.")]
     public float Period = .1f; //seconds
@@ -31,7 +32,9 @@ namespace Leap.Unity{
      * The list of objects which can activate the detector by proximity.
      * @since 4.1.2
      */
+    [Header("Detector Targets")]
     [Tooltip("The list of target objects.")]
+    [DisableIf("UseLayersNotList", true)]
     public GameObject[] TargetObjects;
 
     /**
@@ -41,11 +44,13 @@ namespace Leap.Unity{
     * @since 4.1.3
     */
     [Tooltip("Objects with this tag are added to the list of targets.")]
+    [DisableIf("UseLayersNotList", true)]
     public string TagName = "";
 
     [Tooltip("Use a Layer instead of the target list.")]
     public bool UseLayersNotList = false;
     [Tooltip("The Layer containing the objects to check.")]
+    [DisableIf("UseLayersNotList", false)]
     public LayerMask Layer;
 
     /**
@@ -53,7 +58,9 @@ namespace Leap.Unity{
      * will pass the proximity check.
      * @since 4.1.2
      */
+    [Header("Distance Settings")]
     [Tooltip("The target distance in meters to activate the detector.")]
+    [MinValue(0)]
     public float OnDistance = .01f; //meters
 
     /**
@@ -76,6 +83,7 @@ namespace Leap.Unity{
     /** Whether to draw the detector's Gizmos for debugging. (Not every detector provides gizmos.)
      * @since 4.1.2 
      */
+    [Header("")]
     [Tooltip("Draw this detector's Gizmos, if any. (Gizmos must be on in Unity edtor, too.)")]
     public bool ShowGizmos = true;
 
@@ -83,9 +91,6 @@ namespace Leap.Unity{
     private GameObject _currentObj = null;
 
     protected virtual void OnValidate() {
-      OnDistance = Mathf.Max(0, OnDistance);
-      OffDistance = Mathf.Max(0, OffDistance);
-
       //Activate value cannot be less than deactivate value
       if (OffDistance < OnDistance) {
         OffDistance = OnDistance;

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/InteractionGraspDetector.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/InteractionGraspDetector.cs
@@ -1,19 +1,33 @@
 ﻿using UnityEngine;
 using System.Collections;
-using System.Collections.Generic;
 using Leap.Unity.Attributes;
 using UnityEngine.Events;
 
 namespace Leap.Unity.Interaction {
+  /**
+  * Detects when an interactable object is grasped.
+  * You can specify whether any interactable object or
+  * any object with a specified tag will a activate the detector. You can also
+  * assign a specific list of activating objects.
+  *
+  * All objects must contain an IInteractionBehaviour component and be managed by the
+  * InteractionManager assigned to this detector. 
+  * @since 4.1.5
+  */
   public class InteractionGraspDetector : Detector {
 
+    /**
+    * The InteractionManager managing the target objects. All
+    * targets must be managed by this manager.
+    * @since 4.1.5
+    */
     [AutoFind(AutoFindLocations.Scene)]
     [Tooltip("The Interaction Manager.")]
     public InteractionManager ieManager = null;
     /**
      * The IHandModel instance to observe. 
      * Set automatically if not explicitly set in the editor.
-     * @since 4.1.2
+     * @since 4.1.5
      */
     [AutoFind(AutoFindLocations.Parents)]
     [Tooltip("The hand model to watch. Set automatically if detector is on a hand.")]
@@ -21,14 +35,14 @@ namespace Leap.Unity.Interaction {
 
     /**
  * The interval at which to check palm direction.
- * @since 4.1.2
+ * @since 4.1.5
  */
     [Tooltip("The interval in seconds at which to check this detector's conditions.")]
     public float Period = .1f; //seconds
     /**
-     * Dispatched when the proximity check succeeds.
-     * The ProximityEvent object provides a reference to the proximate GameObject. 
-     * @since 4.1.2
+     * Dispatched when a target interactable object is grasped.
+     * The InteractiveBehaviorGraspEvent object provides a reference to the IInteractiveBehavior instance. 
+     * @since 4.1.5
      */
     [Tooltip("Dispatched when a target object is grasped.")]
     public InteractiveBehaviorGraspEvent OnGrasp;
@@ -37,7 +51,9 @@ namespace Leap.Unity.Interaction {
     public bool AnyInteractionObject = false;
     /**
      * The list of IInteractionBehaviour objects which can activate the detector when held.
-     * @since 4.1.2
+     * Grasping objects in this list will activate the detector even if they do not match the tag
+     * defined in TagName.
+     * @since 4.1.5
      */
     [Tooltip("The list of target objects.")]
     public IInteractionBehaviour[] TargetObjects;
@@ -51,8 +67,8 @@ namespace Leap.Unity.Interaction {
 
     /**
      * The object that is currently held.
-     * 
-     * @since 4.1.2
+     * Null, if no object is currently grasped.
+     * @since 4.1.5
      */
     public IInteractionBehaviour CurrentObject { get { return _currentObj; } }
 
@@ -120,7 +136,7 @@ namespace Leap.Unity.Interaction {
    * An event class that is dispatched by a InteractionGraspDetector when one of its target
    * IInteractiveBehavior objects is grasped.
    * The event parameters provide the IInteractionBehaviour object.
-   * @since 4.1.2
+   * @since 4.1.5
    */
   [System.Serializable]
   public class InteractiveBehaviorGraspEvent : UnityEvent<IInteractionBehaviour> { }

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/InteractionGraspDetector.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/InteractionGraspDetector.cs
@@ -31,7 +31,7 @@ namespace Leap.Unity.Interaction {
     */
     [AutoFind(AutoFindLocations.Scene)]
     [Tooltip("The Interaction Manager.")]
-    public InteractionManager ieManager = null;
+    public InteractionManager interactionManager = null;
 
     /**
      * The IHandModel instance to observe. 
@@ -50,6 +50,8 @@ namespace Leap.Unity.Interaction {
     [Tooltip("The interval in seconds at which to check this detector's conditions.")]
     public float Period = .1f; //seconds
 
+    /** If true, grasping any interactable object activates the detector. */
+    [Header("Detector Targets")]
     [Tooltip("Activate when any interactable object is grasped.")]
     public bool AnyInteractionObject = false;
     /**
@@ -59,13 +61,17 @@ namespace Leap.Unity.Interaction {
      * @since 4.1.5
      */
     [Tooltip("The list of target objects.")]
+    [DisableIf("AnyInteractionObject", true)]
     public IInteractionBehaviour[] TargetObjects;
 
     /**
     * IInteractiveBehaviour objects with this tag name will activate the detector.
+    * The object with the tag does not need to be in the target list and any objects in the target
+    * list will also activate the detector, even if they have a different tag name, or no tag name.
     * @since 4.1.3
     */
     [Tooltip("Activate if the held object has this tag name.")]
+    [DisableIf("AnyInteractionObject", true)]
     public string TagName = "";
 
     /**
@@ -97,14 +103,14 @@ namespace Leap.Unity.Interaction {
       IInteractionBehaviour graspedObject;
       int handId = 0;
       while (true) {
-        if (ieManager != null) {
+        if (interactionManager != null) {
           Leap.Hand hand = HandModel.GetLeapHand();
           if(hand != null) {
             handId = hand.Id;
           } else {
             handId = 0;
           }
-          ieManager.TryGetGraspedObject(handId, out graspedObject);
+          interactionManager.TryGetGraspedObject(handId, out graspedObject);
           graspingState = false;
           if (graspedObject != null) {
             if ((AnyInteractionObject ||

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/InteractionGraspDetector.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/InteractionGraspDetector.cs
@@ -1,0 +1,127 @@
+﻿using UnityEngine;
+using System.Collections;
+using System.Collections.Generic;
+using Leap.Unity.Attributes;
+using UnityEngine.Events;
+
+namespace Leap.Unity.Interaction {
+  public class InteractionGraspDetector : Detector {
+
+    [AutoFind(AutoFindLocations.Scene)]
+    [Tooltip("The Interaction Manager.")]
+    public InteractionManager ieManager = null;
+    /**
+     * The IHandModel instance to observe. 
+     * Set automatically if not explicitly set in the editor.
+     * @since 4.1.2
+     */
+    [AutoFind(AutoFindLocations.Parents)]
+    [Tooltip("The hand model to watch. Set automatically if detector is on a hand.")]
+    public IHandModel HandModel = null;
+
+    /**
+ * The interval at which to check palm direction.
+ * @since 4.1.2
+ */
+    [Tooltip("The interval in seconds at which to check this detector's conditions.")]
+    public float Period = .1f; //seconds
+    /**
+     * Dispatched when the proximity check succeeds.
+     * The ProximityEvent object provides a reference to the proximate GameObject. 
+     * @since 4.1.2
+     */
+    [Tooltip("Dispatched when a target object is grasped.")]
+    public InteractiveBehaviorGraspEvent OnGrasp;
+
+    [Tooltip("Activate when any interactable object is grasped.")]
+    public bool AnyInteractionObject = false;
+    /**
+     * The list of IInteractionBehaviour objects which can activate the detector when held.
+     * @since 4.1.2
+     */
+    [Tooltip("The list of target objects.")]
+    public IInteractionBehaviour[] TargetObjects;
+
+    /**
+    * IInteractiveBehaviour objects with this tag name will activate the detector.
+    * @since 4.1.3
+    */
+    [Tooltip("Activate if the held object has this tag name.")]
+    public string TagName = "";
+
+    /**
+     * The object that is currently held.
+     * 
+     * @since 4.1.2
+     */
+    public IInteractionBehaviour CurrentObject { get { return _currentObj; } }
+
+    private IEnumerator watcherCoroutine;
+    private IInteractionBehaviour _currentObj = null;
+
+    void Awake() {
+      watcherCoroutine = graspWatcher();
+    }
+
+    void OnEnable() {
+      StopCoroutine(watcherCoroutine);
+      StartCoroutine(watcherCoroutine);
+    }
+
+    void OnDisable() {
+      StopCoroutine(watcherCoroutine);
+      Deactivate();
+    }
+
+    IEnumerator graspWatcher() {
+      bool graspingState = false;
+      IInteractionBehaviour graspedObject;
+      int handId = 0;
+      while (true) {
+        if (ieManager != null) {
+          Leap.Hand hand = HandModel.GetLeapHand();
+          if(hand != null) {
+            handId = hand.Id;
+          } else {
+            handId = 0;
+          }
+          ieManager.TryGetGraspedObject(handId, out graspedObject);
+          graspingState = false;
+          if (graspedObject != null) {
+            if ((AnyInteractionObject ||
+                (TagName != "" && graspedObject.gameObject.tag == TagName))) {
+              graspingState = true;
+            } else {
+              for (int o = 0; o < TargetObjects.Length; o++) {
+                if (TargetObjects[o] == graspedObject) {
+                  graspingState = true;
+                  break;
+                }
+              }
+            }
+          }
+          if (graspingState) {
+            if(_currentObj != graspedObject) {
+              _currentObj = graspedObject;
+              OnGrasp.Invoke(_currentObj);
+            }
+            Activate();
+          } else {
+            _currentObj = null;
+            Deactivate();
+          }
+        }
+        yield return new WaitForSeconds(Period);
+      }
+    }
+  }
+
+  /**
+   * An event class that is dispatched by a InteractionGraspDetector when one of its target
+   * IInteractiveBehavior objects is grasped.
+   * The event parameters provide the IInteractionBehaviour object.
+   * @since 4.1.2
+   */
+  [System.Serializable]
+  public class InteractiveBehaviorGraspEvent : UnityEvent<IInteractionBehaviour> { }
+}

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/InteractionGraspDetector.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/InteractionGraspDetector.cs
@@ -17,6 +17,14 @@ namespace Leap.Unity.Interaction {
   public class InteractionGraspDetector : Detector {
 
     /**
+     * Dispatched when a target interactable object is grasped.
+     * The InteractiveBehaviorGraspEvent object provides a reference to the IInteractiveBehavior instance. 
+     * @since 4.1.5
+     */
+    [Tooltip("Dispatched when a target object is grasped.")]
+    public InteractiveBehaviorGraspEvent OnGrasp;
+
+    /**
     * The InteractionManager managing the target objects. All
     * targets must be managed by this manager.
     * @since 4.1.5
@@ -24,6 +32,7 @@ namespace Leap.Unity.Interaction {
     [AutoFind(AutoFindLocations.Scene)]
     [Tooltip("The Interaction Manager.")]
     public InteractionManager ieManager = null;
+
     /**
      * The IHandModel instance to observe. 
      * Set automatically if not explicitly set in the editor.
@@ -34,18 +43,12 @@ namespace Leap.Unity.Interaction {
     public IHandModel HandModel = null;
 
     /**
- * The interval at which to check palm direction.
- * @since 4.1.5
- */
+    * The interval at which to check palm direction.
+    * @since 4.1.5
+    */
+    [MinValue(0)]
     [Tooltip("The interval in seconds at which to check this detector's conditions.")]
     public float Period = .1f; //seconds
-    /**
-     * Dispatched when a target interactable object is grasped.
-     * The InteractiveBehaviorGraspEvent object provides a reference to the IInteractiveBehavior instance. 
-     * @since 4.1.5
-     */
-    [Tooltip("Dispatched when a target object is grasped.")]
-    public InteractiveBehaviorGraspEvent OnGrasp;
 
     [Tooltip("Activate when any interactable object is grasped.")]
     public bool AnyInteractionObject = false;

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/InteractionGraspDetector.cs.meta
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/InteractionGraspDetector.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: bb1e22808916c2f439feea23775d42bd
+timeCreated: 1472162530
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
A Detector that activates when an IInteractionBehaviour instance is grasped under the auspices of the Interaction Engine.

You can specify that any intractable object can activate the detector; you can supply a tag name, and you can supply a specific list of target objects. (Tags and the list are additive.)