### PR TITLE
Adding the Fold operation

### DIFF
--- a/Assets/LeapMotion/Scripts/Query/DirectQueryOps.cs
+++ b/Assets/LeapMotion/Scripts/Query/DirectQueryOps.cs
@@ -122,6 +122,21 @@ namespace Leap.Unity.Query {
       }
     }
 
+    public QueryType Fold(Func<QueryType, QueryType, QueryType> foldFunc) {
+      using (thisAndConsume) {
+        if (!_op.MoveNext()) {
+          throw new InvalidOperationException();
+        }
+        QueryType value = _op.Current;
+
+        while (_op.MoveNext()) {
+          value = foldFunc(value, _op.Current);
+        }
+
+        return value;
+      }
+    }
+
     public int IndexOf(QueryType value) {
       using (thisAndConsume) {
         int index = 0;

--- a/Assets/LeapMotion/Scripts/Query/Editor/QueryTests.cs
+++ b/Assets/LeapMotion/Scripts/Query/Editor/QueryTests.cs
@@ -147,6 +147,12 @@ namespace Leap.Unity.Query.Test {
     }
 
     [Test]
+    public void FoldTest() {
+      Assert.AreEqual(LIST_0.Query().Fold((a, b) => a + b),
+                      LIST_0.Sum());
+    }
+
+    [Test]
     public void IndexOfTests() {
       Assert.AreEqual(LIST_0.Query().IndexOf(3), 2);
       Assert.AreEqual(LIST_0.Query().IndexOf(100), -1);


### PR DESCRIPTION
The fold operation uses a function to combine all of the elements into a single element.  For example, the sum operation is a type of fold operation that uses addition to combine each numerical element into the final sum.  