### PR TITLE
Adds thread safe queue

### DIFF
--- a/Assets/LeapMotion/Scripts/DataStructures/Editor/Tests/ProduceConsumeBufferTest.cs
+++ b/Assets/LeapMotion/Scripts/DataStructures/Editor/Tests/ProduceConsumeBufferTest.cs
@@ -37,7 +37,7 @@ namespace Leap.Unity.Tests {
           TestStruct s;
           s.index = i;
           s.name = i.ToString();
-          while (!buffer.TryPush(ref s)) { }
+          while (!buffer.TryEnqueue(ref s)) { }
         }
       } catch (Exception e) {
         Assert.Fail(e.Message);
@@ -48,7 +48,7 @@ namespace Leap.Unity.Tests {
       try {
         for (int i = 0; i < buffer.Capacity; i++) {
           TestStruct s;
-          while (!buffer.TryPop(out s)) { }
+          while (!buffer.TryDequeue(out s)) { }
 
           Assert.That(s.index, Is.EqualTo(i));
           Assert.That(s.name, Is.EqualTo(i.ToString()));

--- a/Assets/LeapMotion/Scripts/DataStructures/Editor/Tests/ProduceConsumeBufferTest.cs
+++ b/Assets/LeapMotion/Scripts/DataStructures/Editor/Tests/ProduceConsumeBufferTest.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Threading;
+using NUnit.Framework;
+
+namespace Leap.Unity.Tests {
+
+  public class ProduceConsumeBufferTest {
+
+    private ProduceConsumeBuffer<TestStruct> buffer;
+
+    [SetUp]
+    public void Setup() {
+      buffer = new ProduceConsumeBuffer<TestStruct>(16);
+    }
+
+    [TearDown]
+    public void Teardown() {
+      buffer = null;
+    }
+
+    [Test]
+    [Timeout(1000)]
+    public void Test() {
+      Thread consumer = new Thread(new ThreadStart(consumerThread));
+      Thread producer = new Thread(new ThreadStart(producerThread));
+
+      consumer.Start();
+      producer.Start();
+
+      consumer.Join();
+      producer.Join();
+    }
+
+    private void consumerThread() {
+      try {
+        for (int i = 0; i < buffer.Capacity; i++) {
+          TestStruct s;
+          s.index = i;
+          s.name = i.ToString();
+          while (!buffer.TryPush(ref s)) { }
+        }
+      } catch (Exception e) {
+        Assert.Fail(e.Message);
+      }
+    }
+
+    private void producerThread() {
+      try {
+        for (int i = 0; i < buffer.Capacity; i++) {
+          TestStruct s;
+          while (!buffer.TryPop(out s)) { }
+
+          Assert.That(s.index, Is.EqualTo(i));
+          Assert.That(s.name, Is.EqualTo(i.ToString()));
+        }
+      } catch (Exception e) {
+        Assert.Fail(e.Message);
+      }
+    }
+
+    private struct TestStruct {
+      public int index;
+      public string name;
+    }
+  }
+}

--- a/Assets/LeapMotion/Scripts/DataStructures/Editor/Tests/ProduceConsumeBufferTest.cs.meta
+++ b/Assets/LeapMotion/Scripts/DataStructures/Editor/Tests/ProduceConsumeBufferTest.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: aec4e81abd45f9a4382f51a3b1042379
+timeCreated: 1478742443
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapMotion/Scripts/DataStructures/ProduceConsumeBuffer.cs
+++ b/Assets/LeapMotion/Scripts/DataStructures/ProduceConsumeBuffer.cs
@@ -10,7 +10,8 @@ namespace Leap.Unity {
 
     /// <summary>
     /// Constructs a new produce consumer buffer of a given capacity.  This capacity
-    /// is fixed and cannot be changed after the buffer is created.
+    /// is fixed and cannot be changed after the buffer is created.  This capacity
+    /// must be a power of two.
     /// </summary>
     public ProduceConsumeBuffer(int capacity) {
       if (capacity <= 0) {

--- a/Assets/LeapMotion/Scripts/DataStructures/ProduceConsumeBuffer.cs
+++ b/Assets/LeapMotion/Scripts/DataStructures/ProduceConsumeBuffer.cs
@@ -9,21 +9,30 @@ namespace Leap.Unity {
     private uint _head, _tail;
 
     /// <summary>
-    /// Constructs a new produce consumer buffer of a given capacity.  This capacity
-    /// is fixed and cannot be changed after the buffer is created.  This capacity
-    /// must be a power of two.
+    /// Constructs a new produce consumer buffer of at least a certain capacity.  Once the
+    /// buffer is created, the capacity cannot be modified.
     /// 
-    /// The power of two requirement is an optimization.  Internally this class can
-    /// use a bitwise AND operation instead of a slower modulus operation for indexing
-    /// if the length of the buffer is a power of two.
+    /// If the minimum capacity is a power of two, it will be used as the actual capacity.
+    /// If the minimum capacity is not a power of two, the next highest power of two will
+    /// be used as the capacity.  This behavior is an optimization, Internally this class 
+    /// uses a bitwise AND operation instead of a slower modulus operation for indexing, 
+    /// which only is possible if the array length is a power of two.
     /// </summary>
-    public ProduceConsumeBuffer(int capacity) {
-      if (capacity <= 0) {
+    public ProduceConsumeBuffer(int minCapacity) {
+      if (minCapacity <= 0) {
         throw new ArgumentOutOfRangeException("The capacity of the ProduceConsumeBuffer must be positive and non-zero.");
       }
 
-      if (Mathf.ClosestPowerOfTwo(capacity) != capacity) {
-        throw new ArgumentException("The capacity of the ProduceConsumeBuffer must be a power of two.");
+      int capacity;
+      int closestPowerOfTwo = Mathf.ClosestPowerOfTwo(minCapacity);
+      if (closestPowerOfTwo == minCapacity) {
+        capacity = minCapacity;
+      } else {
+        if (closestPowerOfTwo < minCapacity) {
+          capacity = closestPowerOfTwo * 2;
+        } else {
+          capacity = closestPowerOfTwo;
+        }
       }
 
       _buffer = new T[capacity];

--- a/Assets/LeapMotion/Scripts/DataStructures/ProduceConsumeBuffer.cs
+++ b/Assets/LeapMotion/Scripts/DataStructures/ProduceConsumeBuffer.cs
@@ -38,11 +38,11 @@ namespace Leap.Unity {
     }
 
     /// <summary>
-    /// Tries to push a value into the buffer.  If the buffer is already full, this
+    /// Tries to enqueue a value into the buffer.  If the buffer is already full, this
     /// method will perform no action and return false.  This method is only safe to
     /// be called from a single producer thread.
     /// </summary>
-    public bool TryPush(ref T t) {
+    public bool TryEnqueue(ref T t) {
       uint nextTail = (_tail + 1) & _bufferMask;
       if (nextTail == _head) return false;
 
@@ -52,11 +52,11 @@ namespace Leap.Unity {
     }
 
     /// <summary>
-    /// Tries to pop a value off of the buffer.  If the buffer is empty this method
+    /// Tries to dequeue a value off of the buffer.  If the buffer is empty this method
     /// will perform no action and return false.  This method is only safe to be
     /// called from a single consumer thread.
     /// </summary>
-    public bool TryPop(out T t) {
+    public bool TryDequeue(out T t) {
       if (_tail == _head) {
         t = default(T);
         return false;

--- a/Assets/LeapMotion/Scripts/DataStructures/ProduceConsumeBuffer.cs
+++ b/Assets/LeapMotion/Scripts/DataStructures/ProduceConsumeBuffer.cs
@@ -12,6 +12,10 @@ namespace Leap.Unity {
     /// Constructs a new produce consumer buffer of a given capacity.  This capacity
     /// is fixed and cannot be changed after the buffer is created.  This capacity
     /// must be a power of two.
+    /// 
+    /// The power of two requirement is an optimization.  Internally this class can
+    /// use a bitwise AND operation instead of a slower modulus operation for indexing
+    /// if the length of the buffer is a power of two.
     /// </summary>
     public ProduceConsumeBuffer(int capacity) {
       if (capacity <= 0) {

--- a/Assets/LeapMotion/Scripts/DataStructures/ProduceConsumeBuffer.cs
+++ b/Assets/LeapMotion/Scripts/DataStructures/ProduceConsumeBuffer.cs
@@ -1,0 +1,69 @@
+﻿using UnityEngine;
+using System;
+
+namespace Leap.Unity {
+
+  public class ProduceConsumeBuffer<T> {
+    private T[] _buffer;
+    private uint _bufferMask;
+    private uint _head, _tail;
+
+    /// <summary>
+    /// Constructs a new produce consumer buffer of a given capacity.  This capacity
+    /// is fixed and cannot be changed after the buffer is created.
+    /// </summary>
+    public ProduceConsumeBuffer(int capacity) {
+      if (capacity <= 0) {
+        throw new ArgumentOutOfRangeException("The capacity of the ProduceConsumeBuffer must be positive and non-zero.");
+      }
+
+      if (Mathf.ClosestPowerOfTwo(capacity) != capacity) {
+        throw new ArgumentException("The capacity of the ProduceConsumeBuffer must be a power of two.");
+      }
+
+      _buffer = new T[capacity];
+      _bufferMask = (uint)(capacity - 1);
+      _head = 0;
+      _tail = 0;
+    }
+
+    /// <summary>
+    /// Returns the maximum number of elements that the buffer can hold.
+    /// </summary>
+    public int Capacity {
+      get {
+        return _buffer.Length;
+      }
+    }
+
+    /// <summary>
+    /// Tries to push a value into the buffer.  If the buffer is already full, this
+    /// method will perform no action and return false.  This method is only safe to
+    /// be called from a single producer thread.
+    /// </summary>
+    public bool TryPush(ref T t) {
+      uint nextTail = (_tail + 1) & _bufferMask;
+      if (nextTail == _head) return false;
+
+      _buffer[_tail] = t;
+      _tail = nextTail;
+      return true;
+    }
+
+    /// <summary>
+    /// Tries to pop a value off of the buffer.  If the buffer is empty this method
+    /// will perform no action and return false.  This method is only safe to be
+    /// called from a single consumer thread.
+    /// </summary>
+    public bool TryPop(out T t) {
+      if (_tail == _head) {
+        t = default(T);
+        return false;
+      }
+
+      t = _buffer[_head];
+      _head = (_head + 1) & _bufferMask;
+      return true;
+    }
+  }
+}

--- a/Assets/LeapMotion/Scripts/DataStructures/ProduceConsumeBuffer.cs.meta
+++ b/Assets/LeapMotion/Scripts/DataStructures/ProduceConsumeBuffer.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: f8ba098e71204224b990914e7849b442
+timeCreated: 1478742443
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR adds the ProduceConsumeBuffer data structure.  This is a type of lock-free, wait-free, thread-safe queue that supports a single producer and a single consumer.  Only one thread (the producer) is allowed to call TryEnqueue, and only one thread (the consumer) is allowed to call TryDequeue.  

To test:
 - [ ] Make sure tests pass