### PR TITLE
Fixed a warning caused by an unused variable

### DIFF
--- a/Assets/LeapMotion/Scripts/Attributes/AutoFindAttribute.cs
+++ b/Assets/LeapMotion/Scripts/Attributes/AutoFindAttribute.cs
@@ -18,10 +18,10 @@ namespace Leap.Unity.Attributes {
   }
 
   public class AutoFindAttribute : CombinablePropertyAttribute, IPropertyConstrainer {
-    private AutoFindLocations _searchLocations;
+    public readonly AutoFindLocations searchLocations;
 
     public AutoFindAttribute(AutoFindLocations searchLocations = AutoFindLocations.All) {
-      _searchLocations = searchLocations;
+      this.searchLocations = searchLocations;
     }
 
 #if UNITY_EDITOR
@@ -36,7 +36,7 @@ namespace Leap.Unity.Attributes {
     }
 
     private bool search(SerializedProperty property, AutoFindLocations location, Func<Type, UnityEngine.Object> searchDelegate) {
-      if ((_searchLocations & location) != 0) {
+      if ((searchLocations & location) != 0) {
         var value = searchDelegate(fieldInfo.FieldType);
         if (value != null) {
           property.objectReferenceValue = value;


### PR DESCRIPTION
The AutoFind variable '_searchLocations' became unused when doing a build because it was only used by editor code.  Since the editor code gets disabled when building, it triggered the warning.  Solution was to make the field public (but readonly like is done for many attributes). 

To test:
 - [ ] Do a build of an empty scene and verify there are no warning generated 