### PR TITLE
Allow textures with their wrap mode set to repeat

### DIFF
--- a/Assets/LeapMotion/Scripts/Utils/Utils.cs
+++ b/Assets/LeapMotion/Scripts/Utils/Utils.cs
@@ -10,6 +10,13 @@ namespace Leap.Unity {
 
   public static class Utils {
 
+    #region Math Utils
+    public static int Repeat(int x, int m) {
+      int r = x % m;
+      return r < 0 ? r + m : r;
+    }
+    #endregion
+
     #region Orientation Utils
 
     /// <summary>
@@ -56,16 +63,16 @@ namespace Leap.Unity {
       }
     }
 
-  #endregion
+    #endregion
 
     #region Gizmo Utils
 
-    public static void DrawCircle(Vector3 center, 
-                           Vector3 normal, 
-                           float radius, 
-                           Color color, 
-                           int quality = 32, 
-                           float duration = 0, 
+    public static void DrawCircle(Vector3 center,
+                           Vector3 normal,
+                           float radius,
+                           Color color,
+                           int quality = 32,
+                           float duration = 0,
                            bool depthTest = true) {
       Vector3 planeA = Vector3.Slerp(normal, -normal, 0.5f);
       DrawArc(360, center, planeA, normal, radius, color, quality);
@@ -73,20 +80,20 @@ namespace Leap.Unity {
 
     /* Adapted from: Zarrax (http://math.stackexchange.com/users/3035/zarrax), Parametric Equation of a Circle in 3D Space?, 
      * URL (version: 2014-09-09): http://math.stackexchange.com/q/73242 */
-    public static void DrawArc(   float arc,
-                           Vector3 center, 
+    public static void DrawArc(float arc,
+                           Vector3 center,
                            Vector3 forward,
                            Vector3 normal,
-                           float radius, 
-                           Color color, 
+                           float radius,
+                           Color color,
                            int quality = 32) {
 
       Gizmos.color = color;
       Vector3 right = Vector3.Cross(normal, forward).normalized;
-      float deltaAngle = arc/quality;
+      float deltaAngle = arc / quality;
       Vector3 thisPoint = center + forward * radius;
       Vector3 nextPoint = new Vector3();
-      for(float angle = 0; Mathf.Abs(angle) <= Mathf.Abs(arc); angle += deltaAngle){
+      for (float angle = 0; Mathf.Abs(angle) <= Mathf.Abs(arc); angle += deltaAngle) {
         float cosAngle = Mathf.Cos(angle * Constants.DEG_TO_RAD);
         float sinAngle = Mathf.Sin(angle * Constants.DEG_TO_RAD);
         nextPoint.x = center.x + radius * (cosAngle * forward.x + sinAngle * right.x);
@@ -97,17 +104,17 @@ namespace Leap.Unity {
       }
     }
 
-    public static void DrawCone(Vector3 origin, 
-                           Vector3 direction, 
+    public static void DrawCone(Vector3 origin,
+                           Vector3 direction,
                            float angle,
                            float height,
-                           Color color, 
-                           int quality = 4, 
-                           float duration = 0, 
-                           bool depthTest = true){
+                           Color color,
+                           int quality = 4,
+                           float duration = 0,
+                           bool depthTest = true) {
 
-      float step = height/quality;
-      for(float q = step; q <= height; q += step){
+      float step = height / quality;
+      for (float q = step; q <= height; q += step) {
         DrawCircle(origin + direction * q, direction, Mathf.Tan(angle * Constants.DEG_TO_RAD) * q, color, quality * 8, duration, depthTest);
       }
     }

--- a/Assets/LeapMotionModules/ElementRenderer/Scripts/Renderers/LeapGuiMesherBase.cs
+++ b/Assets/LeapMotionModules/ElementRenderer/Scripts/Renderers/LeapGuiMesherBase.cs
@@ -85,10 +85,6 @@ public abstract class LeapGuiMesherBase : LeapGuiRenderer,
           var tex = dataObj.texture;
           if (tex == null) continue;
 
-          if (tex.wrapMode == TextureWrapMode.Repeat) {
-            info[i] = info[i].OrWorse(SupportInfo.Error("Currently textures must have their wrap mode set to Clamp when using a non-zero border amount."));
-          }
-
           if (!Texture2DUtility.readWriteFormats.Contains(tex.format)) {
             info[i] = info[i].OrWorse(SupportInfo.Error("Textures must use a format that supports writing (a non-compressed format) when using a non-zero-border."));
           }

--- a/Assets/LeapMotionModules/ElementRenderer/Scripts/Utility/PackUtil.cs
+++ b/Assets/LeapMotionModules/ElementRenderer/Scripts/Utility/PackUtil.cs
@@ -117,8 +117,7 @@ public static class PackUtil {
     BorderKey key = new BorderKey() { texture = source, border = border };
     if (!_cachedBorderedTextures.TryGetValue(key, out bordered)) {
       source.EnsureReadWriteEnabled();
-      bordered = UnityEngine.Object.Instantiate(source);
-      bordered.AddBorder(border);
+      bordered = source.GetBordered(border);
       _cachedBorderedTextures[key] = bordered;
     }
     return bordered;

--- a/Assets/LeapMotionModules/ElementRenderer/Scripts/Utility/PackUtil.cs
+++ b/Assets/LeapMotionModules/ElementRenderer/Scripts/Utility/PackUtil.cs
@@ -96,6 +96,8 @@ public static class PackUtil {
     for (int i = 0; i < textureArray.Length; i++) {
       if (textureArray[i] == null) {
         textureArray[i] = defaultTexture;
+      } else {
+        textureArray[i].EnsureReadWriteEnabled();
       }
     }
 

--- a/Assets/LeapMotionModules/ElementRenderer/Scripts/Utility/Texture2DUtility.cs
+++ b/Assets/LeapMotionModules/ElementRenderer/Scripts/Utility/Texture2DUtility.cs
@@ -16,7 +16,7 @@ public static class Texture2DUtility {
     TextureFormat.RGFloat,
     TextureFormat.RFloat
   };
-
+  
   public static Color GetPixelUnbounded(this Texture2D texture, int x, int y) {
     if (texture.wrapMode == TextureWrapMode.Clamp) {
       x = Mathf.Clamp(x, 0, texture.width - 1);
@@ -25,12 +25,11 @@ public static class Texture2DUtility {
       x = Utils.Repeat(x, texture.width);
       y = Utils.Repeat(y, texture.height);
     }
+
     return texture.GetPixel(x, y);
   }
 
-  public static void AddBorder(this Texture2D texture, int pixelAmount) {
-    if (pixelAmount <= 0) return;
-
+  public static Texture2D GetBordered(this Texture2D texture, int pixelAmount) {
     texture.EnsureReadWriteEnabled();
     Color[] colors = texture.GetPixels();
 
@@ -38,9 +37,11 @@ public static class Texture2DUtility {
     int originalHeight = texture.height;
     int newWidth = originalWidth + pixelAmount * 2;
     int newHeight = originalHeight + pixelAmount * 2;
-    texture.Resize(newWidth, newHeight);
 
-    texture.SetPixels(pixelAmount, pixelAmount, originalWidth, originalHeight, colors);
+    var newTexture = Object.Instantiate(texture);
+    newTexture.Resize(newWidth, newHeight);
+
+    newTexture.SetPixels(pixelAmount, pixelAmount, originalWidth, originalHeight, colors);
 
     for (int x = 0; x < newWidth; x++) {
       for (int dy = 0; dy < pixelAmount; dy++) {
@@ -48,33 +49,33 @@ public static class Texture2DUtility {
         {
           int y = dy;
           int innerY = y - pixelAmount;
-          texture.SetPixel(x, y, texture.GetPixelUnbounded(innerX, innerY));
+          newTexture.SetPixel(x, y, texture.GetPixelUnbounded(innerX, innerY));
         }
         {
-          int y = texture.height - dy - 1;
-          int innerY = y + pixelAmount;
-          texture.SetPixel(x, y, texture.GetPixelUnbounded(innerX, innerY));
+          int y = newTexture.height - dy - 1;
+          int innerY = y - pixelAmount;
+          newTexture.SetPixel(x, y, texture.GetPixelUnbounded(innerX, innerY));
         }
       }
     }
 
-    for (int y = pixelAmount; y < newWidth - pixelAmount; y++) {
+    for (int y = pixelAmount; y < newHeight - pixelAmount; y++) {
       for (int dx = 0; dx < pixelAmount; dx++) {
         int innerY = y - pixelAmount;
         {
           int x = dx;
           int innerX = x - pixelAmount;
-          texture.SetPixel(x, y, texture.GetPixelUnbounded(innerX, innerY));
+          newTexture.SetPixel(x, y, texture.GetPixelUnbounded(innerX, innerY));
         }
         {
-          int x = texture.width - dx - 1;
-          int innerX = x + pixelAmount;
-          texture.SetPixel(x, y, texture.GetPixelUnbounded(innerX, innerY));
+          int x = newTexture.width - dx - 1;
+          int innerX = x - pixelAmount;
+          newTexture.SetPixel(x, y, texture.GetPixelUnbounded(innerX, innerY));
         }
       }
     }
 
-    texture.Apply();
+    newTexture.Apply();
+    return newTexture;
   }
-
 }


### PR DESCRIPTION
Adding support for adding the correct border to textures with their wrap mode set to repeat.  Also added a helper function called GetPixelUnbounded(), which allows you to sample a texture outside of it's bounds, which takes the wrap mode into account.

To test:
 - [ ] Set a texture's wrap mode to Repeat, and make sure it can still be used in the LeapGui