### PR TITLE
Upgrade query implementation

### DIFF
--- a/Assets/LeapMotion/Scripts/Query.meta
+++ b/Assets/LeapMotion/Scripts/Query.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 1d8c1f93eb40de342896f9d19611a90e
+guid: 73bc0db1a60d24643989153754ee99f3
 folderAsset: yes
 timeCreated: 1484345970
 licenseType: Pro

--- a/Assets/LeapMotion/Scripts/Query/Concat.cs.meta
+++ b/Assets/LeapMotion/Scripts/Query/Concat.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b7083f6fe6a20b54e88b5d4a6794b974
+guid: 526b11f2d219cee46880d473e1008da0
 timeCreated: 1484042691
 licenseType: Free
 MonoImporter:

--- a/Assets/LeapMotion/Scripts/Query/DirectQueryOps.cs.meta
+++ b/Assets/LeapMotion/Scripts/Query/DirectQueryOps.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f4de96d5773c1ab439edca52129263d4
+guid: d94501ad6a1aae347adb0220e4085262
 timeCreated: 1484116168
 licenseType: Free
 MonoImporter:

--- a/Assets/LeapMotion/Scripts/Query/Editor.meta
+++ b/Assets/LeapMotion/Scripts/Query/Editor.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 3a5e83ee4cdfe1642b629c3e1501ee4d
+guid: 7d773c7d2f6970b47bbba49d5c73141b
 folderAsset: yes
 timeCreated: 1484347961
 licenseType: Pro

--- a/Assets/LeapMotion/Scripts/Query/Editor/ListAndArrayExtensionTests.cs.meta
+++ b/Assets/LeapMotion/Scripts/Query/Editor/ListAndArrayExtensionTests.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 12db06d2453f42e4d9ceb2cd31d9896c
+guid: 0a1881a1455853c4b84ee2a3dbf2729b
 timeCreated: 1486406452
 licenseType: Free
 MonoImporter:

--- a/Assets/LeapMotion/Scripts/Query/Editor/QueryTests.cs
+++ b/Assets/LeapMotion/Scripts/Query/Editor/QueryTests.cs
@@ -1,8 +1,7 @@
 ﻿using System.Linq;
+using System.Collections;
 using System.Collections.Generic;
 using NUnit.Framework;
