### PR TITLE
Hotfix for editor building and warning

### DIFF
--- a/Assets/LeapMotion/Scripts/Attributes/EditTimeOnly.cs
+++ b/Assets/LeapMotion/Scripts/Attributes/EditTimeOnly.cs
@@ -10,6 +10,6 @@ namespace Leap.Unity.Attributes {
     public bool ShouldDisable(SerializedProperty property) {
       return EditorApplication.isPlaying;
     }
-  }
 #endif
+  }
 }

--- a/Assets/LeapMotion/Scripts/Utils/RuntimeGizmoManager.cs
+++ b/Assets/LeapMotion/Scripts/Utils/RuntimeGizmoManager.cs
@@ -542,7 +542,6 @@ namespace Leap.Unity.RuntimeGizmos {
       Vector3 right = Vector3.Cross(up, forward).normalized * radius;
 
       float height = (start - end).magnitude;
-      Vector3 middle = (end + start) * 0.5F;
 
       // Radial circles
       DrawLineWireCircle(start, up, radius);


### PR DESCRIPTION
Fixed an ifdef that was preventing standalone builds due to a compile error.  Also remove an unused variable in RuntimeGizmoManager to remove a warning message.

To test:
 - [ ] Make sure no warnings/errors are thrown when you make a standalone build