### PR TITLE
Bugfix PR for renderer

### DIFF
--- a/Assets/LeapMotionModules/ElementRenderer/Resources/BakedRenderer.cginc
+++ b/Assets/LeapMotionModules/ElementRenderer/Resources/BakedRenderer.cginc
@@ -1,5 +1,6 @@
 #include "Assets/LeapMotionModules/ElementRenderer/Resources/LeapGui.cginc"
 
+
 /************************************************************************* 
  * Movement name:
  *  _ (none)
@@ -11,17 +12,15 @@
  *************************************************************************/
 
 #ifdef LEAP_GUI_MOVEMENT_TRANSLATION
+#ifndef LEAP_GUI_MOVEMENT
 #define LEAP_GUI_MOVEMENT
-void ApplyElementMotion(inout float4 vert, int elementId) { }
+#endif
 #endif
 
 #ifdef LEAP_GUI_MOVEMENT_FULL
+#ifndef LEAP_GUI_MOVEMENT
 #define LEAP_GUI_MOVEMENT
-float4x4 _GuiElementMovement_Transform[ELEMENT_MAX];
-
-void ApplyElementMotion(inout float4 vert, int elementId) {
-  vert = mul(_GuiElementMovement_Transform[elementId], vert);
-}
+#endif
 #endif
 
 #ifdef LEAP_GUI_MOVEMENT
@@ -39,7 +38,7 @@ void ApplyElementMotion(inout float4 vert, int elementId) {
  *  LEAP_GUI_SPHERICAL
  *    spherical space
  ***********************************/
-
+#ifdef LEAP_GUI_MOVEMENT
 #ifdef LEAP_GUI_CYLINDRICAL
 #define LEAP_GUI_WARPING
 #include "Assets/LeapMotionModules/ElementRenderer/Resources/CylindricalSpace.cginc"
@@ -58,7 +57,9 @@ void ApplyGuiWarping(inout float4 vert, int elementId) {
 }
 #endif
 #endif
+#endif
 
+#ifdef LEAP_GUI_MOVEMENT
 #ifdef LEAP_GUI_SPHERICAL
 #define LEAP_GUI_WARPING
 #include "Assets/LeapMotionModules/ElementRenderer/Resources/SphericalSpace.cginc"
@@ -77,8 +78,10 @@ void ApplyGuiWarping(inout float4 vert, int elementId) {
 }
 #endif
 #endif
+#endif
 
 //Base-case fallback, rect transformations
+#ifdef LEAP_GUI_MOVEMENT
 #ifndef LEAP_GUI_WARPING
 #define LEAP_GUI_WARPING
 float3 _LeapGuiRect_ElementPositions[ELEMENT_MAX];
@@ -92,7 +95,7 @@ void ApplyGuiWarping(inout float4 vert, int elementId) {
   vert.xyz += _LeapGuiRect_ElementPositions[elementId];
 }
 #endif
-
+#endif
 #endif
 
 #ifdef LEAP_GUI_WARPING

--- a/Assets/LeapMotionModules/ElementRenderer/Scripts/Features/Texture/Editor/LeapGuiTextureDataEditor.cs
+++ b/Assets/LeapMotionModules/ElementRenderer/Scripts/Features/Texture/Editor/LeapGuiTextureDataEditor.cs
@@ -25,7 +25,12 @@ public class LeapGuiTextureDataEditor : CustomEditorBase<LeapGuiTextureData> {
     if (mainFeature != null) {
       EditorGUILayout.PropertyField(property, new GUIContent(mainFeature.propertyName, property.tooltip));
     } else {
-      EditorGUILayout.PropertyField(property);
+      int mainIndex = mainData.element.data.IndexOf(mainData);
+      if (targets.Query().Any(t => t.element.data.IndexOf(t) != mainIndex)) {
+        EditorGUILayout.PropertyField(property);
+      } else {
+        EditorGUILayout.PropertyField(property, new GUIContent("Channel " + mainIndex, property.tooltip));
+      }
     }
   }
 }

