### PR TITLE
Added ElementAt, as well as some helpers

### DIFF
--- a/Assets/LeapMotion/Scripts/Query/DirectQueryOps.cs
+++ b/Assets/LeapMotion/Scripts/Query/DirectQueryOps.cs
@@ -66,6 +66,14 @@ namespace Leap.Unity.Query {
       }
     }
 
+    public QueryType ElementAt(int index) {
+      return Skip(index).First();
+    }
+
+    public QueryType ElementAtOrDefault(int index) {
+      return Skip(index).FirstOrDefault();
+    }
+
     public QueryType First() {
       using (thisAndConsume) {
         if (!_op.MoveNext()) {

--- a/Assets/LeapMotion/Scripts/Query/Editor/QueryTests.cs
+++ b/Assets/LeapMotion/Scripts/Query/Editor/QueryTests.cs
@@ -8,6 +8,14 @@ namespace Leap.Unity.Query.Test {
     public int[] LIST_1 = { 6, 7, 8, 9, 10 };
 
     [Test]
+    public void CastTest() {
+      object[] objs = new object[] { "Hello", "World", "These", "Are", "All", "Strings" };
+
+      Assert.That(objs.Cast<string>().SequenceEqual(
+                  objs.Query().Cast<string>().ToList()));
+    }
+
+    [Test]
     public void ConcatTest() {
       Assert.That(LIST_0.Concat(LIST_1).SequenceEqual(
                   LIST_0.Query().Concat(LIST_1.Query()).ToList()));
@@ -19,6 +27,9 @@ namespace Leap.Unity.Query.Test {
 
       Assert.That(objs.OfType<string>().SequenceEqual(
                   objs.Query().OfType<string>().ToList()));
+
+      Assert.That(objs.OfType<string>().SequenceEqual(
+                  objs.Query().OfType(typeof(string)).Cast<string>().ToList()));
     }
 
     [Test]
@@ -100,6 +111,15 @@ namespace Leap.Unity.Query.Test {
 
       Assert.AreEqual(LIST_0.Count(i => i % 2 == 0),
                       LIST_0.Query().Count(i => i % 2 == 0));
+    }
+
+    [Test]
+    public void ElemenAtTest() {
+      Assert.AreEqual(LIST_0.ElementAt(3),
+                      LIST_0.Query().ElementAt(3));
+
+      Assert.AreEqual(LIST_0.ElementAtOrDefault(100),
+                      LIST_0.Query().ElementAtOrDefault(100));
     }
 
     [Test]

--- a/Assets/LeapMotion/Scripts/Query/OfType.cs
+++ b/Assets/LeapMotion/Scripts/Query/OfType.cs
@@ -5,8 +5,8 @@ using System.Collections.Generic;
 namespace Leap.Unity.Query {
 
   public struct OfTypeOp<SourceType, ResultType, SourceOp> : IEnumerator<ResultType>
-  where SourceOp : IEnumerator<SourceType>
-  where ResultType : class {
+    where SourceOp : IEnumerator<SourceType>
+    where ResultType : class {
     private SourceOp _source;
 
     public OfTypeOp(SourceOp source) {
@@ -49,6 +49,10 @@ namespace Leap.Unity.Query {
   public partial struct QueryWrapper<QueryType, QueryOp> where QueryOp : IEnumerator<QueryType> {
     public QueryWrapper<CastType, OfTypeOp<QueryType, CastType, QueryOp>> OfType<CastType>() where CastType : class {
       return new QueryWrapper<CastType, OfTypeOp<QueryType, CastType, QueryOp>>(new OfTypeOp<QueryType, CastType, QueryOp>(_op));
+    }
+
+    public QueryWrapper<QueryType, WhereOp<QueryType, QueryOp>> OfType(Type type) {
+      return new QueryWrapper<QueryType, WhereOp<QueryType, QueryOp>>(new WhereOp<QueryType, QueryOp>(_op, element => element != null && type.IsAssignableFrom(element.GetType())));
     }
   }
 }

--- a/Assets/LeapMotion/Scripts/Query/Select.cs
+++ b/Assets/LeapMotion/Scripts/Query/Select.cs
@@ -44,5 +44,9 @@ namespace Leap.Unity.Query {
     public QueryWrapper<NewType, SelectOp<QueryType, NewType, QueryOp>> Select<NewType>(Func<QueryType, NewType> mapping) {
       return new QueryWrapper<NewType, SelectOp<QueryType, NewType, QueryOp>>(new SelectOp<QueryType, NewType, QueryOp>(_op, mapping));
     }
+
+    public QueryWrapper<NewType, SelectOp<QueryType, NewType, QueryOp>> Cast<NewType>() where NewType : class {
+      return Select(obj => obj as NewType);
+    }
   }
 }


### PR DESCRIPTION
Adds the ElementAt query operator, which is basically an index, but which can operate on a query (and can return default value if out of bounds).  Also adds 2 helper queries which just use existing queries as a backer, but are shorter.  The first is the Cast<> query, which takes a sequence and casts each element to a new type.  The second is a non-generic OfType, for situations where you need to filter based off of type but the type is not known at compile time.

To test:
 - [ ] Review code changes
 - [ ] Make sure unit tests pass