### PR TITLE
Fixed uninitialized values in Activity Monitor

### DIFF
--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/ActivityMonitor.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/ActivityMonitor.cs
@@ -40,6 +40,11 @@ namespace Leap.Unity.Interaction {
       Revive();
 
       _rigidbody = GetComponent<Rigidbody>();
+
+      _prevPosition = _rigidbody.position;
+      _prevVelocity = _rigidbody.velocity;
+      _prevRotation = _rigidbody.rotation;
+      _prevAngularVelocity = _rigidbody.angularVelocity;
     }
 
     public override void Revive() {


### PR DESCRIPTION
Previous values in the activity monitor were not initialized, and so any object that was found to be too far away from the origin (the default position) was detected as an explosion instead.  Values are now updated when the object is activated.

To test:
 - [x] Make sure objects are not considered exploded when they are activated too far away from the origin