### PR TITLE
Feature serializable dictionary

### DIFF
--- a/Assets/LeapMotion/Scripts/DataStructures/Editor/SerializableDictionaryEditor.cs
+++ b/Assets/LeapMotion/Scripts/DataStructures/Editor/SerializableDictionaryEditor.cs
@@ -196,7 +196,7 @@ public class SerializableDictionaryEditor : PropertyDrawer {
       copy.NextVisible(true);
       while (!SerializedProperty.EqualContents(copy, endProp)) {
         r.height = EditorGUI.GetPropertyHeight(copy);
-        EditorGUI.PropertyField(r, copy, false);
+        EditorGUI.PropertyField(r, copy, true);
         r.y += r.height;
         copy.NextVisible(false);
       }

--- a/Assets/LeapMotion/Scripts/DataStructures/Editor/SerializableDictionaryEditor.cs
+++ b/Assets/LeapMotion/Scripts/DataStructures/Editor/SerializableDictionaryEditor.cs
@@ -1,0 +1,208 @@
+﻿using UnityEngine;
+using UnityEditor;
+using UnityEditorInternal;
+using System.Collections.Generic;
+
+[CustomPropertyDrawer(typeof(SDictionary))]
+public class SerializableDictionaryEditor : PropertyDrawer {
+
+  private ReorderableList _list;
+  private SerializedProperty _currProperty;
+
+  private List<Pair> _pairs = new List<Pair>();
+  private class Pair {
+    public int index;
+    public bool isDuplicate;
+    public SerializedProperty a;
+    public SerializedProperty b;
+
+    public Pair(int index, bool isDuplicate, SerializedProperty a, SerializedProperty b) {
+      this.index = index;
+      this.isDuplicate = isDuplicate;
+      this.a = a;
+      this.b = b;
+    }
+  }
+
+  public SerializableDictionaryEditor() {
+    _list = new ReorderableList(_pairs, typeof(Pair),
+                                draggable: true,
+                                displayHeader: true,
+                                displayAddButton: true,
+                                displayRemoveButton: true);
+
+    _list.drawElementCallback = drawElementCallback;
+    _list.elementHeightCallback = elementHeightCallback;
+    _list.drawHeaderCallback = drawHeader;
+    _list.onAddCallback = onAddCallback;
+    _list.onRemoveCallback = onRemoveCallback;
+    _list.onReorderCallback = onReorderCallback;
+  }
+
+
+  public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
+    _currProperty = property;
+
+    updatePairsFromProperty(property);
+
+    EditorGUIUtility.labelWidth /= 2;
+    _list.DoList(position);
+    EditorGUIUtility.labelWidth *= 2;
+  }
+
+  public override float GetPropertyHeight(SerializedProperty property, GUIContent label) {
+    updatePairsFromProperty(property);
+    return _list.GetHeight();
+  }
+
+  private void updatePairsFromProperty(SerializedProperty property) {
+    SerializedProperty keys = property.FindPropertyRelative("_keys");
+    SerializedProperty values = property.FindPropertyRelative("_values");
+
+    var dup = (fieldInfo.GetValue(property.serializedObject.targetObject) as ICanReportDuplicateInformation).GetDuplicationInformation();
+
+    _pairs.Clear();
+    int count = keys.arraySize;
+    for (int i = 0; i < count; i++) {
+      SerializedProperty key = keys.GetArrayElementAtIndex(i);
+      SerializedProperty value = values.GetArrayElementAtIndex(i);
+
+      bool isDup = false;
+      if (i < dup.Count) {
+        isDup = dup[i] > 1;
+      }
+
+      _pairs.Add(new Pair(i, isDup, key, value));
+    }
+  }
+
+  private void drawHeader(Rect rect) {
+    EditorGUI.LabelField(rect, _currProperty.displayName);
+    rect.x += rect.width - 110;
+    rect.width = 110;
+    if (GUI.Button(rect, "Clear Duplicates")) {
+      Undo.RecordObject(_currProperty.serializedObject.targetObject, "Cleared duplicates");
+      (fieldInfo.GetValue(_currProperty.serializedObject.targetObject) as ICanReportDuplicateInformation).ClearDuplicates();
+    }
+  }
+
+  private void drawElementCallback(Rect rect, int index, bool isActive, bool isFocused) {
+    Rect leftRect = rect;
+    leftRect.width *= 0.5f;
+
+    Rect rightRect = leftRect;
+    rightRect.x += rightRect.width;
+
+    Pair pair = _pairs[index];
+
+    if (pair.isDuplicate) {
+      GUI.contentColor = new Color(1, 0.7f, 0);
+      GUI.color = new Color(1, 0.7f, 0.5f);
+    }
+
+    drawProp(pair.a, leftRect);
+
+    GUI.contentColor = Color.white;
+    GUI.color = Color.white;
+    GUI.backgroundColor = Color.white;
+
+    drawProp(pair.b, rightRect);
+  }
+
+  private void onAddCallback(ReorderableList list) {
+    SerializedProperty keys = _currProperty.FindPropertyRelative("_keys");
+    SerializedProperty values = _currProperty.FindPropertyRelative("_values");
+
+    keys.arraySize++;
+    values.arraySize++;
+
+    updatePairsFromProperty(_currProperty);
+  }
+
+  private void onRemoveCallback(ReorderableList list) {
+    SerializedProperty keys = _currProperty.FindPropertyRelative("_keys");
+    SerializedProperty values = _currProperty.FindPropertyRelative("_values");
+
+    keys.DeleteArrayElementAtIndex(list.index);
+    values.DeleteArrayElementAtIndex(list.index);
+
+    updatePairsFromProperty(_currProperty);
+  }
+
+  private void onReorderCallback(ReorderableList list) {
+    SerializedProperty keys = _currProperty.FindPropertyRelative("_keys");
+    SerializedProperty values = _currProperty.FindPropertyRelative("_values");
+
+    int startIndex = -1, endIndex = -1;
+    bool isForward = true;
+
+    for (int i = 0; i < _pairs.Count; i++) {
+      if (i != _pairs[i].index) {
+        if (_pairs[i].index - i > 1) {
+          isForward = false;
+        }
+        startIndex = i;
+        break;
+      }
+    }
+
+    for (int i = _pairs.Count; i-- != 0;) {
+      if (i != _pairs[i].index) {
+        endIndex = i;
+        break;
+      }
+    }
+
+    if (isForward) {
+      keys.MoveArrayElement(startIndex, endIndex);
+      values.MoveArrayElement(startIndex, endIndex);
+    } else {
+      keys.MoveArrayElement(endIndex, startIndex);
+      values.MoveArrayElement(endIndex, startIndex);
+    }
+
+    updatePairsFromProperty(_currProperty);
+  }
+
+  private float elementHeightCallback(int index) {
+    Pair pair = _pairs[index];
+    float size = Mathf.Max(getSize(pair.a), getSize(pair.b));
+    _list.elementHeight = size;
+    return size;
+  }
+
+  private float getSize(SerializedProperty prop) {
+
+    float size = 0;
+    if (prop.propertyType == SerializedPropertyType.Generic) {
+      SerializedProperty copy = prop.Copy();
+      SerializedProperty endProp = copy.GetEndProperty(false);
+
+      copy.NextVisible(true);
+      while (!SerializedProperty.EqualContents(copy, endProp)) {
+        size += EditorGUI.GetPropertyHeight(copy);
+        copy.NextVisible(false);
+      }
+    } else {
+      size = EditorGUI.GetPropertyHeight(prop, GUIContent.none, false);
+    }
+    return size;
+  }
+
+  private void drawProp(SerializedProperty prop, Rect r) {
+    if (prop.propertyType == SerializedPropertyType.Generic) {
+      SerializedProperty copy = prop.Copy();
+      SerializedProperty endProp = copy.GetEndProperty(false);
+      copy.NextVisible(true);
+      while (!SerializedProperty.EqualContents(copy, endProp)) {
+        r.height = EditorGUI.GetPropertyHeight(copy);
+        EditorGUI.PropertyField(r, copy, false);
+        r.y += r.height;
+        copy.NextVisible(false);
+      }
+    } else {
+      r.height = EditorGUI.GetPropertyHeight(prop);
+      EditorGUI.PropertyField(r, prop, GUIContent.none, false);
+    }
+  }
+}

