### PR TITLE
Improve auto find

### DIFF
--- a/Assets/LeapMotion/Scripts/Attributes/AutoFindAttribute.cs
+++ b/Assets/LeapMotion/Scripts/Attributes/AutoFindAttribute.cs
@@ -54,7 +54,7 @@ namespace Leap.Unity.Attributes {
 
       for (int j = 0; j < scripts.Length; j++) {
         MonoBehaviour script = scripts[j];
-        
+
         SerializedObject sObj = new SerializedObject(script);
         SerializedProperty it = sObj.GetIterator();
 
@@ -68,6 +68,8 @@ namespace Leap.Unity.Attributes {
           KeyValuePair<AutoFindAttribute, FieldInfo> info;
           if (!cache.TryGetValue(key, out info)) {
             FieldInfo field = scriptType.GetField(it.name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy);
+            if (field == null) continue;
+
             object[] attributes = field.GetCustomAttributes(typeof(AutoFindAttribute), true);
 
             if (attributes.Length == 0) {

--- a/Assets/LeapMotion/Scripts/Attributes/AutoFindAttribute.cs
+++ b/Assets/LeapMotion/Scripts/Attributes/AutoFindAttribute.cs
@@ -1,7 +1,10 @@
 ﻿using System;
+using System.Reflection;
 using System.Collections.Generic;
 #if UNITY_EDITOR
 using UnityEditor;
+using UnityEditor.Callbacks;
+using UnityEditor.SceneManagement;
 #endif
 using UnityEngine;
 
@@ -26,14 +29,14 @@ namespace Leap.Unity.Attributes {
     public void ConstrainValue(SerializedProperty property) {
       if (property.objectReferenceValue != null) return;
       if (component == null) return;
-      
+
       if (search(property, AutoFindLocations.Object, component.GetComponent)) return;
       if (search(property, AutoFindLocations.Parents, component.GetComponentInParent)) return;
       if (search(property, AutoFindLocations.Children, component.GetComponentInChildren)) return;
       if (search(property, AutoFindLocations.Scene, UnityEngine.Object.FindObjectOfType)) return;
     }
 
-    private bool search(SerializedProperty property, AutoFindLocations location,Func<Type, UnityEngine.Object> searchDelegate) {
+    private bool search(SerializedProperty property, AutoFindLocations location, Func<Type, UnityEngine.Object> searchDelegate) {
       if ((_searchLocations & location) != 0) {
         var value = searchDelegate(fieldInfo.FieldType);
         if (value != null) {
@@ -42,6 +45,53 @@ namespace Leap.Unity.Attributes {
         }
       }
       return false;
+    }
+
+    [PostProcessScene]
+    private static void OnPostProcessScene() {
+      MonoBehaviour[] scripts = UnityEngine.Object.FindObjectsOfType<MonoBehaviour>();
+
+      Dictionary<KeyValuePair<Type, string>, KeyValuePair<AutoFindAttribute, FieldInfo>> cache = new Dictionary<KeyValuePair<Type, string>, KeyValuePair<AutoFindAttribute, FieldInfo>>();
+
+      for (int j = 0; j < scripts.Length; j++) {
+        MonoBehaviour script = scripts[j];
+        
+        SerializedObject sObj = new SerializedObject(script);
+        SerializedProperty it = sObj.GetIterator();
+
+        Type scriptType = script.GetType();
+        bool wasConstrained = false;
+
+        it.NextVisible(true);
+        while (it.NextVisible(false)) {
+          KeyValuePair<Type, string> key = new KeyValuePair<Type, string>(scriptType, it.name);
+
+          KeyValuePair<AutoFindAttribute, FieldInfo> info;
+          if (!cache.TryGetValue(key, out info)) {
+            FieldInfo field = scriptType.GetField(it.name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy);
+            object[] attributes = field.GetCustomAttributes(typeof(AutoFindAttribute), true);
+
+            if (attributes.Length == 0) {
+              cache[key] = new KeyValuePair<AutoFindAttribute, FieldInfo>(null, null);
+            } else {
+              cache[key] = info = new KeyValuePair<AutoFindAttribute, FieldInfo>(attributes[0] as AutoFindAttribute, field);
+            }
+          }
+
+          AutoFindAttribute attribute = info.Key;
+
+          if (attribute != null) {
+            wasConstrained = true;
+            attribute.component = script;
+            attribute.fieldInfo = info.Value;
+            attribute.ConstrainValue(it);
+          }
+        }
+
+        if (wasConstrained) {
+          sObj.ApplyModifiedProperties();
+        }
+      }
     }
 
     public override IEnumerable<SerializedPropertyType> SupportedTypes {

--- a/Assets/LeapMotion/Scripts/Attributes/AutoFindAttribute.cs
+++ b/Assets/LeapMotion/Scripts/Attributes/AutoFindAttribute.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 #if UNITY_EDITOR
 using UnityEditor;
 using UnityEditor.Callbacks;
-using UnityEditor.SceneManagement;
 #endif
 using UnityEngine;
 


### PR DESCRIPTION
Auto find now searches the scene upon play or build, and automatically runs AutoFind operations on any object that has it.  This ensures that even if the object has not been viewed, that it will still auto-find.

@protodeep 

To Test:
 - [x] Verify that an auto-found field gets filled even if it isn't viewed.