### PR TITLE
Hotfix for gui building

### DIFF
--- a/Assets/LeapMotionModules/ElementRenderer/Scripts/Editor/LeapGuiEditor.cs
+++ b/Assets/LeapMotionModules/ElementRenderer/Scripts/Editor/LeapGuiEditor.cs
@@ -130,7 +130,7 @@ public class LeapGuiEditor : CustomEditorBase {
     EditorGUI.BeginDisabledGroup(gui.features.Count == 0);
     if (GUI.Button(middle, "-", EditorStyles.miniButtonMid) && _featureList.index >= 0) {
       gui.features.RemoveAt(_featureList.index);
-      gui.ScheduleFullUpdate();
+      gui.ScheduleEditorUpdate();
       EditorUtility.SetDirty(gui);
     }
     EditorGUI.EndDisabledGroup();
@@ -238,7 +238,7 @@ public class LeapGuiEditor : CustomEditorBase {
     EditorGUI.BeginChangeCheck();
     feature.DrawFeatureEditor(rect.NextLine().Indent(), isActive, isFocused);
     if (EditorGUI.EndChangeCheck()) {
-      gui.ScheduleFullUpdate();
+      gui.ScheduleEditorUpdate();
       EditorUtility.SetDirty(feature);
     }
   }

--- a/Assets/LeapMotionModules/ElementRenderer/Scripts/LeapGui.cs
+++ b/Assets/LeapMotionModules/ElementRenderer/Scripts/LeapGui.cs
@@ -158,14 +158,14 @@ public class LeapGui : MonoBehaviour {
 
   //Begin editor-only private api
 #if UNITY_EDITOR
-  public void ScheduleFullUpdate() {
+  public void ScheduleEditorUpdate() {
     //Dirty the hash by changing it to something else
     _previousHierarchyHash++;
   }
 
   public void SetSpace(Type spaceType) {
     AssertHelper.AssertEditorOnly();
-    ScheduleFullUpdate();
+    ScheduleEditorUpdate();
 
     UnityEditor.Undo.RecordObject(this, "Change Gui Space");
     UnityEditor.EditorUtility.SetDirty(this);
@@ -184,7 +184,7 @@ public class LeapGui : MonoBehaviour {
 
   public void AddFeature(Type featureType) {
     AssertHelper.AssertEditorOnly();
-    ScheduleFullUpdate();
+    ScheduleEditorUpdate();
 
     var feature = gameObject.AddComponent(featureType);
     _features.Add(feature as LeapGuiFeatureBase);
@@ -192,7 +192,7 @@ public class LeapGui : MonoBehaviour {
 
   public void SetRenderer(Type rendererType) {
     AssertHelper.AssertEditorOnly();
-    ScheduleFullUpdate();
+    ScheduleEditorUpdate();
 
     UnityEditor.Undo.RecordObject(this, "Changed Gui Renderer");
     UnityEditor.EditorUtility.SetDirty(this);
@@ -379,7 +379,9 @@ public class LeapGui : MonoBehaviour {
   #region PRIVATE IMPLEMENTATION
 
   private LeapGui() {
+#if UNITY_EDITOR
     _delayedHeavyRebuild = new DelayedAction(() => doEditorUpdateLogic(fullRebuild: true, heavyRebuild: true));
+#endif
   }
 
 #if UNITY_EDITOR

--- a/Assets/LeapMotionModules/ElementRenderer/Scripts/LeapGuiRenderer.cs
+++ b/Assets/LeapMotionModules/ElementRenderer/Scripts/LeapGuiRenderer.cs
@@ -10,9 +10,11 @@ public abstract class LeapGuiRenderer : LeapGuiComponentBase<LeapGui> {
   protected override void OnValidate() {
     base.OnValidate();
 
+#if UNITY_EDITOR
     if (gui != null) {
-      gui.ScheduleFullUpdate();
+      gui.ScheduleEditorUpdate();
     }
+#endif
   }
 
   protected bool isHeavyUpdate { get; private set; }

--- a/Assets/LeapMotionModules/ElementRenderer/Scripts/LeapGuiSpace.cs
+++ b/Assets/LeapMotionModules/ElementRenderer/Scripts/LeapGuiSpace.cs
@@ -47,9 +47,11 @@ public abstract class LeapGuiSpace : LeapGuiComponentBase<LeapGui> {
   protected override void OnValidate() {
     base.OnValidate();
 
+#if UNITY_EDITOR
     if (gui != null) {
-      gui.ScheduleFullUpdate();
+      gui.ScheduleEditorUpdate();
     }
+#endif
   }
 
   /// <summary>

--- a/Assets/LeapMotionModules/ElementRenderer/Scripts/Renderers/LeapGuiBakedRenderer.cs
+++ b/Assets/LeapMotionModules/ElementRenderer/Scripts/Renderers/LeapGuiBakedRenderer.cs
@@ -218,9 +218,13 @@ public class LeapGuiBakedRenderer : LeapGuiMesherBase {
     //or size, so just disable culling entirely by making the bound gigantic.
     _currMesh.bounds = new Bounds(Vector3.zero, Vector3.one * 100000);
 
+    //No solution right now for baking lightmap uvs at runtime
+    //But, that wasn't important anyway :P
+#if UNITY_EDITOR
     if (_enableLightmapping && isHeavyUpdate) {
       _lightmapUnwrapSettings.GenerateLightmapUvs(_currMesh);
     }
+#endif
   }
 
   protected override bool doesRequireSpecialUv3() {

--- a/Assets/LeapMotionModules/ElementRenderer/Scripts/Utility/DelayedAction.cs
+++ b/Assets/LeapMotionModules/ElementRenderer/Scripts/Utility/DelayedAction.cs
@@ -2,6 +2,7 @@
 #if UNITY_EDITOR
 using UnityEditor;
 #endif
+using UnityEngine;
 
 public class DelayedAction {
   private Action _action;

--- a/Assets/LeapMotionModules/ElementRenderer/Scripts/Utility/ReadWriteUtility.cs
+++ b/Assets/LeapMotionModules/ElementRenderer/Scripts/Utility/ReadWriteUtility.cs
@@ -23,8 +23,9 @@ public static class ReadWriteUtility {
     return reciever;
   }
 
-#if UNITY_EDITOR
+
   public static bool IsReadable(this Texture2D texture) {
+#if UNITY_EDITOR
     string assetPath = AssetDatabase.GetAssetPath(texture);
     if (string.IsNullOrEmpty(assetPath)) {
       return false;
@@ -36,8 +37,13 @@ public static class ReadWriteUtility {
     }
 
     return importer.isReadable;
-  }
+#else
+    //Welp, guess the user is just gonna have to eat the errors if they are wrong!
+    //No way to check currently :(
+    return true;
 #endif
+  }
+
 
   public static bool TryEnableReadWrite(this Mesh mesh) {
 #if UNITY_EDITOR


### PR DESCRIPTION
Made sure all editor-only calls were properly wrapped with the correct #if UNITY_EDITOR guards.  Also changed the name of ScheduleFullUpdate to ScheduleEditorUpdate to properly convey that it is an editor only update concept, and not part of any runtime concept.  Also made Texture2D.IsReadable runtime as well, but to always return true.  Currently there is no way I can see to tell if a texture is readable at runtime.