### PR TITLE
Fix Multiple Post Processes

### DIFF
--- a/Assets/LeapMotion/Scripts/HandPool.cs
+++ b/Assets/LeapMotion/Scripts/HandPool.cs
@@ -166,12 +166,12 @@ namespace Leap.Unity {
       HandRepresentation handRep = new HandRepresentation(this, hand, handChirality, modelType);
       for (int i = 0; i < ModelPool.Count; i++) {
         ModelGroup group = ModelPool[i];
-        handRep.Group = group;
         if (group.IsEnabled) {
           IHandModel model = group.TryGetModel(handChirality, modelType);
           if (model != null ) {
             handRep.AddModel(model);
             if (!modelToHandRepMapping.ContainsKey(model)) {
+              model.group = group;
               modelToHandRepMapping.Add(model, handRep);
             }
           }

--- a/Assets/LeapMotion/Scripts/HandRepresentation.cs
+++ b/Assets/LeapMotion/Scripts/HandRepresentation.cs
@@ -16,7 +16,6 @@ namespace Leap.Unity {
     public ModelType RepType { get; protected set; }
     public Hand MostRecentHand { get; protected set; }
     public Hand PostProcessHand { get; set; }
-    public HandPool.ModelGroup Group { get; set; }
     public List<IHandModel> handModels;
 
     public HandRepresentation(HandPool parent, Hand hand, Chirality repChirality, ModelType repType) {
@@ -69,7 +68,13 @@ namespace Leap.Unity {
       MostRecentHand = hand;
       if (handModels != null) {
         for (int i = 0; i < handModels.Count; i++) {
-          handModels[i].SetLeapHand(hand);
+          if (handModels[i].group != null && handModels[i].group.HandPostProcesses.GetPersistentEventCount() > 0) {
+            PostProcessHand.CopyFrom(hand);
+            handModels[i].group.HandPostProcesses.Invoke(PostProcessHand);
+            handModels[i].SetLeapHand(PostProcessHand);
+          } else {
+            handModels[i].SetLeapHand(hand);
+          }
           handModels[i].UpdateHand();
         }
       }

--- a/Assets/LeapMotion/Scripts/Hands/IHandModel.cs
+++ b/Assets/LeapMotion/Scripts/Hands/IHandModel.cs
@@ -47,6 +47,8 @@ namespace Leap.Unity {
       return false;
     }
 
+    public HandPool.ModelGroup group;
+
 #if UNITY_EDITOR
     void Update() {
       if (!EditorApplication.isPlaying && SupportsEditorPersistence()) {

--- a/Assets/LeapMotion/Scripts/LeapHandController.cs
+++ b/Assets/LeapMotion/Scripts/LeapHandController.cs
@@ -92,13 +92,7 @@ namespace Leap.Unity {
         }
         if (rep != null) {
           rep.IsMarked = true;
-          if (rep.Group != null && rep.Group.HandPostProcesses.GetPersistentEventCount() > 0) {
-            rep.PostProcessHand.CopyFrom(curHand);
-            rep.Group.HandPostProcesses.Invoke(rep.PostProcessHand);
-            rep.UpdateRepresentation(rep.PostProcessHand);
-          } else {
-            rep.UpdateRepresentation(curHand);
-          }
+          rep.UpdateRepresentation(curHand);
           rep.LastUpdatedTime = (int)frame.Timestamp;
         }
       }


### PR DESCRIPTION
There was a subtle bug in the structure of post processes that caused them to apply to all hands of the same model type; this PR ensures post processes apply to hands on a per-model-group basis.

An Example Hand Post Process function (for quick testing) looks like this:
```
 public void setHeldHand(Hand inHand) {
    inHand.SetTransform(transform.position, transform.rotation);
  }
```