### PR TITLE
Fixed foreach because of dumb mistake

### DIFF
--- a/Assets/LeapMotion/Scripts/Query/Editor/QueryTests.cs
+++ b/Assets/LeapMotion/Scripts/Query/Editor/QueryTests.cs
@@ -10,6 +10,15 @@ namespace Leap.Unity.Query.Test {
     public int[] LIST_1 = { 6, 7, 8, 9, 10 };
 
     [Test]
+    public void ForeachTest() {
+      List<int> found = new List<int>();
+      foreach (var item in LIST_0.Query().Concat(LIST_1.Query())) {
+        found.Add(item);
+      }
+      Assert.That(LIST_0.Concat(LIST_1).SequenceEqual(found));
+    }
+
+    [Test]
     public void CastTest() {
       object[] objs = new object[] { "Hello", "World", "These", "Are", "All", "Strings" };
 

--- a/Assets/LeapMotion/Scripts/Query/QueryWrapper.cs
+++ b/Assets/LeapMotion/Scripts/Query/QueryWrapper.cs
@@ -37,7 +37,7 @@ namespace Leap.Unity.Query {
     }
 
     public Enumerator GetEnumerator() {
-      return new Enumerator();
+      return new Enumerator(_op);
     }
 
     public struct Enumerator {


### PR DESCRIPTION
Was creating an uninitialized enumerator when doing foreach, resulting in major suckage.  Now construct the enumerator properly and added a unit test to cover the basic foreach case.