### PR TITLE
Add enumerator query

### DIFF
--- a/Assets/LeapMotion/Scripts/Query/Editor/QueryTests.cs
+++ b/Assets/LeapMotion/Scripts/Query/Editor/QueryTests.cs
@@ -1,5 +1,8 @@
 ﻿using System.Linq;
+using System.Collections.Generic;
 using NUnit.Framework;
+using System;
+using System.Collections;
 
 namespace Leap.Unity.Query.Test {
 
@@ -147,6 +150,29 @@ namespace Leap.Unity.Query.Test {
     public void IndexOfTests() {
       Assert.AreEqual(LIST_0.Query().IndexOf(3), 2);
       Assert.AreEqual(LIST_0.Query().IndexOf(100), -1);
+    }
+
+    public void EnumeratorTest() {
+      Assert.AreEqual(new TestEnumerator().Query().IndexOf(3), 3);
+    }
+
+    public class TestEnumerator : IEnumerator<int> {
+      private int _curr;
+
+      public int Current {
+        get {
+          return _curr;
+        }
+      }
+
+      public bool MoveNext() {
+        _curr++;
+        return (_curr != 10);
+      }
+
+      object IEnumerator.Current { get { return null; } }
+      public void Dispose() { }
+      public void Reset() { }
     }
   }
 }

--- a/Assets/LeapMotion/Scripts/Query/QueryWrapper.cs
+++ b/Assets/LeapMotion/Scripts/Query/QueryWrapper.cs
@@ -73,6 +73,10 @@ namespace Leap.Unity.Query {
       return new QueryWrapper<T, IEnumerator<T>>(enumerable.GetEnumerator());
     }
 
+    public static QueryWrapper<T, IEnumerator<T>> Query<T>(this IEnumerator<T> enumerator) {
+      return new QueryWrapper<T, IEnumerator<T>>(enumerator);
+    }
+
     public static QueryWrapper<T, List<T>.Enumerator> Query<T>(this List<T> list) {
       return new QueryWrapper<T, List<T>.Enumerator>(list.GetEnumerator());
     }


### PR DESCRIPTION
Allow queries to be run directly on IEnumerator objects.  The query itself is allocation free, although the method used to obtain the enumerator may not be.