--- a/Assets/LeapMotion/Scripts/DataStructures/Editor/SerializableDictionaryEditor.cs
+++ b/Assets/LeapMotion/Scripts/DataStructures/Editor/SerializableDictionaryEditor.cs
@@ -102,6 +102,11 @@ namespace Leap.Unity {
         GUI.color = new Color(1, 0.7f, 0.5f);
       }
 
+      if (pair.a.propertyType == SerializedPropertyType.ObjectReference && pair.a.objectReferenceValue == null) {
+        GUI.contentColor = new Color(1, 0, 0);
+        GUI.color = new Color(1, 0, 0);
+      }
+
       drawProp(pair.a, leftRect);
 
       GUI.contentColor = Color.white;

--- a/Assets/LeapMotion/Scripts/DataStructures/Editor/SerializableDictionaryEditor.cs
+++ b/Assets/LeapMotion/Scripts/DataStructures/Editor/SerializableDictionaryEditor.cs
@@ -83,8 +83,15 @@ namespace Leap.Unity {
       rect.x += rect.width - 110;
       rect.width = 110;
       if (GUI.Button(rect, "Clear Duplicates")) {
+        markDirty(_currProperty);
+
         Undo.RecordObject(_currProperty.serializedObject.targetObject, "Cleared duplicates");
         (fieldInfo.GetValue(_currProperty.serializedObject.targetObject) as ICanReportDuplicateInformation).ClearDuplicates();
+
+        _currProperty.serializedObject.Update();
+
+        markDirty(_currProperty);
+        updatePairsFromProperty(_currProperty);
       }
     }
 
@@ -130,8 +137,8 @@ namespace Leap.Unity {
       SerializedProperty keys = _currProperty.FindPropertyRelative("_keys");
       SerializedProperty values = _currProperty.FindPropertyRelative("_values");
 
-      keys.DeleteArrayElementAtIndex(list.index);
-      values.DeleteArrayElementAtIndex(list.index);
+      actuallyDeleteAt(keys, list.index);
+      actuallyDeleteAt(values, list.index);
 
       updatePairsFromProperty(_currProperty);
     }
@@ -210,6 +217,22 @@ namespace Leap.Unity {
       } else {
         r.height = EditorGUI.GetPropertyHeight(prop);
         EditorGUI.PropertyField(r, prop, GUIContent.none, false);
+      }
+    }
+
+    private void markDirty(SerializedProperty property) {
+      SerializedProperty keys = property.FindPropertyRelative("_keys");
+      int size = keys.arraySize;
+
+      keys.InsertArrayElementAtIndex(size);
+      actuallyDeleteAt(keys, size);
+    }
+
+    private static void actuallyDeleteAt(SerializedProperty property, int index) {
+      int arraySize = property.arraySize;
+
+      while (property.arraySize == arraySize) {
+        property.DeleteArrayElementAtIndex(index);
       }
     }
   }

