### PR TITLE
Moved all persistent logic inside check

### DIFF
--- a/Assets/LeapMotion/Scripts/Hands/IHandModel.cs
+++ b/Assets/LeapMotion/Scripts/Hands/IHandModel.cs
@@ -49,13 +49,15 @@ namespace Leap.Unity {
 
 #if UNITY_EDITOR
     void Update() {
-      Transform editorPoseSpace;
-      LeapServiceProvider leapServiceProvider = FindObjectOfType<LeapServiceProvider>();
-      if (leapServiceProvider) {
-        editorPoseSpace = leapServiceProvider.transform;
-      }
-      else editorPoseSpace = transform;
       if (!EditorApplication.isPlaying && SupportsEditorPersistence()) {
+        Transform editorPoseSpace;
+        LeapServiceProvider leapServiceProvider = FindObjectOfType<LeapServiceProvider>();
+        if (leapServiceProvider) {
+          editorPoseSpace = leapServiceProvider.transform;
+        } else {
+          editorPoseSpace = transform;
+        }
+
         Hand hand = TestHandFactory.MakeTestHand(0, 0, Handedness == Chirality.Left).TransformedCopy(UnityMatrixExtension.GetLeapMatrix(editorPoseSpace));
         if (GetLeapHand() == null) {
           SetLeapHand(hand);


### PR DESCRIPTION
Previously, some of the logic inside IHandModel for persistence was being done even if persistence was currently disabled.  This caused unnecessary overhead during runtime and edit time.

@protodeep 
@jselstad 
@nickjbenson 