### PR TITLE
Fixed multi-value editing

### DIFF
--- a/Assets/LeapMotion/Scripts/Attributes/Editor/CombinablePropertyDrawer.cs
+++ b/Assets/LeapMotion/Scripts/Attributes/Editor/CombinablePropertyDrawer.cs
@@ -15,9 +15,9 @@ namespace Leap.Unity.Attributes {
         CombinablePropertyAttribute combinableProperty = o as CombinablePropertyAttribute;
         if (combinableProperty != null) {
           if (combinableProperty.SupportedTypes.Count() != 0 && !combinableProperty.SupportedTypes.Contains(property.propertyType)) {
-            Debug.LogError("Property attribute " + 
-                           combinableProperty.GetType().Name + 
-                           " does not support property type " + 
+            Debug.LogError("Property attribute " +
+                           combinableProperty.GetType().Name +
+                           " does not support property type " +
                            property.propertyType + ".");
             continue;
           }
@@ -84,6 +84,7 @@ namespace Leap.Unity.Attributes {
       }
 
       Rect r = position;
+      EditorGUI.BeginChangeCheck();
       EditorGUI.BeginDisabledGroup(shouldDisable);
 
       drawAdditive<IBeforeLabelAdditiveDrawer>(ref r, property);
@@ -123,10 +124,13 @@ namespace Leap.Unity.Attributes {
       drawAdditive<IAfterFieldAdditiveDrawer>(ref r, property);
 
       EditorGUI.EndDisabledGroup();
+      bool didChange = EditorGUI.EndChangeCheck();
 
-      foreach (var a in attributes) {
-        if (a is IPropertyConstrainer) {
-          (a as IPropertyConstrainer).ConstrainValue(property);
+      if (didChange || !property.hasMultipleDifferentValues) {
+        foreach (var a in attributes) {
+          if (a is IPropertyConstrainer) {
+            (a as IPropertyConstrainer).ConstrainValue(property);
+          }
         }
       }
 


### PR DESCRIPTION
When highlighting multiple components of the same type, any properties with constraint attributes would automatically all resolve to the same value, even if they all had different values.  This would silently lose information.

Now constraints are only applied when the user gui detects a change for that field, or when only one value is being edited.