--- a/Assets/LeapMotion/Scripts/DataStructures/Editor/SerializableDictionaryEditor.cs
+++ b/Assets/LeapMotion/Scripts/DataStructures/Editor/SerializableDictionaryEditor.cs
@@ -43,18 +43,27 @@ namespace Leap.Unity {
 
 
     public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
-      _currProperty = property;
+      if (property.hasMultipleDifferentValues) {
+        GUI.Box(position, "");
+        EditorGUI.LabelField(position, "Multi-object editing not supported for Serialized Dictionaries.", EditorStyles.miniLabel);
+      } else {
+        _currProperty = property;
 
-      updatePairsFromProperty(property);
+        updatePairsFromProperty(property);
 
-      EditorGUIUtility.labelWidth /= 2;
-      _list.DoList(position);
-      EditorGUIUtility.labelWidth *= 2;
+        EditorGUIUtility.labelWidth /= 2;
+        _list.DoList(position);
+        EditorGUIUtility.labelWidth *= 2;
+      }
     }
 
     public override float GetPropertyHeight(SerializedProperty property, GUIContent label) {
-      updatePairsFromProperty(property);
-      return _list.GetHeight();
+      if (property.hasMultipleDifferentValues) {
+        return EditorGUIUtility.singleLineHeight;
+      } else {
+        updatePairsFromProperty(property);
+        return _list.GetHeight();
+      }
     }
 
     private void updatePairsFromProperty(SerializedProperty property) {

--- a/Assets/LeapMotion/Scripts/DataStructures/Editor/SerializableDictionaryEditor.cs
+++ b/Assets/LeapMotion/Scripts/DataStructures/Editor/SerializableDictionaryEditor.cs
@@ -3,206 +3,209 @@ using UnityEditor;
 using UnityEditorInternal;
 using System.Collections.Generic;
 
-[CustomPropertyDrawer(typeof(SDictionary))]
-public class SerializableDictionaryEditor : PropertyDrawer {
+namespace Leap.Unity {
 
-  private ReorderableList _list;
-  private SerializedProperty _currProperty;
+  [CustomPropertyDrawer(typeof(SDictionaryAttribute))]
+  public class SerializableDictionaryEditor : PropertyDrawer {
 
-  private List<Pair> _pairs = new List<Pair>();
-  private class Pair {
-    public int index;
-    public bool isDuplicate;
-    public SerializedProperty a;
-    public SerializedProperty b;
+    private ReorderableList _list;
+    private SerializedProperty _currProperty;
 
-    public Pair(int index, bool isDuplicate, SerializedProperty a, SerializedProperty b) {
-      this.index = index;
-      this.isDuplicate = isDuplicate;
-      this.a = a;
-      this.b = b;
-    }
-  }
+    private List<Pair> _pairs = new List<Pair>();
+    private class Pair {
+      public int index;
+      public bool isDuplicate;
+      public SerializedProperty a;
+      public SerializedProperty b;
 
-  public SerializableDictionaryEditor() {
-    _list = new ReorderableList(_pairs, typeof(Pair),
-                                draggable: true,
-                                displayHeader: true,
-                                displayAddButton: true,
-                                displayRemoveButton: true);
-
-    _list.drawElementCallback = drawElementCallback;
-    _list.elementHeightCallback = elementHeightCallback;
-    _list.drawHeaderCallback = drawHeader;
-    _list.onAddCallback = onAddCallback;
-    _list.onRemoveCallback = onRemoveCallback;
-    _list.onReorderCallback = onReorderCallback;
-  }
-
-
-  public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
-    _currProperty = property;
-
-    updatePairsFromProperty(property);
-
-    EditorGUIUtility.labelWidth /= 2;
-    _list.DoList(position);
-    EditorGUIUtility.labelWidth *= 2;
-  }
-
-  public override float GetPropertyHeight(SerializedProperty property, GUIContent label) {
-    updatePairsFromProperty(property);
-    return _list.GetHeight();
-  }
-
-  private void updatePairsFromProperty(SerializedProperty property) {
-    SerializedProperty keys = property.FindPropertyRelative("_keys");
-    SerializedProperty values = property.FindPropertyRelative("_values");
-
-    var dup = (fieldInfo.GetValue(property.serializedObject.targetObject) as ICanReportDuplicateInformation).GetDuplicationInformation();
-
-    _pairs.Clear();
-    int count = keys.arraySize;
-    for (int i = 0; i < count; i++) {
-      SerializedProperty key = keys.GetArrayElementAtIndex(i);
-      SerializedProperty value = values.GetArrayElementAtIndex(i);
-
-      bool isDup = false;
-      if (i < dup.Count) {
-        isDup = dup[i] > 1;
+      public Pair(int index, bool isDuplicate, SerializedProperty a, SerializedProperty b) {
+        this.index = index;
+        this.isDuplicate = isDuplicate;
+        this.a = a;
+        this.b = b;
       }
-
-      _pairs.Add(new Pair(i, isDup, key, value));
-    }
-  }
-
-  private void drawHeader(Rect rect) {
-    EditorGUI.LabelField(rect, _currProperty.displayName);
-    rect.x += rect.width - 110;
-    rect.width = 110;
-    if (GUI.Button(rect, "Clear Duplicates")) {
-      Undo.RecordObject(_currProperty.serializedObject.targetObject, "Cleared duplicates");
-      (fieldInfo.GetValue(_currProperty.serializedObject.targetObject) as ICanReportDuplicateInformation).ClearDuplicates();
-    }
-  }
-
-  private void drawElementCallback(Rect rect, int index, bool isActive, bool isFocused) {
-    Rect leftRect = rect;
-    leftRect.width *= 0.5f;
-
-    Rect rightRect = leftRect;
-    rightRect.x += rightRect.width;
-
-    Pair pair = _pairs[index];
-
-    if (pair.isDuplicate) {
-      GUI.contentColor = new Color(1, 0.7f, 0);
-      GUI.color = new Color(1, 0.7f, 0.5f);
     }
 
-    drawProp(pair.a, leftRect);
+    public SerializableDictionaryEditor() {
+      _list = new ReorderableList(_pairs, typeof(Pair),
+                                  draggable: true,
+                                  displayHeader: true,
+                                  displayAddButton: true,
+                                  displayRemoveButton: true);
 
-    GUI.contentColor = Color.white;
-    GUI.color = Color.white;
-    GUI.backgroundColor = Color.white;
+      _list.drawElementCallback = drawElementCallback;
+      _list.elementHeightCallback = elementHeightCallback;
+      _list.drawHeaderCallback = drawHeader;
+      _list.onAddCallback = onAddCallback;
+      _list.onRemoveCallback = onRemoveCallback;
+      _list.onReorderCallback = onReorderCallback;
+    }
 
-    drawProp(pair.b, rightRect);
-  }
 
-  private void onAddCallback(ReorderableList list) {
-    SerializedProperty keys = _currProperty.FindPropertyRelative("_keys");
-    SerializedProperty values = _currProperty.FindPropertyRelative("_values");
+    public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
+      _currProperty = property;
 
-    keys.arraySize++;
-    values.arraySize++;
+      updatePairsFromProperty(property);
 
-    updatePairsFromProperty(_currProperty);
-  }
+      EditorGUIUtility.labelWidth /= 2;
+      _list.DoList(position);
+      EditorGUIUtility.labelWidth *= 2;
+    }
 
-  private void onRemoveCallback(ReorderableList list) {
-    SerializedProperty keys = _currProperty.FindPropertyRelative("_keys");
-    SerializedProperty values = _currProperty.FindPropertyRelative("_values");
+    public override float GetPropertyHeight(SerializedProperty property, GUIContent label) {
+      updatePairsFromProperty(property);
+      return _list.GetHeight();
+    }
 
-    keys.DeleteArrayElementAtIndex(list.index);
-    values.DeleteArrayElementAtIndex(list.index);
+    private void updatePairsFromProperty(SerializedProperty property) {
+      SerializedProperty keys = property.FindPropertyRelative("_keys");
+      SerializedProperty values = property.FindPropertyRelative("_values");
 
-    updatePairsFromProperty(_currProperty);
-  }
+      var dup = (fieldInfo.GetValue(property.serializedObject.targetObject) as ICanReportDuplicateInformation).GetDuplicationInformation();
 
-  private void onReorderCallback(ReorderableList list) {
-    SerializedProperty keys = _currProperty.FindPropertyRelative("_keys");
-    SerializedProperty values = _currProperty.FindPropertyRelative("_values");
+      _pairs.Clear();
+      int count = keys.arraySize;
+      for (int i = 0; i < count; i++) {
+        SerializedProperty key = keys.GetArrayElementAtIndex(i);
+        SerializedProperty value = values.GetArrayElementAtIndex(i);
 
-    int startIndex = -1, endIndex = -1;
-    bool isForward = true;
-
-    for (int i = 0; i < _pairs.Count; i++) {
-      if (i != _pairs[i].index) {
-        if (_pairs[i].index - i > 1) {
-          isForward = false;
+        bool isDup = false;
+        if (i < dup.Count) {
+          isDup = dup[i] > 1;
         }
-        startIndex = i;
-        break;
+
+        _pairs.Add(new Pair(i, isDup, key, value));
       }
     }
 
-    for (int i = _pairs.Count; i-- != 0;) {
-      if (i != _pairs[i].index) {
-        endIndex = i;
-        break;
+    private void drawHeader(Rect rect) {
+      EditorGUI.LabelField(rect, _currProperty.displayName);
+      rect.x += rect.width - 110;
+      rect.width = 110;
+      if (GUI.Button(rect, "Clear Duplicates")) {
+        Undo.RecordObject(_currProperty.serializedObject.targetObject, "Cleared duplicates");
+        (fieldInfo.GetValue(_currProperty.serializedObject.targetObject) as ICanReportDuplicateInformation).ClearDuplicates();
       }
     }
 
-    if (isForward) {
-      keys.MoveArrayElement(startIndex, endIndex);
-      values.MoveArrayElement(startIndex, endIndex);
-    } else {
-      keys.MoveArrayElement(endIndex, startIndex);
-      values.MoveArrayElement(endIndex, startIndex);
+    private void drawElementCallback(Rect rect, int index, bool isActive, bool isFocused) {
+      Rect leftRect = rect;
+      leftRect.width *= 0.5f;
+
+      Rect rightRect = leftRect;
+      rightRect.x += rightRect.width;
+
+      Pair pair = _pairs[index];
+
+      if (pair.isDuplicate) {
+        GUI.contentColor = new Color(1, 0.7f, 0);
+        GUI.color = new Color(1, 0.7f, 0.5f);
+      }
+
+      drawProp(pair.a, leftRect);
+
+      GUI.contentColor = Color.white;
+      GUI.color = Color.white;
+      GUI.backgroundColor = Color.white;
+
+      drawProp(pair.b, rightRect);
     }
 
-    updatePairsFromProperty(_currProperty);
-  }
+    private void onAddCallback(ReorderableList list) {
+      SerializedProperty keys = _currProperty.FindPropertyRelative("_keys");
+      SerializedProperty values = _currProperty.FindPropertyRelative("_values");
 
-  private float elementHeightCallback(int index) {
-    Pair pair = _pairs[index];
-    float size = Mathf.Max(getSize(pair.a), getSize(pair.b));
-    _list.elementHeight = size;
-    return size;
-  }
+      keys.arraySize++;
+      values.arraySize++;
 
-  private float getSize(SerializedProperty prop) {
-
-    float size = 0;
-    if (prop.propertyType == SerializedPropertyType.Generic) {
-      SerializedProperty copy = prop.Copy();
-      SerializedProperty endProp = copy.GetEndProperty(false);
-
-      copy.NextVisible(true);
-      while (!SerializedProperty.EqualContents(copy, endProp)) {
-        size += EditorGUI.GetPropertyHeight(copy);
-        copy.NextVisible(false);
-      }
-    } else {
-      size = EditorGUI.GetPropertyHeight(prop, GUIContent.none, false);
+      updatePairsFromProperty(_currProperty);
     }
-    return size;
-  }
 
-  private void drawProp(SerializedProperty prop, Rect r) {
-    if (prop.propertyType == SerializedPropertyType.Generic) {
-      SerializedProperty copy = prop.Copy();
-      SerializedProperty endProp = copy.GetEndProperty(false);
-      copy.NextVisible(true);
-      while (!SerializedProperty.EqualContents(copy, endProp)) {
-        r.height = EditorGUI.GetPropertyHeight(copy);
-        EditorGUI.PropertyField(r, copy, true);
-        r.y += r.height;
-        copy.NextVisible(false);
+    private void onRemoveCallback(ReorderableList list) {
+      SerializedProperty keys = _currProperty.FindPropertyRelative("_keys");
+      SerializedProperty values = _currProperty.FindPropertyRelative("_values");
+
+      keys.DeleteArrayElementAtIndex(list.index);
+      values.DeleteArrayElementAtIndex(list.index);
+
+      updatePairsFromProperty(_currProperty);
+    }
+
+    private void onReorderCallback(ReorderableList list) {
+      SerializedProperty keys = _currProperty.FindPropertyRelative("_keys");
+      SerializedProperty values = _currProperty.FindPropertyRelative("_values");
+
+      int startIndex = -1, endIndex = -1;
+      bool isForward = true;
+
+      for (int i = 0; i < _pairs.Count; i++) {
+        if (i != _pairs[i].index) {
+          if (_pairs[i].index - i > 1) {
+            isForward = false;
+          }
+          startIndex = i;
+          break;
+        }
       }
-    } else {
-      r.height = EditorGUI.GetPropertyHeight(prop);
-      EditorGUI.PropertyField(r, prop, GUIContent.none, false);
+
+      for (int i = _pairs.Count; i-- != 0;) {
+        if (i != _pairs[i].index) {
+          endIndex = i;
+          break;
+        }
+      }
+
+      if (isForward) {
+        keys.MoveArrayElement(startIndex, endIndex);
+        values.MoveArrayElement(startIndex, endIndex);
+      } else {
+        keys.MoveArrayElement(endIndex, startIndex);
+        values.MoveArrayElement(endIndex, startIndex);
+      }
+
+      updatePairsFromProperty(_currProperty);
+    }
+
+    private float elementHeightCallback(int index) {
+      Pair pair = _pairs[index];
+      float size = Mathf.Max(getSize(pair.a), getSize(pair.b));
+      _list.elementHeight = size;
+      return size;
+    }
+
+    private float getSize(SerializedProperty prop) {
+
+      float size = 0;
+      if (prop.propertyType == SerializedPropertyType.Generic) {
+        SerializedProperty copy = prop.Copy();
+        SerializedProperty endProp = copy.GetEndProperty(false);
+
+        copy.NextVisible(true);
+        while (!SerializedProperty.EqualContents(copy, endProp)) {
+          size += EditorGUI.GetPropertyHeight(copy);
+          copy.NextVisible(false);
+        }
+      } else {
+        size = EditorGUI.GetPropertyHeight(prop, GUIContent.none, false);
+      }
+      return size;
+    }
+
+    private void drawProp(SerializedProperty prop, Rect r) {
+      if (prop.propertyType == SerializedPropertyType.Generic) {
+        SerializedProperty copy = prop.Copy();
+        SerializedProperty endProp = copy.GetEndProperty(false);
+        copy.NextVisible(true);
+        while (!SerializedProperty.EqualContents(copy, endProp)) {
+          r.height = EditorGUI.GetPropertyHeight(copy);
+          EditorGUI.PropertyField(r, copy, true);
+          r.y += r.height;
+          copy.NextVisible(false);
+        }
+      } else {
+        r.height = EditorGUI.GetPropertyHeight(prop);
+        EditorGUI.PropertyField(r, prop, GUIContent.none, false);
+      }
     }
   }
 }

--- a/Assets/LeapMotion/Scripts/DataStructures/Editor/SerializableDictionaryEditor.cs.meta
+++ b/Assets/LeapMotion/Scripts/DataStructures/Editor/SerializableDictionaryEditor.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 00286de223036e24ca172c3f2641f53c
+timeCreated: 1473458946
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapMotion/Scripts/DataStructures/SerializableDictionary.cs
+++ b/Assets/LeapMotion/Scripts/DataStructures/SerializableDictionary.cs
@@ -1,0 +1,90 @@
+﻿using UnityEngine;
+using System.Collections.Generic;
+
+public class SDictionary : PropertyAttribute { }
+
+public interface ICanReportDuplicateInformation {
+  List<int> GetDuplicationInformation();
+  void ClearDuplicates();
+}
+
+public class SerializableDictionary<TKey, TValue> : Dictionary<TKey, TValue>, ICanReportDuplicateInformation, ISerializationCallbackReceiver {
+
+  [SerializeField]
+  private List<TKey> _keys;
+
+  [SerializeField]
+  private List<TValue> _values;
+
+  public void OnAfterDeserialize() {
+    Clear();
+
+    if (_keys != null && _values != null) {
+      int count = Mathf.Min(_keys.Count, _values.Count);
+      for (int i = 0; i < count; i++) {
+        this[_keys[i]] = _values[i];
+      }
+    }
+  }
+
+  public List<int> GetDuplicationInformation() {
+    Dictionary<TKey, int> info = new Dictionary<TKey, int>();
+
+    for (int i = 0; i < _keys.Count; i++) {
+      TKey key = _keys[i];
+      if (info.ContainsKey(key)) {
+        info[key]++;
+      } else {
+        info[key] = 1;
+      }
+    }
+
+    List<int> dups = new List<int>();
+    for (int i = 0; i < _keys.Count; i++) {
+      dups.Add(info[_keys[i]]);
+    }
+
+    return dups;
+  }
+
+  public void ClearDuplicates() {
+    HashSet<TKey> takenKeys = new HashSet<TKey>();
+    for (int i = 0; i < _keys.Count; i++) {
+      TKey key = _keys[i];
+      if (takenKeys.Contains(key)) {
+        _keys.RemoveAt(i);
+        _values.RemoveAt(i);
+        i--;
+      } else {
+        takenKeys.Add(key);
+      }
+    }
+  }
+
+  public void OnBeforeSerialize() {
+    if (_keys == null) {
+      _keys = new List<TKey>();
+    }
+
+    if (_values == null) {
+      _values = new List<TValue>();
+    }
+
+    for (int i = _keys.Count; i-- != 0;) {
+      if (!ContainsKey(_keys[i])) {
+        _keys.RemoveAt(i);
+        _values.RemoveAt(i);
+      }
+    }
+
+    Enumerator enumerator = GetEnumerator();
+    while (enumerator.MoveNext()) {
+      var pair = enumerator.Current;
+
+      if (!_keys.Contains(pair.Key)) {
+        _keys.Add(pair.Key);
+        _values.Add(pair.Value);
+      }
+    }
+  }
+}

--- a/Assets/LeapMotion/Scripts/DataStructures/SerializableDictionary.cs
+++ b/Assets/LeapMotion/Scripts/DataStructures/SerializableDictionary.cs
@@ -10,8 +10,10 @@ namespace Leap.Unity {
   public class SDictionaryAttribute : PropertyAttribute { }
 
   public interface ICanReportDuplicateInformation {
+#if UNITY_EDITOR
     List<int> GetDuplicationInformation();
     void ClearDuplicates();
+#endif
   }
 
   /// <summary>

--- a/Assets/LeapMotion/Scripts/DataStructures/SerializableDictionary.cs
+++ b/Assets/LeapMotion/Scripts/DataStructures/SerializableDictionary.cs
@@ -1,6 +1,7 @@
 ﻿using UnityEngine;
 using System.Text;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Leap.Unity {
 
@@ -32,12 +33,14 @@ namespace Leap.Unity {
     
     public override string ToString() {
       StringBuilder toReturn = new StringBuilder();
+      List<TKey> keys = Keys.ToList<TKey>();
+      List<TValue> values = Values.ToList<TValue>();
       toReturn.Append("[");
-      for (int i = 0; i < _keys.Count; i++) {
+      for (int i = 0; i < keys.Count; i++) {
         toReturn.Append("{");
-        toReturn.Append(_keys[i].ToString());
+        toReturn.Append(keys[i].ToString());
         toReturn.Append(" : ");
-        toReturn.Append(_values[i].ToString());
+        toReturn.Append(values[i].ToString());
         toReturn.Append("}, \n");
       }
       toReturn.Remove(toReturn.Length-3, 3);

--- a/Assets/LeapMotion/Scripts/DataStructures/SerializableDictionary.cs
+++ b/Assets/LeapMotion/Scripts/DataStructures/SerializableDictionary.cs
@@ -33,7 +33,14 @@ namespace Leap.Unity {
       if (_keys != null && _values != null) {
         int count = Mathf.Min(_keys.Count, _values.Count);
         for (int i = 0; i < count; i++) {
-          this[_keys[i]] = _values[i];
+          TKey key = _keys[i];
+          TValue value = _values[i];
+
+          if (key == null) {
+            continue;
+          }
+
+          this[key] = value;
         }
       }
 
@@ -49,6 +56,10 @@ namespace Leap.Unity {
 
       for (int i = 0; i < _keys.Count; i++) {
         TKey key = _keys[i];
+        if (key == null) {
+          continue;
+        }
+
         if (info.ContainsKey(key)) {
           info[key]++;
         } else {
@@ -58,7 +69,12 @@ namespace Leap.Unity {
 
       List<int> dups = new List<int>();
       for (int i = 0; i < _keys.Count; i++) {
-        dups.Add(info[_keys[i]]);
+        TKey key = _keys[i];
+        if (key == null) {
+          continue;
+        }
+
+        dups.Add(info[key]);
       }
 
       return dups;
@@ -90,7 +106,10 @@ namespace Leap.Unity {
 
 #if UNITY_EDITOR
       for (int i = _keys.Count; i-- != 0;) {
-        if (!ContainsKey(_keys[i])) {
+        TKey key = _keys[i];
+        if (key == null) continue;
+
+        if (!ContainsKey(key)) {
           _keys.RemoveAt(i);
           _values.RemoveAt(i);
         }

--- a/Assets/LeapMotion/Scripts/DataStructures/SerializableDictionary.cs
+++ b/Assets/LeapMotion/Scripts/DataStructures/SerializableDictionary.cs
@@ -1,4 +1,5 @@
 ﻿using UnityEngine;
+using System.Text;
 using System.Collections.Generic;
 
 namespace Leap.Unity {
@@ -28,6 +29,21 @@ namespace Leap.Unity {
 
     [SerializeField]
     private List<TValue> _values;
+    
+    public override string ToString() {
+      StringBuilder toReturn = new StringBuilder();
+      toReturn.Append("[");
+      for (int i = 0; i < _keys.Count; i++) {
+        toReturn.Append("{");
+        toReturn.Append(_keys[i].ToString());
+        toReturn.Append(" : ");
+        toReturn.Append(_values[i].ToString());
+        toReturn.Append("}, \n");
+      }
+      toReturn.Remove(toReturn.Length-3, 3);
+      toReturn.Append("]");
+      return toReturn.ToString();
+    }
 
     public void OnAfterDeserialize() {
       Clear();

--- a/Assets/LeapMotion/Scripts/DataStructures/SerializableDictionary.cs
+++ b/Assets/LeapMotion/Scripts/DataStructures/SerializableDictionary.cs
@@ -1,89 +1,101 @@
 ﻿using UnityEngine;
 using System.Collections.Generic;
 
-public class SDictionary : PropertyAttribute { }
+namespace Leap.Unity {
 
-public interface ICanReportDuplicateInformation {
-  List<int> GetDuplicationInformation();
-  void ClearDuplicates();
-}
+  /// <summary>
+  /// You must mark a serializable dictionary with this attribute in order to 
+  /// use the custom inspector editor.
+  /// </summary>
+  public class SDictionaryAttribute : PropertyAttribute { }
 
-public class SerializableDictionary<TKey, TValue> : Dictionary<TKey, TValue>, ICanReportDuplicateInformation, ISerializationCallbackReceiver {
-
-  [SerializeField]
-  private List<TKey> _keys;
-
-  [SerializeField]
-  private List<TValue> _values;
-
-  public void OnAfterDeserialize() {
-    Clear();
-
-    if (_keys != null && _values != null) {
-      int count = Mathf.Min(_keys.Count, _values.Count);
-      for (int i = 0; i < count; i++) {
-        this[_keys[i]] = _values[i];
-      }
-    }
+  public interface ICanReportDuplicateInformation {
+    List<int> GetDuplicationInformation();
+    void ClearDuplicates();
   }
 
-  public List<int> GetDuplicationInformation() {
-    Dictionary<TKey, int> info = new Dictionary<TKey, int>();
+  /// <summary>
+  /// In order to have this class be serialized, you will always need to create your own
+  /// non-generic version specific to your needs.  This is the same workflow that exists
+  /// for using the UnityEvent class as well. 
+  /// </summary>
+  public class SerializableDictionary<TKey, TValue> : Dictionary<TKey, TValue>, ICanReportDuplicateInformation, ISerializationCallbackReceiver {
+    
+    [SerializeField]
+    private List<TKey> _keys;
+    
+    [SerializeField]
+    private List<TValue> _values;
 
-    for (int i = 0; i < _keys.Count; i++) {
-      TKey key = _keys[i];
-      if (info.ContainsKey(key)) {
-        info[key]++;
-      } else {
-        info[key] = 1;
+    public void OnAfterDeserialize() {
+      Clear();
+
+      if (_keys != null && _values != null) {
+        int count = Mathf.Min(_keys.Count, _values.Count);
+        for (int i = 0; i < count; i++) {
+          this[_keys[i]] = _values[i];
+        }
       }
     }
 
-    List<int> dups = new List<int>();
-    for (int i = 0; i < _keys.Count; i++) {
-      dups.Add(info[_keys[i]]);
-    }
+    public List<int> GetDuplicationInformation() {
+      Dictionary<TKey, int> info = new Dictionary<TKey, int>();
 
-    return dups;
-  }
-
-  public void ClearDuplicates() {
-    HashSet<TKey> takenKeys = new HashSet<TKey>();
-    for (int i = 0; i < _keys.Count; i++) {
-      TKey key = _keys[i];
-      if (takenKeys.Contains(key)) {
-        _keys.RemoveAt(i);
-        _values.RemoveAt(i);
-        i--;
-      } else {
-        takenKeys.Add(key);
+      for (int i = 0; i < _keys.Count; i++) {
+        TKey key = _keys[i];
+        if (info.ContainsKey(key)) {
+          info[key]++;
+        } else {
+          info[key] = 1;
+        }
       }
-    }
-  }
 
-  public void OnBeforeSerialize() {
-    if (_keys == null) {
-      _keys = new List<TKey>();
-    }
+      List<int> dups = new List<int>();
+      for (int i = 0; i < _keys.Count; i++) {
+        dups.Add(info[_keys[i]]);
+      }
 
-    if (_values == null) {
-      _values = new List<TValue>();
+      return dups;
     }
 
-    for (int i = _keys.Count; i-- != 0;) {
-      if (!ContainsKey(_keys[i])) {
-        _keys.RemoveAt(i);
-        _values.RemoveAt(i);
+    public void ClearDuplicates() {
+      HashSet<TKey> takenKeys = new HashSet<TKey>();
+      for (int i = 0; i < _keys.Count; i++) {
+        TKey key = _keys[i];
+        if (takenKeys.Contains(key)) {
+          _keys.RemoveAt(i);
+          _values.RemoveAt(i);
+          i--;
+        } else {
+          takenKeys.Add(key);
+        }
       }
     }
 
-    Enumerator enumerator = GetEnumerator();
-    while (enumerator.MoveNext()) {
-      var pair = enumerator.Current;
+    public void OnBeforeSerialize() {
+      if (_keys == null) {
+        _keys = new List<TKey>();
+      }
 
-      if (!_keys.Contains(pair.Key)) {
-        _keys.Add(pair.Key);
-        _values.Add(pair.Value);
+      if (_values == null) {
+        _values = new List<TValue>();
+      }
+
+      for (int i = _keys.Count; i-- != 0;) {
+        if (!ContainsKey(_keys[i])) {
+          _keys.RemoveAt(i);
+          _values.RemoveAt(i);
+        }
+      }
+
+      Enumerator enumerator = GetEnumerator();
+      while (enumerator.MoveNext()) {
+        var pair = enumerator.Current;
+
+        if (!_keys.Contains(pair.Key)) {
+          _keys.Add(pair.Key);
+          _values.Add(pair.Value);
+        }
       }
     }
   }

--- a/Assets/LeapMotion/Scripts/DataStructures/SerializableDictionary.cs
+++ b/Assets/LeapMotion/Scripts/DataStructures/SerializableDictionary.cs
@@ -20,10 +20,10 @@ namespace Leap.Unity {
   /// for using the UnityEvent class as well. 
   /// </summary>
   public class SerializableDictionary<TKey, TValue> : Dictionary<TKey, TValue>, ICanReportDuplicateInformation, ISerializationCallbackReceiver {
-    
+
     [SerializeField]
     private List<TKey> _keys;
-    
+
     [SerializeField]
     private List<TValue> _values;
 
@@ -36,8 +36,14 @@ namespace Leap.Unity {
           this[_keys[i]] = _values[i];
         }
       }
+
+#if !UNITY_EDITOR
+      _keys.Clear();
+      _values.Clear();
+#endif
     }
 
+#if UNITY_EDITOR
     public List<int> GetDuplicationInformation() {
       Dictionary<TKey, int> info = new Dictionary<TKey, int>();
 
@@ -71,6 +77,7 @@ namespace Leap.Unity {
         }
       }
     }
+#endif
 
     public void OnBeforeSerialize() {
       if (_keys == null) {
@@ -81,21 +88,28 @@ namespace Leap.Unity {
         _values = new List<TValue>();
       }
 
+#if UNITY_EDITOR
       for (int i = _keys.Count; i-- != 0;) {
         if (!ContainsKey(_keys[i])) {
           _keys.RemoveAt(i);
           _values.RemoveAt(i);
         }
       }
+#endif
 
       Enumerator enumerator = GetEnumerator();
       while (enumerator.MoveNext()) {
         var pair = enumerator.Current;
 
+#if UNITY_EDITOR
         if (!_keys.Contains(pair.Key)) {
           _keys.Add(pair.Key);
           _values.Add(pair.Value);
         }
+#else
+        _keys.Add(pair.Key);
+        _values.Add(pair.Value);
+#endif
       }
     }
   }

--- a/Assets/LeapMotion/Scripts/DataStructures/SerializableDictionary.cs.meta
+++ b/Assets/LeapMotion/Scripts/DataStructures/SerializableDictionary.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: f19778805d6261f44864d12fb8297973
+timeCreated: 1473458947
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR adds the class SerializableDictionary, which is a subclass of the normal Dictionary class, but which supports unity serialization.  In order to use it, you will need to create a non-generic subclass for your specific use-case (just like using UnityEvent).  If you want the dictionary to show up nicely in the inspector, make sure to tag the dictionary with the [SDictionary] attribute.

To test:
 - [x] Make sure that when duplicate keys are present, that they are marked as duplicates (should appear yellow)
 - [x] Make sure that a serialized dictionary retains its values when Unity is closed
 - [x] Make sure that a serialized dictionary retains its values when the scene is played
 - [x] Make sure that a serialized dictionary retains its values in a build
 - [x] Make sure that a serialized dictionary retains its values when it is on an object that is duplicated.
 - [x] Make sure that you can use serializable structs as keys
 - [x] Make sure that you can use object references as keys (like gameObject)
 - [x] Make sure that null object-references do not get saved into the dictionary (they should appear red)
 - [x] Make sure that the button to remove duplicates works as expected.
 - [x] Make sure that you can remove pairs when the key is an object reference
 - [x] Make sure things don't crash when you try to multi-edit multiply dictionaries at once.