### PR TITLE
Adding edit time only attribute

### DIFF
--- a/Assets/LeapMotion/Scripts/Attributes/EditTimeOnly.cs
+++ b/Assets/LeapMotion/Scripts/Attributes/EditTimeOnly.cs
@@ -1,0 +1,15 @@
+﻿#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+namespace Leap.Unity.Attributes {
+
+  public class EditTimeOnly : CombinablePropertyAttribute, IPropertyDisabler {
+
+#if UNITY_EDITOR
+    public bool ShouldDisable(SerializedProperty property) {
+      return EditorApplication.isPlaying;
+    }
+  }
+#endif
+}

--- a/Assets/LeapMotion/Scripts/Attributes/EditTimeOnly.cs.meta
+++ b/Assets/LeapMotion/Scripts/Attributes/EditTimeOnly.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: ab3239bb7c9bce046a45a11f13b5d5f4
+timeCreated: 1489178208
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adding a super basic attribute that allows us to tag fields that should only be editable at edit time.

To test:
 - [ ] Make sure it works as expected.