### PR TITLE
Reuse physics frames in update

### DIFF
--- a/Assets/LeapMotion/Editor/LeapServiceProviderEditor.cs
+++ b/Assets/LeapMotion/Editor/LeapServiceProviderEditor.cs
@@ -9,6 +9,26 @@ namespace Leap.Unity {
 
       specifyConditionalDrawing("_overrideDeviceType",
                                 "_overrideDeviceTypeWith");
+
+      specifyCustomDecorator("_frameOptimization", frameOptimizationWarning);
+    }
+
+    private void frameOptimizationWarning(SerializedProperty property) {
+      var mode = (LeapServiceProvider.FrameOptimizationMode)property.intValue;
+      string warningText;
+
+      switch (mode) {
+        case LeapServiceProvider.FrameOptimizationMode.ReuseUpdateForPhysics:
+          warningText = "Reusing update frames for physics introduces a frame of latency for physics interactions.";
+          break;
+        case LeapServiceProvider.FrameOptimizationMode.ReusePhysicsForUpdate:
+          warningText = "This optimization REQUIRES physics framerate to match your target framerate EXACTLY.";
+          break;
+        default:
+          return;
+      }
+
+      EditorGUILayout.HelpBox(warningText, MessageType.Warning);
     }
   }
 }

--- a/Assets/LeapMotion/Scripts/LeapServiceProvider.cs
+++ b/Assets/LeapMotion/Scripts/LeapServiceProvider.cs
@@ -406,7 +406,7 @@ namespace Leap.Unity {
             //if (RealtimeGraph.Instance != null) { RealtimeGraph.Instance.AddSample("Precull Tracking Latency", RealtimeGraph.GraphUnits.Miliseconds, (GetLeapController().Now() - _transformedPreCullFrame.Timestamp) * 0.001f); }
             for (int i = 0; i < _transformedPreCullFrame.Hands.Count; i++) {
               Hand preCullHand = _transformedPreCullFrame.Hands[i];
-              Hand updateHand = _transformedUpdateFrame.Hand(preCullHand.Id);
+              Hand updateHand = CurrentFrame.Hand(preCullHand.Id);
 
               if (preCullHand != null && updateHand != null) {
                 //Pass PreCullHand * Inverse(UpdateHand) to the shader

--- a/Assets/LeapMotion/Scripts/LeapServiceProvider.cs
+++ b/Assets/LeapMotion/Scripts/LeapServiceProvider.cs
@@ -31,9 +31,7 @@ namespace Leap.Unity {
     [SerializeField]
     protected LeapVRTemporalWarping _temporalWarping;
 
-    [Tooltip("When true, update frames will be re-used for physics.  This is an optimization, since the total number " +
-             "of frames that need to be calculated is halved.  However, this introduces extra latency and inaccuracy " +
-             "into the physics frames.")]
+    [Tooltip("When enabled, the provider will only calculate one leap frame instead of two.")]
     [SerializeField]
     protected FrameOptimizationMode _frameOptimization = FrameOptimizationMode.None;
 
@@ -222,7 +220,7 @@ namespace Leap.Unity {
 
       _fixedOffset.Update(Time.time - Time.fixedTime, Time.deltaTime);
 
-      if(_frameOptimization == FrameOptimizationMode.ReusePhysicsForUpdate) {
+      if (_frameOptimization == FrameOptimizationMode.ReusePhysicsForUpdate) {
         DispatchUpdateFrameEvent(_transformedFixedFrame);
         return;
       }


### PR DESCRIPTION
Added an option to reuse physics frames for update frames.  This is the optimization used in blocks to both reduce time spent creating frames, but also does not have the latency problems of reusing the update frames for physics.  This optimization requires that the physics framerate match the application framerate exactly, or else bad jitter will happen.  Late latching can mask this jitter a little bit, but for best results you really should match the framerates.  I added some warning dialogs that automatically pop up, but we cant throw an error because we cannot determine the target framerate ahead of time.

@jselstad 