### PR TITLE
Adding ability to modify maximum element amount

### DIFF
--- a/Assets/LeapMotionModules/ElementRenderer/Resources/LeapGui.cginc
+++ b/Assets/LeapMotionModules/ElementRenderer/Resources/LeapGui.cginc
@@ -1,3 +1,5 @@
 #include "UnityCG.cginc"
 
+// This line is auto-generated, do not modify!
+// Maximum element count can be changed in the preferences dialog.
 #define ELEMENT_MAX 32

--- a/Assets/LeapMotionModules/ElementRenderer/Scripts/Editor/LeapGuiEditor.cs
+++ b/Assets/LeapMotionModules/ElementRenderer/Scripts/Editor/LeapGuiEditor.cs
@@ -103,7 +103,7 @@ public class LeapGuiEditor : CustomEditorBase {
   }
 
   private void featureDecorator(SerializedProperty property) {
-    int elementMax = LeapGuiPreferences.ElementMax;
+    int elementMax = LeapGuiPreferences.elementMax;
 
     if (gui.elements.Count > elementMax) {
       EditorGUILayout.HelpBox("This gui currently has " + gui.elements.Count.ToString() +

--- a/Assets/LeapMotionModules/ElementRenderer/Scripts/Editor/LeapGuiEditor.cs
+++ b/Assets/LeapMotionModules/ElementRenderer/Scripts/Editor/LeapGuiEditor.cs
@@ -96,9 +96,22 @@ public class LeapGuiEditor : CustomEditorBase {
       _spaceEditor = CreateEditor(gui.space);
     }
 
+    specifyCustomDecorator("_features", featureDecorator);
     specifyCustomDrawer("_features", drawFeatures);
     specifyCustomDrawer("_space", drawSpace);
     specifyCustomDrawer("_renderer", drawRenderer);
+  }
+
+  private void featureDecorator(SerializedProperty property) {
+    int elementMax = LeapGuiPreferences.ElementMax;
+
+    if (gui.elements.Count > elementMax) {
+      EditorGUILayout.HelpBox("This gui currently has " + gui.elements.Count.ToString() +
+                              " elements, which is greater than the maximum of " +
+                              elementMax + ".  Visit the preferences to change the maximum element count.",
+                              MessageType.Warning);
+      return;
+    }
   }
 
   private void drawFeatures(SerializedProperty property) {

--- a/Assets/LeapMotionModules/ElementRenderer/Scripts/Editor/LeapGuiEditor.cs
+++ b/Assets/LeapMotionModules/ElementRenderer/Scripts/Editor/LeapGuiEditor.cs
@@ -108,7 +108,7 @@ public class LeapGuiEditor : CustomEditorBase {
     if (gui.elements.Count > elementMax) {
       EditorGUILayout.HelpBox("This gui currently has " + gui.elements.Count.ToString() +
                               " elements, which is greater than the maximum of " +
-                              elementMax + ".  Visit the preferences to change the maximum element count.",
+                              elementMax + ".  Visit Edit->Preferences to change the maximum element count.",
                               MessageType.Warning);
       return;
     }

--- a/Assets/LeapMotionModules/ElementRenderer/Scripts/Editor/LeapGuiElementEditor.cs
+++ b/Assets/LeapMotionModules/ElementRenderer/Scripts/Editor/LeapGuiElementEditor.cs
@@ -32,6 +32,15 @@ public class LeapGuiElementEditor : Editor {
     if (elements.Count == 0) return;
     var mainElement = elements[0];
 
+    int maxElements = LeapGuiPreferences.ElementMax;
+    if (elements.Query().Any(e => e.attachedGui != null && e.attachedGui.elements.IndexOf(e) >= maxElements)) {
+      string noun = elements.Count == 1 ? "This element" : "Some of these elements";
+      string guiName = elements.Count == 1 ? "its gui" : "their guis";
+      EditorGUILayout.HelpBox(noun + " may not be properly displayed because there are too many elements on " + guiName + ".  " +
+                              "Either lower the number of elements or increase the maximum element count in the " +
+                              "preferences window.", MessageType.Warning);
+    }
+
     if (tempArray.Length != elements.Count) {
       tempArray = new Object[elements.Count];
     }

--- a/Assets/LeapMotionModules/ElementRenderer/Scripts/Editor/LeapGuiElementEditor.cs
+++ b/Assets/LeapMotionModules/ElementRenderer/Scripts/Editor/LeapGuiElementEditor.cs
@@ -37,8 +37,8 @@ public class LeapGuiElementEditor : Editor {
       string noun = elements.Count == 1 ? "This element" : "Some of these elements";
       string guiName = elements.Count == 1 ? "its gui" : "their guis";
       EditorGUILayout.HelpBox(noun + " may not be properly displayed because there are too many elements on " + guiName + ".  " +
-                              "Either lower the number of elements or increase the maximum element count in the " +
-                              "preferences window.", MessageType.Warning);
+                              "Either lower the number of elements or increase the maximum element count by visiting " +
+                              "Edit->Preferences.", MessageType.Warning);
     }
 
     if (tempArray.Length != elements.Count) {

--- a/Assets/LeapMotionModules/ElementRenderer/Scripts/Editor/LeapGuiElementEditor.cs
+++ b/Assets/LeapMotionModules/ElementRenderer/Scripts/Editor/LeapGuiElementEditor.cs
@@ -32,7 +32,7 @@ public class LeapGuiElementEditor : Editor {
     if (elements.Count == 0) return;
     var mainElement = elements[0];
 
-    int maxElements = LeapGuiPreferences.ElementMax;
+    int maxElements = LeapGuiPreferences.elementMax;
     if (elements.Query().Any(e => e.attachedGui != null && e.attachedGui.elements.IndexOf(e) >= maxElements)) {
       string noun = elements.Count == 1 ? "This element" : "Some of these elements";
       string guiName = elements.Count == 1 ? "its gui" : "their guis";

--- a/Assets/LeapMotionModules/ElementRenderer/Scripts/Editor/LeapGuiPreferences.cs
+++ b/Assets/LeapMotionModules/ElementRenderer/Scripts/Editor/LeapGuiPreferences.cs
@@ -1,0 +1,88 @@
+﻿using UnityEngine;
+using UnityEditor;
+using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
+
+public class LeapGuiPreferences : MonoBehaviour {
+  public const string LEAP_GUI_CGINC_PATH = "LeapMotionModules/ElementRenderer/Resources/LeapGui.cginc";
+  private static Regex _elementMaxRegex = new Regex(@"^#define\s+ELEMENT_MAX\s+(\d+)\s*$");
+
+  [PreferenceItem("Leap Gui")]
+  private static void preferencesGUI() {
+    string path = Path.Combine(Application.dataPath, LEAP_GUI_CGINC_PATH);
+    if (!File.Exists(path)) {
+      displayHelpBox("Could not locate the Leap cginclude file, was it renamed or deleted?");
+      return;
+    }
+
+    List<string> lines = new List<string>();
+
+    StreamReader reader = null;
+    try {
+      reader = File.OpenText(path);
+
+      while (true) {
+        string line = reader.ReadLine();
+        if (line == null) {
+          break;
+        }
+        lines.Add(line);
+      }
+    } catch (Exception e) {
+      displayHelpBox("Exception caught when trying to read file.");
+      Debug.LogError(e);
+      return;
+    } finally {
+      if (reader != null) {
+        reader.Dispose();
+      }
+    }
+
+    Match successMatch = null;
+    int lineIndex = -1;
+    for (int i = 0; i < lines.Count; i++) {
+      string line = lines[i];
+      var match = _elementMaxRegex.Match(line);
+      if (match.Success) {
+        successMatch = match;
+        lineIndex = i;
+        break;
+      }
+    }
+
+    if (successMatch == null) {
+      displayHelpBox("Could not parse the file correctly, it might have been modified!");
+      return;
+    }
+
+    int elementMax;
+    if (!int.TryParse(successMatch.Groups[1].Value, out elementMax)) {
+      displayHelpBox("The maximum element value must always be an integer value!");
+      return;
+    }
+    
+    int newElementMax = EditorGUILayout.DelayedIntField("Maximum Elements", elementMax);
+    newElementMax = Mathf.Clamp(newElementMax, 1, 1024);
+
+    if (newElementMax == elementMax) {
+      return; //work here is done!
+    }
+
+    lines[lineIndex] = lines[lineIndex].Replace(successMatch.Groups[1].Value, newElementMax.ToString());
+
+    //Write the new data to the file
+    File.WriteAllLines(path, lines.ToArray());
+
+    //Make sure to re-import all the shaders
+    AssetDatabase.ImportAsset("Assets/LeapMotionModules/ElementRenderer/Shaders/", ImportAssetOptions.ImportRecursive);
+  }
+
+  private static void displayHelpBox(string primaryMessage) {
+    EditorGUILayout.HelpBox(primaryMessage +
+                            "\n\nRe-installing the Leap Gui package can help fix this problem.",
+                            MessageType.Warning);
+  }
+
+}

--- a/Assets/LeapMotionModules/ElementRenderer/Scripts/Editor/LeapGuiPreferences.cs
+++ b/Assets/LeapMotionModules/ElementRenderer/Scripts/Editor/LeapGuiPreferences.cs
@@ -11,7 +11,7 @@ public class LeapGuiPreferences : MonoBehaviour {
   private static Regex _elementMaxRegex = new Regex(@"^#define\s+ELEMENT_MAX\s+(\d+)\s*$");
 
   private static int _cachedElementMax = -1; //-1 signals dirty
-  public static int ElementMax {
+  public static int elementMax {
     get {
       if (_cachedElementMax == -1) {
         string errorMesage;

--- a/Assets/LeapMotionModules/ElementRenderer/Scripts/Editor/LeapGuiPreferences.cs
+++ b/Assets/LeapMotionModules/ElementRenderer/Scripts/Editor/LeapGuiPreferences.cs
@@ -10,12 +10,24 @@ public class LeapGuiPreferences : MonoBehaviour {
   public const string LEAP_GUI_SHADER_FOLDER = "Assets/LeapMotionModules/ElementRenderer/Shaders/";
   private static Regex _elementMaxRegex = new Regex(@"^#define\s+ELEMENT_MAX\s+(\d+)\s*$");
 
-  public static bool TryCalculateElementMax(out int elementMax, out string errorMessage) {
-    string path;
-    List<string> lines;
-    int lineIndex;
+  private static int _cachedElementMax = -1; //-1 signals dirty
+  public static int ElementMax {
+    get {
+      if (_cachedElementMax == -1) {
+        string errorMesage;
+        string path;
+        List<string> lines;
+        int lineIndex;
 
-    return tryCalculateElementMax(out elementMax, out errorMessage, out path, out lines, out lineIndex);
+        tryCalculateElementMax(out _cachedElementMax, out errorMesage, out path, out lines, out lineIndex);
+
+        if (errorMesage != null) {
+          _cachedElementMax = int.MaxValue;
+        }
+      }
+
+      return _cachedElementMax;
+    }
   }
 
   [PreferenceItem("Leap Gui")]
@@ -26,6 +38,7 @@ public class LeapGuiPreferences : MonoBehaviour {
     List<string> lines;
     int lineIndex;
 
+    _cachedElementMax = -1;
     if (!tryCalculateElementMax(out elementMax, out errorMessage, out path, out lines, out lineIndex)) {
       EditorGUILayout.HelpBox(errorMessage +
                               "\n\nRe-installing the Leap Gui package can help fix this problem.",
@@ -55,7 +68,7 @@ public class LeapGuiPreferences : MonoBehaviour {
                                              out List<string> lines,
                                              out int lineIndex) {
     elementMax = -1;
-    errorMessage = "";
+    errorMessage = null;
     lines = null;
     lineIndex = -1;
 

--- a/Assets/LeapMotionModules/ElementRenderer/Scripts/Editor/LeapGuiPreferences.cs.meta
+++ b/Assets/LeapMotionModules/ElementRenderer/Scripts/Editor/LeapGuiPreferences.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 808ea61b820d77649a412050dd13c580
+timeCreated: 1487091138
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This adds the ability to change the maximum element count, as well as the ability for the gui to emit warnings whenever you are over the limit.

To test:
 - [ ] Visit the Edit->Preferences->Leap Gui dialog and verify that you can change the maximum element count
 - [ ] Verify that the LeapGui inspector tells you when you have too many elements
 - [ ] Verify that a LeapGuiElement inspector tells you whenever it is not able to fit into the current element count.