### PR TITLE
Fixed naming error and added validation

### DIFF
--- a/Assets/LeapMotion/Scripts/Utils/Editor/SingleLayerEditor.cs
+++ b/Assets/LeapMotion/Scripts/Utils/Editor/SingleLayerEditor.cs
@@ -13,7 +13,11 @@ namespace Leap.Unity {
     public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
       ensureLayersInitialized();
 
-      SerializedProperty layerProperty = property.FindPropertyRelative("layer");
+      SerializedProperty layerProperty = property.FindPropertyRelative("layerIndex");
+      if (layerProperty == null) {
+        Debug.LogWarning("Could not find the layer index property, was it renamed or removed?");
+        return;
+      }
 
       int index = _layerValues.IndexOf(layerProperty.intValue);
       if (index < 0) {


### PR DESCRIPTION
Hotfix for the bug in the single-layer editor that prevented it from working at all!

To test:
 - [x] Make sure it works when you view it in the inspector!  The IE manager is an example of a component that uses this property.