### PR TITLE
DisableIf now supports enum values

### DIFF
--- a/Assets/LeapMotion/Scripts/Attributes/DisableIf.cs
+++ b/Assets/LeapMotion/Scripts/Attributes/DisableIf.cs
@@ -11,18 +11,26 @@ namespace Leap.Unity.Attributes {
     public readonly object testValue;
     public readonly bool disableResult;
 
-    public DisableIf(string propertyName, object equalTo = null, object notEqualTo = null) {
+    /// <summary>
+    /// Conditionally disables a property based on the value of another property.  The only condition
+    /// types that are currently supported are bool types, and enum types.  The property has two arguments
+    /// names 'equalTo' and 'notEqualTo'.  Exactly one of them must be specified, like so:
+    /// 
+    /// [DisableIf("myBoolProperty", isEqualTo: true)]
+    /// [DisableIf("myEnumProperty", isNotEqualTo: MyEnum.Value)]
+    /// </summary>
+    public DisableIf(string propertyName, object isEqualTo = null, object isNotEqualTo = null) {
       this.propertyName = propertyName;
 
-      if ((equalTo != null) == (notEqualTo != null)) {
+      if ((isEqualTo != null) == (isNotEqualTo != null)) {
         throw new ArgumentException("Must specify exactly one of 'equalTo' or 'notEqualTo'.");
       }
 
-      if (equalTo != null) {
-        testValue = equalTo;
+      if (isEqualTo != null) {
+        testValue = isEqualTo;
         disableResult = true;
-      } else if (notEqualTo != null) {
-        testValue = notEqualTo;
+      } else if (isNotEqualTo != null) {
+        testValue = isNotEqualTo;
         disableResult = false;
       }
 

--- a/Assets/LeapMotion/Scripts/Attributes/DisableIf.cs
+++ b/Assets/LeapMotion/Scripts/Attributes/DisableIf.cs
@@ -1,22 +1,48 @@
-﻿#if UNITY_EDITOR
+﻿using UnityEngine;
+#if UNITY_EDITOR
 using UnityEditor;
 #endif
+using System;
 
 namespace Leap.Unity.Attributes {
 
   public class DisableIf : CombinablePropertyAttribute, IPropertyDisabler {
     public readonly string propertyName;
-    public readonly bool equalTo;
+    public readonly object testValue;
+    public readonly bool disableResult;
 
-    public DisableIf(string propertyName, bool equalTo = true) {
+    public DisableIf(string propertyName, object equalTo = null, object notEqualTo = null) {
       this.propertyName = propertyName;
-      this.equalTo = equalTo;
+
+      if ((equalTo != null) == (notEqualTo != null)) {
+        throw new ArgumentException("Must specify exactly one of 'equalTo' or 'notEqualTo'.");
+      }
+
+      if (equalTo != null) {
+        testValue = equalTo;
+        disableResult = true;
+      } else if (notEqualTo != null) {
+        testValue = notEqualTo;
+        disableResult = false;
+      }
+
+      if (!(testValue is bool) && !(testValue is Enum)) {
+        throw new ArgumentException("Only values of bool or Enum are allowed in comparisons using DisableIf.");
+      }
     }
 
 #if UNITY_EDITOR
     public bool ShouldDisable(SerializedProperty property) {
       SerializedProperty prop = property.serializedObject.FindProperty(propertyName);
-      return prop.boolValue == equalTo;
+
+      if (prop.propertyType == SerializedPropertyType.Boolean) {
+        return (prop.boolValue == (bool)testValue) == disableResult;
+      } else if (prop.propertyType == SerializedPropertyType.Enum) {
+        return (prop.intValue == (int)testValue) == disableResult;
+      } else {
+        Debug.LogError("Can only conditionally disable based on boolean or enum types.");
+        return false;
+      }
     }
 #endif
   }


### PR DESCRIPTION
 - Disable if now supports enum values as well as bools
 - Supports specifying whether or not you are testing for equality or inequality

To Test:
 - [x] Bools still function as expected
 - [x] Enums now work as well!
 - [x] Both isEqualTo and isNotEqualTo function as expected
@jo3w4rd 