--- a/Assets/LeapMotionModules/ElementRenderer/Scripts/LeapGuiElement.cs
+++ b/Assets/LeapMotionModules/ElementRenderer/Scripts/LeapGuiElement.cs
@@ -88,6 +88,10 @@ public abstract class LeapGuiElement : MonoBehaviour {
   public virtual void OnDetachedFromGui() {
     _attachedGroup = null;
     _anchor = null;
+
+    foreach (var dataObj in data) {
+      dataObj.feature = null;
+    }
   }
 
   public virtual void OnAssignFeatureData(List<LeapGuiElementData> data) {

--- a/Assets/LeapMotionModules/ElementRenderer/Scripts/LeapGuiGroup.cs
+++ b/Assets/LeapMotionModules/ElementRenderer/Scripts/LeapGuiGroup.cs
@@ -9,6 +9,7 @@ using UnityEditor;
 using Leap.Unity;
 using Leap.Unity.Query;
 
+[AddComponentMenu("")]
 public class LeapGuiGroup : LeapGuiComponentBase<LeapGui> {
 
   #region INSPECTOR FIELDS

--- a/Assets/LeapMotionModules/ElementRenderer/Scripts/LeapGuiGroup.cs
+++ b/Assets/LeapMotionModules/ElementRenderer/Scripts/LeapGuiGroup.cs
@@ -227,6 +227,12 @@ public class LeapGuiGroup : LeapGuiComponentBase<LeapGui> {
     for (int i = _elements.Count; i-- != 0;) {
       if (_elements[i] == null) {
         _elements.RemoveAt(i);
+        continue;
+      }
+
+      if (!_elements[i].transform.IsChildOf(transform)) {
+        TryRemoveElement(_elements[i]);
+        continue;
       }
     }
   }

--- a/Assets/LeapMotionModules/ElementRenderer/Scripts/Renderers/AssetData/RendererTextureData.cs
+++ b/Assets/LeapMotionModules/ElementRenderer/Scripts/Renderers/AssetData/RendererTextureData.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections;
+﻿using System;
 using System.Collections.Generic;
 using UnityEngine;
 #if UNITY_EDITOR
@@ -61,6 +61,7 @@ public class RendererTextureData : ScriptableObject {
     }
   }
 
+  [Serializable]
   public struct NamedTexture {
     public string propertyName;
     public Texture2D texture;

--- a/Assets/LeapMotionModules/ElementRenderer/Scripts/Renderers/LeapGuiBakedRenderer.cs
+++ b/Assets/LeapMotionModules/ElementRenderer/Scripts/Renderers/LeapGuiBakedRenderer.cs
@@ -91,32 +91,34 @@ public class LeapGuiBakedRenderer : LeapGuiMesherBase {
   public override void OnUpdateRenderer() {
     base.OnUpdateRenderer();
 
-    if (gui.space is LeapGuiRectSpace) {
-      using (new ProfilerSample("Build Material Data")) {
-        _rect_elementPositions.Clear();
-        foreach (var element in group.elements) {
-          var guiSpace = transform.InverseTransformPoint(element.transform.position);
-          _rect_elementPositions.Add(guiSpace);
+    if (_motionType != MotionType.None) {
+      if (gui.space is LeapGuiRectSpace) {
+        using (new ProfilerSample("Build Material Data")) {
+          _rect_elementPositions.Clear();
+          foreach (var element in group.elements) {
+            var guiSpace = transform.InverseTransformPoint(element.transform.position);
+            _rect_elementPositions.Add(guiSpace);
+          }
         }
-      }
 
-      using (new ProfilerSample("Upload Material Data")) {
-        _material.SetVectorArraySafe(RECT_POSITIONS, _rect_elementPositions);
-      }
-    } else if (gui.space is LeapGuiRadialSpaceBase) {
-      var radialSpace = gui.space as LeapGuiRadialSpaceBase;
-
-      using (new ProfilerSample("Build Material Data")) {
-        _curved_elementParameters.Clear();
-        foreach (var element in group.elements) {
-          var t = radialSpace.GetTransformer(element.anchor) as IRadialTransformer;
-          _curved_elementParameters.Add(t.GetVectorRepresentation(element));
+        using (new ProfilerSample("Upload Material Data")) {
+          _material.SetVectorArraySafe(RECT_POSITIONS, _rect_elementPositions);
         }
-      }
+      } else if (gui.space is LeapGuiRadialSpaceBase) {
+        var radialSpace = gui.space as LeapGuiRadialSpaceBase;
 
-      using (new ProfilerSample("Upload Material Data")) {
-        _material.SetFloat(LeapGuiRadialSpaceBase.RADIUS_PROPERTY, radialSpace.radius);
-        _material.SetVectorArraySafe(CURVED_PARAMETERS, _curved_elementParameters);
+        using (new ProfilerSample("Build Material Data")) {
+          _curved_elementParameters.Clear();
+          foreach (var element in group.elements) {
+            var t = radialSpace.GetTransformer(element.anchor) as IRadialTransformer;
+            _curved_elementParameters.Add(t.GetVectorRepresentation(element));
+          }
+        }
+
+        using (new ProfilerSample("Upload Material Data")) {
+          _material.SetFloat(LeapGuiRadialSpaceBase.RADIUS_PROPERTY, radialSpace.radius);
+          _material.SetVectorArraySafe(CURVED_PARAMETERS, _curved_elementParameters);
+        }
       }
     }
 
@@ -181,6 +183,10 @@ public class LeapGuiBakedRenderer : LeapGuiMesherBase {
 
   protected override void prepareMaterial() {
     base.prepareMaterial();
+
+    foreach (var keyword in _material.shaderKeywords) {
+      _material.DisableKeyword(keyword);
+    }
 
     if (_enableLightmapping) {
       _material.globalIlluminationFlags = _giFlags;

--- a/Assets/LeapMotionModules/ElementRenderer/Scripts/Utility/Editor/RendererStatsWindow.cs
+++ b/Assets/LeapMotionModules/ElementRenderer/Scripts/Utility/Editor/RendererStatsWindow.cs
@@ -1,0 +1,57 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEditor;
+using Leap.Unity.Query;
+
+public class RendererStatsWindow : EditorWindow {
+
+  [MenuItem("Window/Renderer Stats")]
+  static void Init() {
+    EditorWindow.GetWindow<RendererStatsWindow>().Show();
+  }
+
+  private void OnEnable() {
+    Selection.selectionChanged += Repaint;
+  }
+
+  private void OnDisable() {
+    Selection.selectionChanged -= Repaint;
+  }
+
+  private void OnGUI() {
+    var renderers = Selection.gameObjects.Query().
+                                          Select(g => g.GetComponent<Renderer>()).
+                                          Where(r => r != null).
+                                          ToList();
+
+    if (renderers.Count == 0) {
+      EditorGUILayout.HelpBox("Select a renderer to see statistics!", MessageType.Info);
+      return;
+    }
+
+    foreach (var renderer in renderers) {
+      using (new EditorGUI.DisabledGroupScope(true)) {
+        EditorGUILayout.ObjectField(renderer, typeof(Renderer), allowSceneObjects: true);
+      }
+
+      EditorGUILayout.LabelField("Variant keywords:", EditorStyles.boldLabel);
+      EditorGUI.indentLevel++;
+
+      foreach (var material in renderer.sharedMaterials) {
+        if (material == null) continue;
+
+        using (new EditorGUI.DisabledGroupScope(true)) {
+          EditorGUILayout.ObjectField(material, typeof(Material), allowSceneObjects: true);
+        }
+        
+        foreach (var keyword in material.shaderKeywords) {
+          EditorGUILayout.LabelField(keyword);
+        }
+      }
+
+      EditorGUI.indentLevel--;
+      EditorGUILayout.Space();
+    }
+  }
+}

--- a/Assets/LeapMotionModules/ElementRenderer/Scripts/Utility/Editor/RendererStatsWindow.cs.meta
+++ b/Assets/LeapMotionModules/ElementRenderer/Scripts/Utility/Editor/RendererStatsWindow.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 5b9e2612d29ce894aa592413d8371b69
+timeCreated: 1490055790
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Various bugfixes for the renderer:
 - Default baked shader works properly when motion is disabled
 - Baked renderer no longer uploads shader information if motion is disabled 
 - Make sure texture data is actually saved so that it doesn't go away upon recompile
 - Removed leapGuiGroup from the addcomponent menu
 - Elements removed from the gui now clean up their references
 - Texture data improved it's editor when not attached to a gui 

Also added a new RendererStats window to help debugging.  Currently it can only view shader keywords that are enabled, but we could add any number of cool things.  View it by going to Window->RendererStats