-using System;
-using System.Collections;
 
 namespace Leap.Unity.Query.Test {
 
@@ -45,6 +44,11 @@ namespace Leap.Unity.Query.Test {
     public void SelectManyTest() {
       Assert.That(LIST_0.SelectMany(i => LIST_1.Select(j => j * i)).SequenceEqual(
                   LIST_0.Query().SelectMany(i => LIST_1.Query().Select(j => j * i)).ToList()));
+    }
+
+    [Test]
+    public void SelectManyEmptyTest() {
+      new int[] { }.Query().SelectMany(i => new int[] { }.Query()).ToList();
     }
 
     [Test]
@@ -158,12 +162,13 @@ namespace Leap.Unity.Query.Test {
       Assert.AreEqual(LIST_0.Query().IndexOf(100), -1);
     }
 
+    [Test]
     public void EnumeratorTest() {
       Assert.AreEqual(new TestEnumerator().Query().IndexOf(3), 3);
     }
 
     public class TestEnumerator : IEnumerator<int> {
-      private int _curr;
+      private int _curr = -1;
 
       public int Current {
         get {

--- a/Assets/LeapMotion/Scripts/Query/Editor/QueryTests.cs.meta
+++ b/Assets/LeapMotion/Scripts/Query/Editor/QueryTests.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8d54d7315096c0a42851bac84b306cba
+guid: 3edc7fa2c92cc69418361f4bc61a4f3e
 timeCreated: 1484348001
 licenseType: Pro
 MonoImporter:

--- a/Assets/LeapMotion/Scripts/Query/ListAndArrayExtensions.cs.meta
+++ b/Assets/LeapMotion/Scripts/Query/ListAndArrayExtensions.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 4c958bba27451a6468f571f7f6364fa0
+guid: fea26fc55cd2c0947ab44e4cab54487b
 timeCreated: 1484969015
 licenseType: Free
 MonoImporter:

--- a/Assets/LeapMotion/Scripts/Query/OfType.cs.meta
+++ b/Assets/LeapMotion/Scripts/Query/OfType.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b1ab1cbc3577de443bc1a7993031965d
+guid: bea14e07d1595ea47aba72f49c04dcc6
 timeCreated: 1484110995
 licenseType: Free
 MonoImporter:

--- a/Assets/LeapMotion/Scripts/Query/QueryWrapper.cs.meta
+++ b/Assets/LeapMotion/Scripts/Query/QueryWrapper.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 227d364f9eb6e9a4583cfc6964a74898
+guid: 0c6611426c0536b4394d9636e3a3e2a9
 timeCreated: 1484042035
 licenseType: Free
 MonoImporter:

--- a/Assets/LeapMotion/Scripts/Query/Select.cs
+++ b/Assets/LeapMotion/Scripts/Query/Select.cs
@@ -1,11 +1,9 @@
 ﻿using System;
-using System.Collections;
-using System.Collections.Generic;
 
 namespace Leap.Unity.Query {
 
-  public struct SelectOp<SourceType, ResultType, SourceOp> : IEnumerator<ResultType>
-    where SourceOp : IEnumerator<SourceType> {
+  public struct SelectOp<SourceType, ResultType, SourceOp> : IQueryOp<ResultType>
+    where SourceOp : IQueryOp<SourceType> {
     private SourceOp _source;
     private Func<SourceType, ResultType> _mapping;
 
@@ -14,33 +12,23 @@ namespace Leap.Unity.Query {
       _mapping = mapping;
     }
 
-    public bool MoveNext() {
-      return _source.MoveNext();
-    }
-
-    public ResultType Current {
-      get {
-        return _mapping(_source.Current);
-      }
-    }
-
-    object IEnumerator.Current {
-      get {
-        throw new InvalidOperationException();
+    public bool TryGetNext(out ResultType t) {
+      SourceType sourceObj;
+      if (_source.TryGetNext(out sourceObj)) {
+        t = _mapping(sourceObj);
+        return true;
+      } else {
+        t = default(ResultType);
+        return false;
       }
     }
 
     public void Reset() {
-      throw new InvalidOperationException();
-    }
-
-    public void Dispose() {
-      _source.Dispose();
-      _mapping = null;
+      _source.Reset();
     }
   }
 
-  public partial struct QueryWrapper<QueryType, QueryOp> where QueryOp : IEnumerator<QueryType> {
+  public partial struct QueryWrapper<QueryType, QueryOp> where QueryOp : IQueryOp<QueryType> {
     public QueryWrapper<NewType, SelectOp<QueryType, NewType, QueryOp>> Select<NewType>(Func<QueryType, NewType> mapping) {
       return new QueryWrapper<NewType, SelectOp<QueryType, NewType, QueryOp>>(new SelectOp<QueryType, NewType, QueryOp>(_op, mapping));
     }

--- a/Assets/LeapMotion/Scripts/Query/Select.cs.meta
+++ b/Assets/LeapMotion/Scripts/Query/Select.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d1a0f513d19a3fc4383788f0960549d4
+guid: ed58ae844c840854180a7dd3debe6df9
 timeCreated: 1484043787
 licenseType: Free
 MonoImporter:

--- a/Assets/LeapMotion/Scripts/Query/SelectMany.cs.meta
+++ b/Assets/LeapMotion/Scripts/Query/SelectMany.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 96864993485ed8040b0c6353245492aa
+guid: 7388f42782315c24ba48f3c6733be19b
 timeCreated: 1484795151
 licenseType: Free
 MonoImporter:

--- a/Assets/LeapMotion/Scripts/Query/SkipCount.cs.meta
+++ b/Assets/LeapMotion/Scripts/Query/SkipCount.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 17dcf93ace5936c4b8591e0a2d81c956
+guid: 583b18568538d914a934e6ddabb7ae8a
 timeCreated: 1485794591
 licenseType: Free
 MonoImporter:

--- a/Assets/LeapMotion/Scripts/Query/SkipWhile.cs.meta
+++ b/Assets/LeapMotion/Scripts/Query/SkipWhile.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d04a79bce550d814aad44bdbd60f71fa
+guid: 5844fa2ad1bb8644aaa87a76ef66d8f0
 timeCreated: 1485794296
 licenseType: Free
 MonoImporter:

--- a/Assets/LeapMotion/Scripts/Query/TakeCount.cs
+++ b/Assets/LeapMotion/Scripts/Query/TakeCount.cs
@@ -1,50 +1,35 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
-
+﻿
 namespace Leap.Unity.Query {
 
-  public struct TakeCountOp<SourceType, SourceOp> : IEnumerator<SourceType>
-  where SourceOp : IEnumerator<SourceType> {
+  public struct TakeCountOp<SourceType, SourceOp> : IQueryOp<SourceType>
+  where SourceOp : IQueryOp<SourceType> {
     private SourceOp _source;
+    private int _takeLeft;
     private int _toTake;
 
     public TakeCountOp(SourceOp source, int toTake) {
       _source = source;
+      _takeLeft = toTake;
       _toTake = toTake;
     }
 
-    public bool MoveNext() {
-      if (_toTake == 0) {
+    public bool TryGetNext(out SourceType t) {
+      if (_takeLeft == 0) {
+        t = default(SourceType);
         return false;
       }
 
-      _toTake--;
-      return _source.MoveNext();
-    }
-
-    public SourceType Current {
-      get {
-        return _source.Current;
-      }
-    }
-
-    object IEnumerator.Current {
-      get {
-        throw new InvalidOperationException();
-      }
+      _takeLeft--;
+      return _source.TryGetNext(out t);
     }
 
     public void Reset() {
-      throw new InvalidOperationException();
-    }
-
-    public void Dispose() {
-      _source.Dispose();
+      _takeLeft = _toTake;
+      _source.Reset();
     }
   }
 
-  public partial struct QueryWrapper<QueryType, QueryOp> where QueryOp : IEnumerator<QueryType> {
+  public partial struct QueryWrapper<QueryType, QueryOp> where QueryOp : IQueryOp<QueryType> {
     public QueryWrapper<QueryType, TakeCountOp<QueryType, QueryOp>> Take(int count) {
       return new QueryWrapper<QueryType, TakeCountOp<QueryType, QueryOp>>(new TakeCountOp<QueryType, QueryOp>(_op, count));
     }

--- a/Assets/LeapMotion/Scripts/Query/TakeCount.cs.meta
+++ b/Assets/LeapMotion/Scripts/Query/TakeCount.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 8ad3ca738a88f914287cd20246b39205
+guid: 7df9d4afb12007f4fa377abbed85ab22
 timeCreated: 1485794726
 licenseType: Free
 MonoImporter:

--- a/Assets/LeapMotion/Scripts/Query/TakeWhile.cs.meta
+++ b/Assets/LeapMotion/Scripts/Query/TakeWhile.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b5af020c00dfe2b419380392b6c894da
+guid: 0adcba7e997c9bd45b6feb99a5ce4734
 timeCreated: 1484115592
 licenseType: Free
 MonoImporter:

--- a/Assets/LeapMotion/Scripts/Query/Where.cs.meta
+++ b/Assets/LeapMotion/Scripts/Query/Where.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b163cb95defdd764d8895328ff711b9b
+guid: e38a102eb8c89c4418f1d543adaabd05
 timeCreated: 1484042079
 licenseType: Free
 MonoImporter:

--- a/Assets/LeapMotion/Scripts/Query/Zip.cs.meta
+++ b/Assets/LeapMotion/Scripts/Query/Zip.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 7480e8c7eb738244ea80c923c9a86601
+guid: 6399c119c98cd34458a1f16951b72c26
 timeCreated: 1484794103
 licenseType: Free
 MonoImporter:


### PR DESCRIPTION
The query implementation has been re-written for better performance and readability.  Instead of using the existing IEnumerator interface, a more lightweight and specialized interface (IQueryOp) was created instead.  This allows greater performance due to the use of the out parameter to prevent copying, and the consolidation of the MoveNext and the Current into a single method, TryGetNext.  It also means that you need to write less boilerplate when creating a new op because you only need to implement 2 methods instead of the handful inside IEnumerator.

To test
 - [ ] Review code and make sure everything is sound
 - [ ] Make sure all tests pass