### PR TITLE
Add MinValue/MaxValue support for Vector2 and Vector3

### DIFF
--- a/Assets/LeapMotion/Scripts/Attributes/MaxValue.cs
+++ b/Assets/LeapMotion/Scripts/Attributes/MaxValue.cs
@@ -19,13 +19,19 @@ namespace Leap.Unity.Attributes {
         property.floatValue = Mathf.Min(maxValue, property.floatValue);
       } else if (property.propertyType == SerializedPropertyType.Integer) {
         property.intValue = Mathf.Min((int)maxValue, property.intValue);
-      }
+      } else if (property.propertyType == SerializedPropertyType.Vector2) {
+        property.vector2Value = new Vector2(Mathf.Min(minValue, property.vector2Value.x), Mathf.Min(minValue, property.vector2Value.y));
+      } else if (property.propertyType == SerializedPropertyType.Vector3) {
+        property.vector3Value = new Vector3(Mathf.Min(minValue, property.vector3Value.x), Mathf.Min(minValue, property.vector3Value.y), Mathf.Max(minValue, property.vector3Value.z));
+      } 
     }
 
     public override IEnumerable<SerializedPropertyType> SupportedTypes {
       get {
         yield return SerializedPropertyType.Integer;
         yield return SerializedPropertyType.Float;
+        yield return SerializedPropertyType.Vector2;
+        yield return SerializedPropertyType.Vector3;
       }
     }
 #endif

--- a/Assets/LeapMotion/Scripts/Attributes/MaxValue.cs
+++ b/Assets/LeapMotion/Scripts/Attributes/MaxValue.cs
@@ -22,7 +22,7 @@ namespace Leap.Unity.Attributes {
       } else if (property.propertyType == SerializedPropertyType.Vector2) {
         property.vector2Value = new Vector2(Mathf.Min(minValue, property.vector2Value.x), Mathf.Min(minValue, property.vector2Value.y));
       } else if (property.propertyType == SerializedPropertyType.Vector3) {
-        property.vector3Value = new Vector3(Mathf.Min(minValue, property.vector3Value.x), Mathf.Min(minValue, property.vector3Value.y), Mathf.Max(minValue, property.vector3Value.z));
+        property.vector3Value = new Vector3(Mathf.Min(minValue, property.vector3Value.x), Mathf.Min(minValue, property.vector3Value.y), Mathf.Min(minValue, property.vector3Value.z));
       } 
     }
 

--- a/Assets/LeapMotion/Scripts/Attributes/MinValue.cs
+++ b/Assets/LeapMotion/Scripts/Attributes/MinValue.cs
@@ -19,13 +19,19 @@ namespace Leap.Unity.Attributes {
         property.floatValue = Mathf.Max(minValue, property.floatValue);
       } else if (property.propertyType == SerializedPropertyType.Integer) {
         property.intValue = Mathf.Max((int)minValue, property.intValue);
-      }
+      } else if (property.propertyType == SerializedPropertyType.Vector2) {
+        property.vector2Value = new Vector2(Mathf.Max(minValue, property.vector2Value.x), Mathf.Max(minValue, property.vector2Value.y));
+      } else if (property.propertyType == SerializedPropertyType.Vector3) {
+        property.vector3Value = new Vector3(Mathf.Max(minValue, property.vector3Value.x), Mathf.Max(minValue, property.vector3Value.y), Mathf.Max(minValue, property.vector3Value.z));
+      } 
     }
 
     public override IEnumerable<SerializedPropertyType> SupportedTypes {
       get {
         yield return SerializedPropertyType.Integer;
         yield return SerializedPropertyType.Float;
+        yield return SerializedPropertyType.Vector2;
+        yield return SerializedPropertyType.Vector3;
       }
     }
 #endif


### PR DESCRIPTION
Because sometimes I want my Vector2s to have minimum nonzero X and Y values, and Vector3s for good measure because why not, and MaxValue too because also why not.