### PR TITLE
Bugfixes for graphic renderer

### DIFF
--- a/Assets/LeapMotion/Scripts/DataStructures/Hash.cs
+++ b/Assets/LeapMotion/Scripts/DataStructures/Hash.cs
@@ -43,7 +43,13 @@ namespace Leap.Unity {
 
       root.GetComponents(_behaviourCache);
       for (int i = 0; i < _behaviourCache.Count; i++) {
-        hash.Add(_behaviourCache[i].enabled);
+        var behaviour = _behaviourCache[i];
+
+        //A behaviour returned from GetComponents can be null if it is an invalid
+        //script object or due to a compile error >.>
+        if (behaviour != null) {
+          hash.Add(behaviour.enabled);
+        }
       }
 
       return hash;

--- a/Assets/LeapMotionModules/GraphicRenderer/Scenes/FeatureTest.unity
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scenes/FeatureTest.unity
@@ -192,85 +192,6 @@ Transform:
   m_Father: {fileID: 658088855}
   m_RootOrder: 30
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &94151149
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 94151150}
-  - component: {fileID: 94151152}
-  - component: {fileID: 94151151}
-  - component: {fileID: 94151153}
-  m_Layer: 0
-  m_Name: Element (3)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &94151150
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 94151149}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 1, y: -2, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1238297700}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &94151151
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 94151149}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b7dca36e8e5c88459b2626007befebc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  parent: {fileID: 1238297699}
-  space: {fileID: 1307638100}
---- !u!114 &94151152
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 94151149}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8fb726b2ea51dd94d8601fa443872ec2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _anchor: {fileID: 0}
-  _featureData:
-  - {fileID: 94151153}
-  _attachedGroup: {fileID: 1307638099}
-  _preferredRendererType:
-    _fullName: Leap.Unity.GraphicalRenderer.LeapBakedRenderer
-  vertexColor: {r: 0.6911765, g: 0.6911765, b: 0.6911765, a: 1}
-  _mesh: {fileID: 4300000, guid: 14e47e6e841b85146813b9d552dc3d37, type: 3}
-  _remappableChannels: -1
---- !u!114 &94151153
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 94151149}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d2c8779b1bdf86c4dbcbe18f17e44e53, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _persistentId: 1157708450
-  graphic: {fileID: 94151152}
-  feature: {fileID: 1307638097}
-  texture: {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
 --- !u!1 &129763931
 GameObject:
   m_ObjectHideFlags: 0
@@ -537,7 +458,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d2c8779b1bdf86c4dbcbe18f17e44e53, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _persistentId: 1157708450
   graphic: {fileID: 465469650}
   feature: {fileID: 1535910914}
   texture: {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
@@ -862,7 +782,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d2c8779b1bdf86c4dbcbe18f17e44e53, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _persistentId: -1169280965
   graphic: {fileID: 747764345}
   feature: {fileID: 1535910914}
   texture: {fileID: 2800000, guid: 93f4f81256c947642a93d907d828ee98, type: 3}
@@ -996,33 +915,6 @@ Transform:
   m_Father: {fileID: 658088855}
   m_RootOrder: 25
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!21 &863663351
-Material:
-  serializedVersion: 6
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_Name: Procedural Graphic Material
-  m_Shader: {fileID: 4800000, guid: 692ffa38f03db184d8b27b0661d5bf0d, type: 3}
-  m_ShaderKeywords: GRAPHIC_RENDERER_MOVEMENT_TRANSLATION GRAPHIC_RENDERER_VERTEX_UV_0
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MainTex2:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Floats: []
-    m_Colors: []
 --- !u!1 &885763360
 GameObject:
   m_ObjectHideFlags: 0
@@ -1050,85 +942,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 658088855}
   m_RootOrder: 26
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &900640420
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 900640424}
-  - component: {fileID: 900640422}
-  - component: {fileID: 900640423}
-  - component: {fileID: 900640421}
-  m_Layer: 0
-  m_Name: Element (5)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &900640421
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 900640420}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d2c8779b1bdf86c4dbcbe18f17e44e53, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _persistentId: -1764417259
-  graphic: {fileID: 900640422}
-  feature: {fileID: 1307638097}
-  texture: {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
---- !u!114 &900640422
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 900640420}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8fb726b2ea51dd94d8601fa443872ec2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _anchor: {fileID: 0}
-  _featureData:
-  - {fileID: 900640421}
-  _attachedGroup: {fileID: 1307638099}
-  _preferredRendererType:
-    _fullName: Leap.Unity.GraphicalRenderer.LeapBakedRenderer
-  vertexColor: {r: 1, g: 0, b: 0, a: 1}
-  _mesh: {fileID: 4300000, guid: 14e47e6e841b85146813b9d552dc3d37, type: 3}
-  _remappableChannels: -1
---- !u!114 &900640423
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 900640420}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b7dca36e8e5c88459b2626007befebc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  parent: {fileID: 1238297699}
-  space: {fileID: 1307638100}
---- !u!4 &900640424
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 900640420}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -3, y: -2, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1238297700}
-  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &905548334
 GameObject:
@@ -1396,159 +1209,6 @@ Transform:
   m_Father: {fileID: 658088855}
   m_RootOrder: 23
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1166533748
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 1166533749}
-  - component: {fileID: 1166533751}
-  - component: {fileID: 1166533750}
-  - component: {fileID: 1166533752}
-  m_Layer: 0
-  m_Name: Element (1)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1166533749
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1166533748}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 3, y: -2, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1238297700}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1166533750
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1166533748}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b7dca36e8e5c88459b2626007befebc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  parent: {fileID: 1238297699}
-  space: {fileID: 1307638100}
---- !u!114 &1166533751
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1166533748}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8fb726b2ea51dd94d8601fa443872ec2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _anchor: {fileID: 0}
-  _featureData:
-  - {fileID: 1166533752}
-  _attachedGroup: {fileID: 1307638099}
-  _preferredRendererType:
-    _fullName: Leap.Unity.GraphicalRenderer.LeapBakedRenderer
-  vertexColor: {r: 1, g: 0, b: 0, a: 1}
-  _mesh: {fileID: 4300000, guid: 14e47e6e841b85146813b9d552dc3d37, type: 3}
-  _remappableChannels: -1
---- !u!114 &1166533752
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1166533748}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d2c8779b1bdf86c4dbcbe18f17e44e53, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _persistentId: 813424555
-  graphic: {fileID: 1166533751}
-  feature: {fileID: 1307638097}
-  texture: {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
---- !u!21 &1235518120
-Material:
-  serializedVersion: 6
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_Name: Procedural Graphic Material
-  m_Shader: {fileID: 4800000, guid: 692ffa38f03db184d8b27b0661d5bf0d, type: 3}
-  m_ShaderKeywords: GRAPHIC_RENDERER_MOVEMENT_TRANSLATION GRAPHIC_RENDERER_VERTEX_UV_0
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MainTex2:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Floats: []
-    m_Colors: []
---- !u!1 &1238297698
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 1238297700}
-  - component: {fileID: 1238297699}
-  m_Layer: 0
-  m_Name: Anchor
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1238297699
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1238297698}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b7dca36e8e5c88459b2626007befebc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  parent: {fileID: 1307638100}
-  space: {fileID: 1307638100}
---- !u!4 &1238297700
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1238297698}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 2.3, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 2073345371}
-  - {fileID: 1166533749}
-  - {fileID: 94151150}
-  - {fileID: 1332538154}
-  - {fileID: 900640424}
-  m_Father: {fileID: 1307638105}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1259038824
 GameObject:
   m_ObjectHideFlags: 0
@@ -1633,444 +1293,6 @@ Transform:
   m_Father: {fileID: 658088855}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1307638096
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 1307638105}
-  - component: {fileID: 1307638104}
-  - component: {fileID: 1307638103}
-  - component: {fileID: 1307638102}
-  - component: {fileID: 1307638101}
-  - component: {fileID: 1307638100}
-  - component: {fileID: 1307638099}
-  - component: {fileID: 1307638098}
-  - component: {fileID: 1307638097}
-  m_Layer: 0
-  m_Name: GUI (1)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1307638097
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1307638096}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 36ae2dc675d304041af3c95461f228e2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _persistentId: -331774046
-  featureData:
-  - {fileID: 2073345374}
-  - {fileID: 1166533752}
-  - {fileID: 94151153}
-  - {fileID: 1332538157}
-  - {fileID: 900640421}
-  propertyName: _MainTex
-  channel: 1
---- !u!114 &1307638098
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1307638096}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 00bb44340bd430d44a098a5e36f4de2d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _persistentId: -1596528111
-  renderer: {fileID: 1307638104}
-  group: {fileID: 1307638099}
-  _useUv0: 1
-  _useUv1: 0
-  _useUv2: 0
-  _useUv3: 0
-  _useColors: 0
-  _bakedTint: {r: 1, g: 1, b: 1, a: 1}
-  _useNormals: 0
-  _shader: {fileID: 4800000, guid: 692ffa38f03db184d8b27b0661d5bf0d, type: 3}
-  _atlas:
-    _border: 1
-    _padding: 0
-    _mipMap: 1
-    _filterMode: 1
-    _format: 5
-    _maxAtlasSize: 4096
-  _material: {fileID: 863663351}
-  _meshes: {fileID: 11400000, guid: 7281c07886f07be4197d14f51b29daf0, type: 2}
-  _packedTextures: {fileID: 11400000, guid: f29762def437c804798df4da6a054e36, type: 2}
-  _atlasUvs:
-    _channel0:
-      _keys:
-      - {fileID: 2800000, guid: 93f4f81256c947642a93d907d828ee98, type: 3}
-      - {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
-      _values:
-      - serializedVersion: 2
-        x: 0.015625
-        y: 0.2890625
-        width: 0.5
-        height: 0.25
-      - serializedVersion: 2
-        x: 0.015625
-        y: 0.0078125
-        width: 0.53125
-        height: 0.265625
-    _channel1:
-      _keys: []
-      _values: []
-    _channel2:
-      _keys: []
-      _values: []
-    _channel3:
-      _keys: []
-      _values: []
-    _nullRects:
-    - serializedVersion: 2
-      x: 0
-      y: 0
-      width: 0
-      height: 0
-    - serializedVersion: 2
-      x: 0
-      y: 0
-      width: 0
-      height: 0
-    - serializedVersion: 2
-      x: 0
-      y: 0
-      width: 0
-      height: 0
-    - serializedVersion: 2
-      x: 0
-      y: 0
-      width: 0
-      height: 0
-  _layer:
-    layerIndex: 0
-  _motionType: 1
-  _createMeshRenderers: 1
-  _renderers:
-  - obj: {fileID: 1401500834}
-    filter: {fileID: 1401500836}
-    renderer: {fileID: 1401500835}
---- !u!114 &1307638099
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1307638096}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b32d8e323bfd9df4d82051c22f44d792, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _persistentId: 1152296847
-  _renderingMethod: {fileID: 1307638098}
-  _features:
-  - {fileID: 1307638097}
-  _renderer: {fileID: 1307638104}
-  _graphics:
-  - {fileID: 2073345373}
-  - {fileID: 1166533751}
-  - {fileID: 94151152}
-  - {fileID: 1332538156}
-  - {fileID: 900640422}
-  _supportInfo:
-  - support: 0
-    message: 
-  _addRemoveSupported: 0
---- !u!114 &1307638100
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1307638096}
-  m_Enabled: 0
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9261239b711172441b484496a58d001c, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  parent: {fileID: 1307638100}
-  space: {fileID: 1307638100}
-  _radius: 3.28
---- !u!114 &1307638101
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1307638096}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: cdb13d8a1ce808e4787f1af6f2e7fa1b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _persistentId: 1425470384
-  renderer: {fileID: 0}
-  group: {fileID: 0}
-  _font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-  _dynamicPixelsPerUnit: 20
-  _useColor: 1
-  _globalTint: {r: 1, g: 1, b: 1, a: 1}
-  _shader: {fileID: 4800000, guid: 45c3e855355db4d409f06f94b19ed52f, type: 3}
-  _meshData: {fileID: 0}
---- !u!114 &1307638102
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1307638096}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e4e826f61fa76194f87130a5030b287d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _persistentId: -464593129
-  renderer: {fileID: 0}
-  group: {fileID: 0}
-  _useUv0: 1
-  _useUv1: 0
-  _useUv2: 0
-  _useUv3: 0
-  _useColors: 0
-  _bakedTint: {r: 1, g: 1, b: 1, a: 1}
-  _useNormals: 0
-  _shader: {fileID: 4800000, guid: a770bdf1a8aeb824aa92fc5d9e2ffb55, type: 3}
-  _atlas:
-    _border: 1
-    _padding: 0
-    _mipMap: 1
-    _filterMode: 1
-    _format: 5
-    _maxAtlasSize: 4096
-  _material: {fileID: 1611082225}
-  _meshes: {fileID: 0}
-  _packedTextures: {fileID: 0}
-  _atlasUvs:
-    _channel0:
-      _keys: []
-      _values: []
-    _channel1:
-      _keys: []
-      _values: []
-    _channel2:
-      _keys: []
-      _values: []
-    _channel3:
-      _keys: []
-      _values: []
-    _nullRects:
-    - serializedVersion: 2
-      x: 0
-      y: 0
-      width: 0
-      height: 0
-    - serializedVersion: 2
-      x: 0
-      y: 0
-      width: 0
-      height: 0
-    - serializedVersion: 2
-      x: 0
-      y: 0
-      width: 0
-      height: 0
-    - serializedVersion: 2
-      x: 0
-      y: 0
-      width: 0
-      height: 0
---- !u!114 &1307638103
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1307638096}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 00bb44340bd430d44a098a5e36f4de2d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _persistentId: 167835291
-  renderer: {fileID: 0}
-  group: {fileID: 0}
-  _useUv0: 1
-  _useUv1: 0
-  _useUv2: 0
-  _useUv3: 0
-  _useColors: 0
-  _bakedTint: {r: 1, g: 1, b: 1, a: 1}
-  _useNormals: 1
-  _shader: {fileID: 4800000, guid: 692ffa38f03db184d8b27b0661d5bf0d, type: 3}
-  _atlas:
-    _border: 1
-    _padding: 0
-    _mipMap: 1
-    _filterMode: 1
-    _format: 5
-    _maxAtlasSize: 4096
-  _material: {fileID: 1882322863}
-  _meshes: {fileID: 0}
-  _packedTextures: {fileID: 0}
-  _atlasUvs:
-    _channel0:
-      _keys: []
-      _values: []
-    _channel1:
-      _keys: []
-      _values: []
-    _channel2:
-      _keys: []
-      _values: []
-    _channel3:
-      _keys: []
-      _values: []
-    _nullRects:
-    - serializedVersion: 2
-      x: 0
-      y: 0
-      width: 0
-      height: 0
-    - serializedVersion: 2
-      x: 0
-      y: 0
-      width: 0
-      height: 0
-    - serializedVersion: 2
-      x: 0
-      y: 0
-      width: 0
-      height: 0
-    - serializedVersion: 2
-      x: 0
-      y: 0
-      width: 0
-      height: 0
-  _layer:
-    layerIndex: 0
-  _motionType: 1
-  _createMeshRenderers: 1
-  _renderers:
-  - obj: {fileID: 0}
-    filter: {fileID: 0}
-    renderer: {fileID: 0}
---- !u!114 &1307638104
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1307638096}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: adb71699a7372344cb4e7a163c6c6922, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _selectedGroup: 0
-  _space: {fileID: 0}
-  _groups:
-  - {fileID: 1307638099}
---- !u!4 &1307638105
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1307638096}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 2, z: 3.6}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 1401500837}
-  - {fileID: 1238297700}
-  m_Father: {fileID: 0}
-  m_RootOrder: 4
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1332538153
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 1332538154}
-  - component: {fileID: 1332538156}
-  - component: {fileID: 1332538155}
-  - component: {fileID: 1332538157}
-  m_Layer: 0
-  m_Name: Element (4)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1332538154
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1332538153}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -1, y: -2, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1238297700}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1332538155
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1332538153}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b7dca36e8e5c88459b2626007befebc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  parent: {fileID: 1238297699}
-  space: {fileID: 1307638100}
---- !u!114 &1332538156
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1332538153}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8fb726b2ea51dd94d8601fa443872ec2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _anchor: {fileID: 0}
-  _featureData:
-  - {fileID: 1332538157}
-  _attachedGroup: {fileID: 1307638099}
-  _preferredRendererType:
-    _fullName: Leap.Unity.GraphicalRenderer.LeapBakedRenderer
-  vertexColor: {r: 0.6911765, g: 0.6911765, b: 0.6911765, a: 1}
-  _mesh: {fileID: 4300000, guid: 14e47e6e841b85146813b9d552dc3d37, type: 3}
-  _remappableChannels: -1
---- !u!114 &1332538157
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1332538153}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d2c8779b1bdf86c4dbcbe18f17e44e53, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _persistentId: 1496237382
-  graphic: {fileID: 1332538156}
-  feature: {fileID: 1307638097}
-  texture: {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
 --- !u!1 &1365773555
 GameObject:
   m_ObjectHideFlags: 0
@@ -2100,7 +1322,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d2c8779b1bdf86c4dbcbe18f17e44e53, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _persistentId: 813424555
   graphic: {fileID: 1365773557}
   feature: {fileID: 1535910914}
   texture: {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
@@ -2192,7 +1413,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d2c8779b1bdf86c4dbcbe18f17e44e53, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _persistentId: 1496237382
   graphic: {fileID: 1366916395}
   feature: {fileID: 1535910914}
   texture: {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
@@ -2229,75 +1449,6 @@ MonoBehaviour:
   vertexColor: {r: 0.6911765, g: 0.6911765, b: 0.6911765, a: 1}
   _mesh: {fileID: 4300000, guid: 14e47e6e841b85146813b9d552dc3d37, type: 3}
   _remappableChannels: -1
---- !u!1 &1401500834
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 1401500837}
-  - component: {fileID: 1401500836}
-  - component: {fileID: 1401500835}
-  m_Layer: 0
-  m_Name: Graphic Renderer
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!23 &1401500835
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1401500834}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_Materials:
-  - {fileID: 863663351}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &1401500836
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1401500834}
-  m_Mesh: {fileID: 43073225500203408, guid: 7281c07886f07be4197d14f51b29daf0, type: 2}
---- !u!4 &1401500837
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1401500834}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1307638105}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1520670167
 GameObject:
   m_ObjectHideFlags: 0
@@ -2327,7 +1478,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d2c8779b1bdf86c4dbcbe18f17e44e53, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _persistentId: -1764417259
   graphic: {fileID: 1520670169}
   feature: {fileID: 1535910914}
   texture: {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
@@ -2411,7 +1561,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 00bb44340bd430d44a098a5e36f4de2d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _persistentId: 167835291
   renderer: {fileID: 0}
   group: {fileID: 0}
   _useUv0: 1
@@ -2485,7 +1634,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 00bb44340bd430d44a098a5e36f4de2d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _persistentId: -1596528111
   renderer: {fileID: 1535910906}
   group: {fileID: 1535910909}
   _useUv0: 1
@@ -2503,9 +1651,9 @@ MonoBehaviour:
     _filterMode: 1
     _format: 5
     _maxAtlasSize: 4096
-  _material: {fileID: 1235518120}
-  _meshes: {fileID: 11400000, guid: 7281c07886f07be4197d14f51b29daf0, type: 2}
-  _packedTextures: {fileID: 11400000, guid: f29762def437c804798df4da6a054e36, type: 2}
+  _material: {fileID: 1915229403}
+  _meshes: {fileID: 11400000, guid: 5dc4374b8e12c6249a7c4d53656cad9a, type: 2}
+  _packedTextures: {fileID: 11400000, guid: ab7e18de92f1bd841909148c41debbe2, type: 2}
   _atlasUvs:
     _channel0:
       _keys:
@@ -2615,7 +1763,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b32d8e323bfd9df4d82051c22f44d792, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _persistentId: 1152296847
   _renderingMethod: {fileID: 1535910905}
   _features:
   - {fileID: 1535910914}
@@ -2641,7 +1788,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e4e826f61fa76194f87130a5030b287d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _persistentId: -464593129
   renderer: {fileID: 0}
   group: {fileID: 0}
   _useUv0: 1
@@ -2707,7 +1853,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cdb13d8a1ce808e4787f1af6f2e7fa1b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _persistentId: 1425470384
   renderer: {fileID: 0}
   group: {fileID: 0}
   _font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
@@ -2727,7 +1872,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 36ae2dc675d304041af3c95461f228e2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _persistentId: -331774046
   featureData:
   - {fileID: 747764344}
   - {fileID: 1365773556}
@@ -2984,6 +2128,34 @@ Material:
     - _BumpScale: 1
     - _Smoothness: 1
     m_Colors: []
+--- !u!21 &1915229403
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: Procedural Graphic Material
+  m_Shader: {fileID: 4800000, guid: 692ffa38f03db184d8b27b0661d5bf0d, type: 3}
+  m_ShaderKeywords: GRAPHIC_RENDERER_MOVEMENT_TRANSLATION GRAPHIC_RENDERER_VERTEX_UV_0
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 28041122674155060, guid: ab7e18de92f1bd841909148c41debbe2,
+          type: 2}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex2:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats: []
+    m_Colors: []
 --- !u!1 &1931788082
 GameObject:
   m_ObjectHideFlags: 0
@@ -3014,7 +2186,7 @@ MeshRenderer:
   m_LightProbeUsage: 1
   m_ReflectionProbeUsage: 1
   m_Materials:
-  - {fileID: 1235518120}
+  - {fileID: 1915229403}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0
@@ -3039,7 +2211,7 @@ MeshFilter:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1931788082}
-  m_Mesh: {fileID: 0}
+  m_Mesh: {fileID: 43090069795517828, guid: 5dc4374b8e12c6249a7c4d53656cad9a, type: 2}
 --- !u!4 &1931788085
 Transform:
   m_ObjectHideFlags: 0
@@ -3109,85 +2281,6 @@ Transform:
   m_Father: {fileID: 658088855}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &2073345370
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 2073345371}
-  - component: {fileID: 2073345373}
-  - component: {fileID: 2073345372}
-  - component: {fileID: 2073345374}
-  m_Layer: 0
-  m_Name: Element
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &2073345371
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 2073345370}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1238297700}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &2073345372
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 2073345370}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b7dca36e8e5c88459b2626007befebc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  parent: {fileID: 1238297699}
-  space: {fileID: 1307638100}
---- !u!114 &2073345373
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 2073345370}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8fb726b2ea51dd94d8601fa443872ec2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _anchor: {fileID: 0}
-  _featureData:
-  - {fileID: 2073345374}
-  _attachedGroup: {fileID: 1307638099}
-  _preferredRendererType:
-    _fullName: Leap.Unity.GraphicalRenderer.LeapBakedRenderer
-  vertexColor: {r: 1, g: 1, b: 1, a: 1}
-  _mesh: {fileID: 4300000, guid: 14e47e6e841b85146813b9d552dc3d37, type: 3}
-  _remappableChannels: -1
---- !u!114 &2073345374
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 2073345370}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d2c8779b1bdf86c4dbcbe18f17e44e53, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _persistentId: -1169280965
-  graphic: {fileID: 2073345373}
-  feature: {fileID: 1307638097}
-  texture: {fileID: 2800000, guid: 93f4f81256c947642a93d907d828ee98, type: 3}
 --- !u!1 &2139915609
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/LeapMotionModules/GraphicRenderer/Scenes/FeatureTest.unity
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scenes/FeatureTest.unity
@@ -192,6 +192,85 @@ Transform:
   m_Father: {fileID: 658088855}
   m_RootOrder: 30
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &94151149
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 94151150}
+  - component: {fileID: 94151152}
+  - component: {fileID: 94151151}
+  - component: {fileID: 94151153}
+  m_Layer: 0
+  m_Name: Element (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &94151150
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 94151149}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 1, y: -2, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1238297700}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &94151151
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 94151149}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1b7dca36e8e5c88459b2626007befebc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  parent: {fileID: 1238297699}
+  space: {fileID: 1307638100}
+--- !u!114 &94151152
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 94151149}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8fb726b2ea51dd94d8601fa443872ec2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _anchor: {fileID: 0}
+  _featureData:
+  - {fileID: 94151153}
+  _attachedGroup: {fileID: 1307638099}
+  _preferredRendererType:
+    _fullName: Leap.Unity.GraphicalRenderer.LeapBakedRenderer
+  vertexColor: {r: 0.6911765, g: 0.6911765, b: 0.6911765, a: 1}
+  _mesh: {fileID: 4300000, guid: 14e47e6e841b85146813b9d552dc3d37, type: 3}
+  _remappableChannels: -1
+--- !u!114 &94151153
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 94151149}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d2c8779b1bdf86c4dbcbe18f17e44e53, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _persistentId: 1157708450
+  graphic: {fileID: 94151152}
+  feature: {fileID: 1307638097}
+  texture: {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
 --- !u!1 &129763931
 GameObject:
   m_ObjectHideFlags: 0
@@ -416,33 +495,6 @@ Transform:
   m_Father: {fileID: 658088855}
   m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!21 &457937449
-Material:
-  serializedVersion: 6
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_Name: Procedural Graphic Material
-  m_Shader: {fileID: 4800000, guid: 692ffa38f03db184d8b27b0661d5bf0d, type: 3}
-  m_ShaderKeywords: GRAPHIC_RENDERER_MOVEMENT_TRANSLATION GRAPHIC_RENDERER_VERTEX_UV_0
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MainTex2:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Floats: []
-    m_Colors: []
 --- !u!1 &465469645
 GameObject:
   m_ObjectHideFlags: 0
@@ -453,7 +505,6 @@ GameObject:
   - component: {fileID: 465469646}
   - component: {fileID: 465469650}
   - component: {fileID: 465469648}
-  - component: {fileID: 465469649}
   - component: {fileID: 465469647}
   m_Layer: 0
   m_Name: Element (3)
@@ -483,13 +534,13 @@ MonoBehaviour:
   m_GameObject: {fileID: 465469645}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b051eb69afb505b479d2ea649875e390, type: 3}
+  m_Script: {fileID: 11500000, guid: d2c8779b1bdf86c4dbcbe18f17e44e53, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _persistentId: 1062947571
+  _persistentId: 1157708450
   graphic: {fileID: 465469650}
-  feature: {fileID: 1535910903}
-  sprite: {fileID: 21300000, guid: 7941f01ab879cfa4495b7e425293ddad, type: 3}
+  feature: {fileID: 1535910914}
+  texture: {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
 --- !u!114 &465469648
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -503,17 +554,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   parent: {fileID: 1645781541}
   space: {fileID: 1535910908}
---- !u!114 &465469649
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 465469645}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c437e41a5ae81fd468510f087ba4a70a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &465469650
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -803,7 +843,6 @@ GameObject:
   - component: {fileID: 747764346}
   - component: {fileID: 747764345}
   - component: {fileID: 747764347}
-  - component: {fileID: 747764348}
   - component: {fileID: 747764344}
   m_Layer: 0
   m_Name: Element
@@ -820,13 +859,13 @@ MonoBehaviour:
   m_GameObject: {fileID: 747764343}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b051eb69afb505b479d2ea649875e390, type: 3}
+  m_Script: {fileID: 11500000, guid: d2c8779b1bdf86c4dbcbe18f17e44e53, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _persistentId: -974240100
+  _persistentId: -1169280965
   graphic: {fileID: 747764345}
-  feature: {fileID: 1535910903}
-  sprite: {fileID: 21300000, guid: 7941f01ab879cfa4495b7e425293ddad, type: 3}
+  feature: {fileID: 1535910914}
+  texture: {fileID: 2800000, guid: 93f4f81256c947642a93d907d828ee98, type: 3}
 --- !u!114 &747764345
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -873,17 +912,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   parent: {fileID: 1645781541}
   space: {fileID: 1535910908}
---- !u!114 &747764348
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 747764343}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c437e41a5ae81fd468510f087ba4a70a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &751201669
 GameObject:
   m_ObjectHideFlags: 0
@@ -968,6 +996,33 @@ Transform:
   m_Father: {fileID: 658088855}
   m_RootOrder: 25
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!21 &863663351
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: Procedural Graphic Material
+  m_Shader: {fileID: 4800000, guid: 692ffa38f03db184d8b27b0661d5bf0d, type: 3}
+  m_ShaderKeywords: GRAPHIC_RENDERER_MOVEMENT_TRANSLATION GRAPHIC_RENDERER_VERTEX_UV_0
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex2:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats: []
+    m_Colors: []
 --- !u!1 &885763360
 GameObject:
   m_ObjectHideFlags: 0
@@ -995,6 +1050,85 @@ Transform:
   m_Children: []
   m_Father: {fileID: 658088855}
   m_RootOrder: 26
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &900640420
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 900640424}
+  - component: {fileID: 900640422}
+  - component: {fileID: 900640423}
+  - component: {fileID: 900640421}
+  m_Layer: 0
+  m_Name: Element (5)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &900640421
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 900640420}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d2c8779b1bdf86c4dbcbe18f17e44e53, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _persistentId: -1764417259
+  graphic: {fileID: 900640422}
+  feature: {fileID: 1307638097}
+  texture: {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
+--- !u!114 &900640422
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 900640420}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8fb726b2ea51dd94d8601fa443872ec2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _anchor: {fileID: 0}
+  _featureData:
+  - {fileID: 900640421}
+  _attachedGroup: {fileID: 1307638099}
+  _preferredRendererType:
+    _fullName: Leap.Unity.GraphicalRenderer.LeapBakedRenderer
+  vertexColor: {r: 1, g: 0, b: 0, a: 1}
+  _mesh: {fileID: 4300000, guid: 14e47e6e841b85146813b9d552dc3d37, type: 3}
+  _remappableChannels: -1
+--- !u!114 &900640423
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 900640420}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1b7dca36e8e5c88459b2626007befebc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  parent: {fileID: 1238297699}
+  space: {fileID: 1307638100}
+--- !u!4 &900640424
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 900640420}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -3, y: -2, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1238297700}
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &905548334
 GameObject:
@@ -1234,75 +1368,6 @@ Transform:
   m_Father: {fileID: 658088855}
   m_RootOrder: 24
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &1133138201
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 1133138204}
-  - component: {fileID: 1133138203}
-  - component: {fileID: 1133138202}
-  m_Layer: 0
-  m_Name: Graphic Renderer
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!23 &1133138202
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1133138201}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_Materials:
-  - {fileID: 457937449}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &1133138203
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1133138201}
-  m_Mesh: {fileID: 43039757939608306, guid: 20061cc287d9a4b47b9ed5b22a197028, type: 2}
---- !u!4 &1133138204
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1133138201}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1535910907}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1158511273
 GameObject:
   m_ObjectHideFlags: 0
@@ -1330,6 +1395,159 @@ Transform:
   m_Children: []
   m_Father: {fileID: 658088855}
   m_RootOrder: 23
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1166533748
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1166533749}
+  - component: {fileID: 1166533751}
+  - component: {fileID: 1166533750}
+  - component: {fileID: 1166533752}
+  m_Layer: 0
+  m_Name: Element (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1166533749
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1166533748}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 3, y: -2, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1238297700}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1166533750
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1166533748}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1b7dca36e8e5c88459b2626007befebc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  parent: {fileID: 1238297699}
+  space: {fileID: 1307638100}
+--- !u!114 &1166533751
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1166533748}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8fb726b2ea51dd94d8601fa443872ec2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _anchor: {fileID: 0}
+  _featureData:
+  - {fileID: 1166533752}
+  _attachedGroup: {fileID: 1307638099}
+  _preferredRendererType:
+    _fullName: Leap.Unity.GraphicalRenderer.LeapBakedRenderer
+  vertexColor: {r: 1, g: 0, b: 0, a: 1}
+  _mesh: {fileID: 4300000, guid: 14e47e6e841b85146813b9d552dc3d37, type: 3}
+  _remappableChannels: -1
+--- !u!114 &1166533752
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1166533748}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d2c8779b1bdf86c4dbcbe18f17e44e53, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _persistentId: 813424555
+  graphic: {fileID: 1166533751}
+  feature: {fileID: 1307638097}
+  texture: {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
+--- !u!21 &1235518120
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: Procedural Graphic Material
+  m_Shader: {fileID: 4800000, guid: 692ffa38f03db184d8b27b0661d5bf0d, type: 3}
+  m_ShaderKeywords: GRAPHIC_RENDERER_MOVEMENT_TRANSLATION GRAPHIC_RENDERER_VERTEX_UV_0
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex2:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats: []
+    m_Colors: []
+--- !u!1 &1238297698
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1238297700}
+  - component: {fileID: 1238297699}
+  m_Layer: 0
+  m_Name: Anchor
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1238297699
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1238297698}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1b7dca36e8e5c88459b2626007befebc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  parent: {fileID: 1307638100}
+  space: {fileID: 1307638100}
+--- !u!4 &1238297700
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1238297698}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 2.3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2073345371}
+  - {fileID: 1166533749}
+  - {fileID: 94151150}
+  - {fileID: 1332538154}
+  - {fileID: 900640424}
+  m_Father: {fileID: 1307638105}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1259038824
 GameObject:
@@ -1415,6 +1633,444 @@ Transform:
   m_Father: {fileID: 658088855}
   m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1307638096
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1307638105}
+  - component: {fileID: 1307638104}
+  - component: {fileID: 1307638103}
+  - component: {fileID: 1307638102}
+  - component: {fileID: 1307638101}
+  - component: {fileID: 1307638100}
+  - component: {fileID: 1307638099}
+  - component: {fileID: 1307638098}
+  - component: {fileID: 1307638097}
+  m_Layer: 0
+  m_Name: GUI (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1307638097
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1307638096}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 36ae2dc675d304041af3c95461f228e2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _persistentId: -331774046
+  featureData:
+  - {fileID: 2073345374}
+  - {fileID: 1166533752}
+  - {fileID: 94151153}
+  - {fileID: 1332538157}
+  - {fileID: 900640421}
+  propertyName: _MainTex
+  channel: 1
+--- !u!114 &1307638098
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1307638096}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 00bb44340bd430d44a098a5e36f4de2d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _persistentId: -1596528111
+  renderer: {fileID: 1307638104}
+  group: {fileID: 1307638099}
+  _useUv0: 1
+  _useUv1: 0
+  _useUv2: 0
+  _useUv3: 0
+  _useColors: 0
+  _bakedTint: {r: 1, g: 1, b: 1, a: 1}
+  _useNormals: 0
+  _shader: {fileID: 4800000, guid: 692ffa38f03db184d8b27b0661d5bf0d, type: 3}
+  _atlas:
+    _border: 1
+    _padding: 0
+    _mipMap: 1
+    _filterMode: 1
+    _format: 5
+    _maxAtlasSize: 4096
+  _material: {fileID: 863663351}
+  _meshes: {fileID: 11400000, guid: 7281c07886f07be4197d14f51b29daf0, type: 2}
+  _packedTextures: {fileID: 11400000, guid: f29762def437c804798df4da6a054e36, type: 2}
+  _atlasUvs:
+    _channel0:
+      _keys:
+      - {fileID: 2800000, guid: 93f4f81256c947642a93d907d828ee98, type: 3}
+      - {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
+      _values:
+      - serializedVersion: 2
+        x: 0.015625
+        y: 0.2890625
+        width: 0.5
+        height: 0.25
+      - serializedVersion: 2
+        x: 0.015625
+        y: 0.0078125
+        width: 0.53125
+        height: 0.265625
+    _channel1:
+      _keys: []
+      _values: []
+    _channel2:
+      _keys: []
+      _values: []
+    _channel3:
+      _keys: []
+      _values: []
+    _nullRects:
+    - serializedVersion: 2
+      x: 0
+      y: 0
+      width: 0
+      height: 0
+    - serializedVersion: 2
+      x: 0
+      y: 0
+      width: 0
+      height: 0
+    - serializedVersion: 2
+      x: 0
+      y: 0
+      width: 0
+      height: 0
+    - serializedVersion: 2
+      x: 0
+      y: 0
+      width: 0
+      height: 0
+  _layer:
+    layerIndex: 0
+  _motionType: 1
+  _createMeshRenderers: 1
+  _renderers:
+  - obj: {fileID: 1401500834}
+    filter: {fileID: 1401500836}
+    renderer: {fileID: 1401500835}
+--- !u!114 &1307638099
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1307638096}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b32d8e323bfd9df4d82051c22f44d792, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _persistentId: 1152296847
+  _renderingMethod: {fileID: 1307638098}
+  _features:
+  - {fileID: 1307638097}
+  _renderer: {fileID: 1307638104}
+  _graphics:
+  - {fileID: 2073345373}
+  - {fileID: 1166533751}
+  - {fileID: 94151152}
+  - {fileID: 1332538156}
+  - {fileID: 900640422}
+  _supportInfo:
+  - support: 0
+    message: 
+  _addRemoveSupported: 0
+--- !u!114 &1307638100
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1307638096}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9261239b711172441b484496a58d001c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  parent: {fileID: 1307638100}
+  space: {fileID: 1307638100}
+  _radius: 3.28
+--- !u!114 &1307638101
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1307638096}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cdb13d8a1ce808e4787f1af6f2e7fa1b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _persistentId: 1425470384
+  renderer: {fileID: 0}
+  group: {fileID: 0}
+  _font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+  _dynamicPixelsPerUnit: 20
+  _useColor: 1
+  _globalTint: {r: 1, g: 1, b: 1, a: 1}
+  _shader: {fileID: 4800000, guid: 45c3e855355db4d409f06f94b19ed52f, type: 3}
+  _meshData: {fileID: 0}
+--- !u!114 &1307638102
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1307638096}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e4e826f61fa76194f87130a5030b287d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _persistentId: -464593129
+  renderer: {fileID: 0}
+  group: {fileID: 0}
+  _useUv0: 1
+  _useUv1: 0
+  _useUv2: 0
+  _useUv3: 0
+  _useColors: 0
+  _bakedTint: {r: 1, g: 1, b: 1, a: 1}
+  _useNormals: 0
+  _shader: {fileID: 4800000, guid: a770bdf1a8aeb824aa92fc5d9e2ffb55, type: 3}
+  _atlas:
+    _border: 1
+    _padding: 0
+    _mipMap: 1
+    _filterMode: 1
+    _format: 5
+    _maxAtlasSize: 4096
+  _material: {fileID: 1611082225}
+  _meshes: {fileID: 0}
+  _packedTextures: {fileID: 0}
+  _atlasUvs:
+    _channel0:
+      _keys: []
+      _values: []
+    _channel1:
+      _keys: []
+      _values: []
+    _channel2:
+      _keys: []
+      _values: []
+    _channel3:
+      _keys: []
+      _values: []
+    _nullRects:
+    - serializedVersion: 2
+      x: 0
+      y: 0
+      width: 0
+      height: 0
+    - serializedVersion: 2
+      x: 0
+      y: 0
+      width: 0
+      height: 0
+    - serializedVersion: 2
+      x: 0
+      y: 0
+      width: 0
+      height: 0
+    - serializedVersion: 2
+      x: 0
+      y: 0
+      width: 0
+      height: 0
+--- !u!114 &1307638103
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1307638096}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 00bb44340bd430d44a098a5e36f4de2d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _persistentId: 167835291
+  renderer: {fileID: 0}
+  group: {fileID: 0}
+  _useUv0: 1
+  _useUv1: 0
+  _useUv2: 0
+  _useUv3: 0
+  _useColors: 0
+  _bakedTint: {r: 1, g: 1, b: 1, a: 1}
+  _useNormals: 1
+  _shader: {fileID: 4800000, guid: 692ffa38f03db184d8b27b0661d5bf0d, type: 3}
+  _atlas:
+    _border: 1
+    _padding: 0
+    _mipMap: 1
+    _filterMode: 1
+    _format: 5
+    _maxAtlasSize: 4096
+  _material: {fileID: 1882322863}
+  _meshes: {fileID: 0}
+  _packedTextures: {fileID: 0}
+  _atlasUvs:
+    _channel0:
+      _keys: []
+      _values: []
+    _channel1:
+      _keys: []
+      _values: []
+    _channel2:
+      _keys: []
+      _values: []
+    _channel3:
+      _keys: []
+      _values: []
+    _nullRects:
+    - serializedVersion: 2
+      x: 0
+      y: 0
+      width: 0
+      height: 0
+    - serializedVersion: 2
+      x: 0
+      y: 0
+      width: 0
+      height: 0
+    - serializedVersion: 2
+      x: 0
+      y: 0
+      width: 0
+      height: 0
+    - serializedVersion: 2
+      x: 0
+      y: 0
+      width: 0
+      height: 0
+  _layer:
+    layerIndex: 0
+  _motionType: 1
+  _createMeshRenderers: 1
+  _renderers:
+  - obj: {fileID: 0}
+    filter: {fileID: 0}
+    renderer: {fileID: 0}
+--- !u!114 &1307638104
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1307638096}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: adb71699a7372344cb4e7a163c6c6922, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _selectedGroup: 0
+  _space: {fileID: 0}
+  _groups:
+  - {fileID: 1307638099}
+--- !u!4 &1307638105
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1307638096}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 2, z: 3.6}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1401500837}
+  - {fileID: 1238297700}
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1332538153
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1332538154}
+  - component: {fileID: 1332538156}
+  - component: {fileID: 1332538155}
+  - component: {fileID: 1332538157}
+  m_Layer: 0
+  m_Name: Element (4)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1332538154
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1332538153}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -1, y: -2, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1238297700}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1332538155
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1332538153}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1b7dca36e8e5c88459b2626007befebc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  parent: {fileID: 1238297699}
+  space: {fileID: 1307638100}
+--- !u!114 &1332538156
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1332538153}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8fb726b2ea51dd94d8601fa443872ec2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _anchor: {fileID: 0}
+  _featureData:
+  - {fileID: 1332538157}
+  _attachedGroup: {fileID: 1307638099}
+  _preferredRendererType:
+    _fullName: Leap.Unity.GraphicalRenderer.LeapBakedRenderer
+  vertexColor: {r: 0.6911765, g: 0.6911765, b: 0.6911765, a: 1}
+  _mesh: {fileID: 4300000, guid: 14e47e6e841b85146813b9d552dc3d37, type: 3}
+  _remappableChannels: -1
+--- !u!114 &1332538157
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1332538153}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d2c8779b1bdf86c4dbcbe18f17e44e53, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _persistentId: 1496237382
+  graphic: {fileID: 1332538156}
+  feature: {fileID: 1307638097}
+  texture: {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
 --- !u!1 &1365773555
 GameObject:
   m_ObjectHideFlags: 0
@@ -1425,7 +2081,6 @@ GameObject:
   - component: {fileID: 1365773558}
   - component: {fileID: 1365773557}
   - component: {fileID: 1365773559}
-  - component: {fileID: 1365773560}
   - component: {fileID: 1365773556}
   m_Layer: 0
   m_Name: Element (1)
@@ -1442,13 +2097,13 @@ MonoBehaviour:
   m_GameObject: {fileID: 1365773555}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b051eb69afb505b479d2ea649875e390, type: 3}
+  m_Script: {fileID: 11500000, guid: d2c8779b1bdf86c4dbcbe18f17e44e53, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _persistentId: 700270146
+  _persistentId: 813424555
   graphic: {fileID: 1365773557}
-  feature: {fileID: 1535910903}
-  sprite: {fileID: 21300000, guid: 7941f01ab879cfa4495b7e425293ddad, type: 3}
+  feature: {fileID: 1535910914}
+  texture: {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
 --- !u!114 &1365773557
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1495,17 +2150,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   parent: {fileID: 1645781541}
   space: {fileID: 1535910908}
---- !u!114 &1365773560
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1365773555}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c437e41a5ae81fd468510f087ba4a70a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &1366916390
 GameObject:
   m_ObjectHideFlags: 0
@@ -1516,7 +2160,6 @@ GameObject:
   - component: {fileID: 1366916391}
   - component: {fileID: 1366916395}
   - component: {fileID: 1366916393}
-  - component: {fileID: 1366916394}
   - component: {fileID: 1366916392}
   m_Layer: 0
   m_Name: Element (4)
@@ -1546,13 +2189,13 @@ MonoBehaviour:
   m_GameObject: {fileID: 1366916390}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b051eb69afb505b479d2ea649875e390, type: 3}
+  m_Script: {fileID: 11500000, guid: d2c8779b1bdf86c4dbcbe18f17e44e53, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _persistentId: 250649627
+  _persistentId: 1496237382
   graphic: {fileID: 1366916395}
-  feature: {fileID: 1535910903}
-  sprite: {fileID: 21300000, guid: 7941f01ab879cfa4495b7e425293ddad, type: 3}
+  feature: {fileID: 1535910914}
+  texture: {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
 --- !u!114 &1366916393
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1566,17 +2209,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   parent: {fileID: 1645781541}
   space: {fileID: 1535910908}
---- !u!114 &1366916394
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1366916390}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c437e41a5ae81fd468510f087ba4a70a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &1366916395
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1597,6 +2229,75 @@ MonoBehaviour:
   vertexColor: {r: 0.6911765, g: 0.6911765, b: 0.6911765, a: 1}
   _mesh: {fileID: 4300000, guid: 14e47e6e841b85146813b9d552dc3d37, type: 3}
   _remappableChannels: -1
+--- !u!1 &1401500834
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1401500837}
+  - component: {fileID: 1401500836}
+  - component: {fileID: 1401500835}
+  m_Layer: 0
+  m_Name: Graphic Renderer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!23 &1401500835
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1401500834}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 863663351}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1401500836
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1401500834}
+  m_Mesh: {fileID: 43073225500203408, guid: 7281c07886f07be4197d14f51b29daf0, type: 2}
+--- !u!4 &1401500837
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1401500834}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1307638105}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1520670167
 GameObject:
   m_ObjectHideFlags: 0
@@ -1607,7 +2308,6 @@ GameObject:
   - component: {fileID: 1520670173}
   - component: {fileID: 1520670169}
   - component: {fileID: 1520670172}
-  - component: {fileID: 1520670170}
   - component: {fileID: 1520670168}
   m_Layer: 0
   m_Name: Element (5)
@@ -1624,13 +2324,13 @@ MonoBehaviour:
   m_GameObject: {fileID: 1520670167}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b051eb69afb505b479d2ea649875e390, type: 3}
+  m_Script: {fileID: 11500000, guid: d2c8779b1bdf86c4dbcbe18f17e44e53, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _persistentId: -368488964
+  _persistentId: -1764417259
   graphic: {fileID: 1520670169}
-  feature: {fileID: 1535910903}
-  sprite: {fileID: 21300000, guid: 7941f01ab879cfa4495b7e425293ddad, type: 3}
+  feature: {fileID: 1535910914}
+  texture: {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
 --- !u!114 &1520670169
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1651,17 +2351,6 @@ MonoBehaviour:
   vertexColor: {r: 1, g: 0, b: 0, a: 1}
   _mesh: {fileID: 4300000, guid: 14e47e6e841b85146813b9d552dc3d37, type: 3}
   _remappableChannels: -1
---- !u!114 &1520670170
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1520670167}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: c437e41a5ae81fd468510f087ba4a70a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!114 &1520670172
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1703,7 +2392,7 @@ GameObject:
   - component: {fileID: 1535910908}
   - component: {fileID: 1535910909}
   - component: {fileID: 1535910905}
-  - component: {fileID: 1535910903}
+  - component: {fileID: 1535910914}
   m_Layer: 0
   m_Name: GUI
   m_TagString: Untagged
@@ -1711,26 +2400,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!114 &1535910903
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1535910902}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: eb8619b4d0e4d744183adf2e5fb82581, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _persistentId: -817993344
-  featureData:
-  - {fileID: 747764344}
-  - {fileID: 1365773556}
-  - {fileID: 465469647}
-  - {fileID: 1366916392}
-  - {fileID: 1520670168}
-  propertyName: _MainTex
-  channel: 1
 --- !u!114 &1535910904
 MonoBehaviour:
   m_ObjectHideFlags: 3
@@ -1834,19 +2503,25 @@ MonoBehaviour:
     _filterMode: 1
     _format: 5
     _maxAtlasSize: 4096
-  _material: {fileID: 457937449}
-  _meshes: {fileID: 11400000, guid: 20061cc287d9a4b47b9ed5b22a197028, type: 2}
-  _packedTextures: {fileID: 11400000, guid: c3cda0075b79b9149b8aa3e9e039d031, type: 2}
+  _material: {fileID: 1235518120}
+  _meshes: {fileID: 11400000, guid: 7281c07886f07be4197d14f51b29daf0, type: 2}
+  _packedTextures: {fileID: 11400000, guid: f29762def437c804798df4da6a054e36, type: 2}
   _atlasUvs:
     _channel0:
       _keys:
-      - {fileID: 21300000, guid: 7941f01ab879cfa4495b7e425293ddad, type: 3}
+      - {fileID: 2800000, guid: 93f4f81256c947642a93d907d828ee98, type: 3}
+      - {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
       _values:
       - serializedVersion: 2
-        x: 0
-        y: 0
-        width: 0
-        height: 0
+        x: 0.015625
+        y: 0.2890625
+        width: 0.5
+        height: 0.25
+      - serializedVersion: 2
+        x: 0.015625
+        y: 0.0078125
+        width: 0.53125
+        height: 0.265625
     _channel1:
       _keys: []
       _values: []
@@ -1882,9 +2557,9 @@ MonoBehaviour:
   _motionType: 1
   _createMeshRenderers: 1
   _renderers:
-  - obj: {fileID: 1133138201}
-    filter: {fileID: 1133138203}
-    renderer: {fileID: 1133138202}
+  - obj: {fileID: 1931788082}
+    filter: {fileID: 1931788084}
+    renderer: {fileID: 1931788083}
 --- !u!114 &1535910906
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1910,7 +2585,7 @@ Transform:
   m_LocalPosition: {x: 0, y: 2, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 1133138204}
+  - {fileID: 1931788085}
   - {fileID: 1645781542}
   m_Father: {fileID: 0}
   m_RootOrder: 3
@@ -1943,7 +2618,7 @@ MonoBehaviour:
   _persistentId: 1152296847
   _renderingMethod: {fileID: 1535910905}
   _features:
-  - {fileID: 1535910903}
+  - {fileID: 1535910914}
   _renderer: {fileID: 1535910906}
   _graphics:
   - {fileID: 747764345}
@@ -2041,6 +2716,26 @@ MonoBehaviour:
   _globalTint: {r: 1, g: 1, b: 1, a: 1}
   _shader: {fileID: 4800000, guid: 45c3e855355db4d409f06f94b19ed52f, type: 3}
   _meshData: {fileID: 0}
+--- !u!114 &1535910914
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1535910902}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 36ae2dc675d304041af3c95461f228e2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _persistentId: -331774046
+  featureData:
+  - {fileID: 747764344}
+  - {fileID: 1365773556}
+  - {fileID: 465469647}
+  - {fileID: 1366916392}
+  - {fileID: 1520670168}
+  propertyName: _MainTex
+  channel: 1
 --- !u!1 &1557105950
 GameObject:
   m_ObjectHideFlags: 0
@@ -2289,6 +2984,75 @@ Material:
     - _BumpScale: 1
     - _Smoothness: 1
     m_Colors: []
+--- !u!1 &1931788082
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1931788085}
+  - component: {fileID: 1931788084}
+  - component: {fileID: 1931788083}
+  m_Layer: 0
+  m_Name: Graphic Renderer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!23 &1931788083
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1931788082}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 1235518120}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1931788084
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1931788082}
+  m_Mesh: {fileID: 0}
+--- !u!4 &1931788085
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1931788082}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1535910907}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2020924587
 GameObject:
   m_ObjectHideFlags: 0
@@ -2345,6 +3109,85 @@ Transform:
   m_Father: {fileID: 658088855}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2073345370
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2073345371}
+  - component: {fileID: 2073345373}
+  - component: {fileID: 2073345372}
+  - component: {fileID: 2073345374}
+  m_Layer: 0
+  m_Name: Element
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2073345371
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2073345370}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1238297700}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2073345372
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2073345370}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1b7dca36e8e5c88459b2626007befebc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  parent: {fileID: 1238297699}
+  space: {fileID: 1307638100}
+--- !u!114 &2073345373
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2073345370}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8fb726b2ea51dd94d8601fa443872ec2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _anchor: {fileID: 0}
+  _featureData:
+  - {fileID: 2073345374}
+  _attachedGroup: {fileID: 1307638099}
+  _preferredRendererType:
+    _fullName: Leap.Unity.GraphicalRenderer.LeapBakedRenderer
+  vertexColor: {r: 1, g: 1, b: 1, a: 1}
+  _mesh: {fileID: 4300000, guid: 14e47e6e841b85146813b9d552dc3d37, type: 3}
+  _remappableChannels: -1
+--- !u!114 &2073345374
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2073345370}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d2c8779b1bdf86c4dbcbe18f17e44e53, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _persistentId: -1169280965
+  graphic: {fileID: 2073345373}
+  feature: {fileID: 1307638097}
+  texture: {fileID: 2800000, guid: 93f4f81256c947642a93d907d828ee98, type: 3}
 --- !u!1 &2139915609
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/LeapMotionModules/GraphicRenderer/Scenes/FeatureTest.unity
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scenes/FeatureTest.unity
@@ -13,7 +13,7 @@ OcclusionCullingSettings:
 --- !u!104 &2
 RenderSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 7
+  serializedVersion: 8
   m_Fog: 0
   m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   m_FogMode: 3
@@ -25,6 +25,7 @@ RenderSettings:
   m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
   m_AmbientIntensity: 1.73
   m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
   m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
   m_HaloStrength: 0.5
   m_FlareStrength: 1
@@ -41,7 +42,7 @@ RenderSettings:
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 7
+  serializedVersion: 9
   m_GIWorkflowMode: 1
   m_GISettings:
     serializedVersion: 2
@@ -53,7 +54,7 @@ LightmapSettings:
     m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 0
   m_LightmapEditorSettings:
-    serializedVersion: 4
+    serializedVersion: 8
     m_Resolution: 2
     m_BakeResolution: 10
     m_TextureWidth: 1024
@@ -66,13 +67,27 @@ LightmapSettings:
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 1
     m_TextureCompression: 1
-    m_DirectLightInLightProbes: 1
     m_FinalGather: 0
     m_FinalGatherFiltering: 1
     m_FinalGatherRayCount: 256
     m_ReflectionCompression: 2
+    m_MixedBakeMode: 1
+    m_BakeBackend: 0
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 500
+    m_PVRBounces: 2
+    m_PVRFiltering: 0
+    m_PVRFilteringMode: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousColorSigma: 1
+    m_PVRFilteringAtrousNormalSigma: 1
+    m_PVRFilteringAtrousPositionSigma: 1
   m_LightingDataAsset: {fileID: 0}
-  m_RuntimeCPUUsage: 25
+  m_ShadowMaskMode: 2
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
@@ -89,9 +104,151 @@ NavMeshSettings:
     minRegionArea: 2
     manualCellSize: 0
     cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
     accuratePlacement: 0
   m_NavMeshData: {fileID: 0}
---- !u!21 &98819469
+--- !u!1 &9387232
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 9387233}
+  m_Layer: 0
+  m_Name: GameObject (8)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &9387233
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 9387232}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 658088855}
+  m_RootOrder: 8
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &10473301
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 10473302}
+  m_Layer: 0
+  m_Name: GameObject (34)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &10473302
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 10473301}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 658088855}
+  m_RootOrder: 34
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &18286746
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 18286747}
+  m_Layer: 0
+  m_Name: GameObject (30)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &18286747
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 18286746}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 658088855}
+  m_RootOrder: 30
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &129763931
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 129763932}
+  m_Layer: 0
+  m_Name: GameObject (10)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &129763932
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 129763931}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 658088855}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &160979691
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 160979692}
+  m_Layer: 0
+  m_Name: GameObject (12)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &160979692
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 160979691}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 658088855}
+  m_RootOrder: 12
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!21 &180887270
 Material:
   serializedVersion: 6
   m_ObjectHideFlags: 0
@@ -102,20 +259,188 @@ Material:
   m_ShaderKeywords: GRAPHIC_RENDERER_BLEND_SHAPES GRAPHIC_RENDERER_TINTING GRAPHIC_RENDERER_VERTEX_COLORS
     GRAPHIC_RENDERER_VERTEX_UV_0
   m_LightmapFlags: 5
+  m_EnableInstancingVariants: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}
+  disabledShaderPasses: []
   m_SavedProperties:
-    serializedVersion: 2
+    serializedVersion: 3
     m_TexEnvs:
-    - first:
-        name: _MainTex
-      second:
-        m_Texture: {fileID: 28229601329985056, guid: 2124872ed9cc0924ea3213851caaf209,
+    - _MainTex:
+        m_Texture: {fileID: 28296732769382202, guid: d095a4522ffbc5045a9b308d707c845f,
           type: 2}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     m_Floats: []
     m_Colors: []
+--- !u!1 &196503149
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 196503150}
+  m_Layer: 0
+  m_Name: GameObject (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &196503150
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 196503149}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 658088855}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &216995457
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 216995458}
+  m_Layer: 0
+  m_Name: GameObject (18)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &216995458
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 216995457}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 658088855}
+  m_RootOrder: 18
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &220280774
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 220280775}
+  m_Layer: 0
+  m_Name: GameObject (27)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &220280775
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 220280774}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 658088855}
+  m_RootOrder: 27
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &333114170
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 333114171}
+  m_Layer: 0
+  m_Name: GameObject (19)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &333114171
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 333114170}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 658088855}
+  m_RootOrder: 19
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &379375105
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 379375106}
+  m_Layer: 0
+  m_Name: GameObject (28)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &379375106
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 379375105}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 658088855}
+  m_RootOrder: 28
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &451292044
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 451292045}
+  m_Layer: 0
+  m_Name: GameObject (11)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &451292045
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 451292044}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 658088855}
+  m_RootOrder: 11
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &465469645
 GameObject:
   m_ObjectHideFlags: 0
@@ -234,6 +559,34 @@ MonoBehaviour:
   graphic: {fileID: 465469650}
   feature: {fileID: 1535910914}
   _color: {r: 1, g: 1, b: 1, a: 1}
+--- !u!1 &635359835
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 635359836}
+  m_Layer: 0
+  m_Name: GameObject (4)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &635359836
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 635359835}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 658088855}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &658088851
 GameObject:
   m_ObjectHideFlags: 0
@@ -282,6 +635,7 @@ MeshRenderer:
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
   m_SortingLayerID: 0
+  m_SortingLayer: 0
   m_SortingOrder: 0
 --- !u!64 &658088853
 MeshCollider:
@@ -313,41 +667,157 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 2024734288}
+  - {fileID: 724675961}
+  - {fileID: 196503150}
+  - {fileID: 2020924588}
+  - {fileID: 635359836}
+  - {fileID: 1557105951}
+  - {fileID: 1276638429}
+  - {fileID: 723438903}
+  - {fileID: 9387233}
+  - {fileID: 1259038825}
+  - {fileID: 129763932}
+  - {fileID: 451292045}
+  - {fileID: 160979692}
+  - {fileID: 1677062622}
+  - {fileID: 1575491055}
+  - {fileID: 700929354}
+  - {fileID: 1828774121}
+  - {fileID: 818011203}
+  - {fileID: 216995458}
+  - {fileID: 333114171}
+  - {fileID: 1034683925}
+  - {fileID: 1260315016}
+  - {fileID: 751201670}
+  - {fileID: 1158511274}
+  - {fileID: 1092020811}
+  - {fileID: 831178429}
+  - {fileID: 885763361}
+  - {fileID: 220280775}
+  - {fileID: 379375106}
+  - {fileID: 1863141677}
+  - {fileID: 18286747}
+  - {fileID: 2139915610}
+  - {fileID: 905548335}
+  - {fileID: 664354210}
+  - {fileID: 10473302}
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!21 &680288399
-Material:
-  serializedVersion: 6
+--- !u!1 &664354209
+GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_Name: Procedural Graphic Material
-  m_Shader: {fileID: 4800000, guid: 692ffa38f03db184d8b27b0661d5bf0d, type: 3}
-  m_ShaderKeywords: GRAPHIC_RENDERER_BLEND_SHAPES GRAPHIC_RENDERER_MOVEMENT_TRANSLATION
-    GRAPHIC_RENDERER_TINTING GRAPHIC_RENDERER_VERTEX_COLORS GRAPHIC_RENDERER_VERTEX_UV_0
-  m_LightmapFlags: 5
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  m_SavedProperties:
-    serializedVersion: 2
-    m_TexEnvs:
-    - first:
-        name: _MainTex
-      second:
-        m_Texture: {fileID: 28315382410800256, guid: 0527f845d18159e47a2b324b49fae574,
-          type: 2}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - first:
-        name: _MainTex2
-      second:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Floats: []
-    m_Colors: []
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 664354210}
+  m_Layer: 0
+  m_Name: GameObject (33)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &664354210
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 664354209}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 658088855}
+  m_RootOrder: 33
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &700929353
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 700929354}
+  m_Layer: 0
+  m_Name: GameObject (15)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &700929354
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 700929353}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 658088855}
+  m_RootOrder: 15
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &723438902
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 723438903}
+  m_Layer: 0
+  m_Name: GameObject (7)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &723438903
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 723438902}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 658088855}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &724675960
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 724675961}
+  m_Layer: 0
+  m_Name: GameObject (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &724675961
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 724675960}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 658088855}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &747764343
 GameObject:
   m_ObjectHideFlags: 0
@@ -381,7 +851,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _persistentId: 1469803470
   graphic: {fileID: 747764345}
-  feature: {fileID: 1535910909}
+  feature: {fileID: 1535910915}
   texture: {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
 --- !u!114 &747764345
 MonoBehaviour:
@@ -399,9 +869,9 @@ MonoBehaviour:
   - {fileID: 747764344}
   - {fileID: 747764349}
   - {fileID: 747764348}
-  _attachedGroup: {fileID: 1535910905}
+  _attachedGroup: {fileID: 1535910917}
   _preferredRendererType:
-    _fullName: Leap.Unity.GraphicalRenderer.LeapBakedRenderer
+    _fullName: Leap.Unity.GraphicalRenderer.LeapDynamicRenderer
   vertexColor: {r: 1, g: 1, b: 1, a: 1}
   _mesh: {fileID: 4300000, guid: 14e47e6e841b85146813b9d552dc3d37, type: 3}
   _remappableChannels: -1
@@ -444,7 +914,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _persistentId: 1925012024
   graphic: {fileID: 747764345}
-  feature: {fileID: 1535910918}
+  feature: {fileID: 1535910911}
   _amount: 0
   _type: 1
   _scale: 1.1
@@ -464,8 +934,148 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _persistentId: 837394651
   graphic: {fileID: 747764345}
-  feature: {fileID: 1535910913}
+  feature: {fileID: 1535910914}
   _color: {r: 1, g: 1, b: 1, a: 1}
+--- !u!1 &751201669
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 751201670}
+  m_Layer: 0
+  m_Name: GameObject (22)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &751201670
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 751201669}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 658088855}
+  m_RootOrder: 22
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &818011202
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 818011203}
+  m_Layer: 0
+  m_Name: GameObject (17)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &818011203
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 818011202}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 658088855}
+  m_RootOrder: 17
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &831178428
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 831178429}
+  m_Layer: 0
+  m_Name: GameObject (25)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &831178429
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 831178428}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 658088855}
+  m_RootOrder: 25
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &885763360
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 885763361}
+  m_Layer: 0
+  m_Name: GameObject (26)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &885763361
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 885763360}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 658088855}
+  m_RootOrder: 26
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &905548334
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 905548335}
+  m_Layer: 0
+  m_Name: GameObject (32)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &905548335
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 905548334}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 658088855}
+  m_RootOrder: 32
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &977328817
 GameObject:
   m_ObjectHideFlags: 0
@@ -536,6 +1146,8 @@ Camera:
   m_TargetDisplay: 0
   m_TargetEye: 3
   m_HDR: 0
+  m_AllowMSAA: 1
+  m_ForceIntoRT: 0
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
@@ -552,6 +1164,34 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1034683924
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1034683925}
+  m_Layer: 0
+  m_Name: GameObject (20)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1034683925
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1034683924}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 658088855}
+  m_RootOrder: 20
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1076425313
 GameObject:
@@ -576,7 +1216,7 @@ Light:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1076425313}
   m_Enabled: 1
-  serializedVersion: 7
+  serializedVersion: 8
   m_Type: 1
   m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
   m_Intensity: 1
@@ -601,6 +1241,8 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
   m_ShadowRadius: 0
   m_ShadowAngle: 0
 --- !u!4 &1076425315
@@ -616,6 +1258,146 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 35.260002, y: -1435.839, z: 492.552}
+--- !u!1 &1092020810
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1092020811}
+  m_Layer: 0
+  m_Name: GameObject (24)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1092020811
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1092020810}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 658088855}
+  m_RootOrder: 24
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1158511273
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1158511274}
+  m_Layer: 0
+  m_Name: GameObject (23)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1158511274
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1158511273}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 658088855}
+  m_RootOrder: 23
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1259038824
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1259038825}
+  m_Layer: 0
+  m_Name: GameObject (9)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1259038825
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1259038824}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 658088855}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1260315015
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1260315016}
+  m_Layer: 0
+  m_Name: GameObject (21)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1260315016
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1260315015}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 658088855}
+  m_RootOrder: 21
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1276638428
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1276638429}
+  m_Layer: 0
+  m_Name: GameObject (6)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1276638429
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1276638428}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 658088855}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1365773555
 GameObject:
   m_ObjectHideFlags: 0
@@ -982,12 +1764,7 @@ GameObject:
   - component: {fileID: 1535910904}
   - component: {fileID: 1535910910}
   - component: {fileID: 1535910912}
-  - component: {fileID: 1535910905}
-  - component: {fileID: 1535910903}
-  - component: {fileID: 1535910909}
   - component: {fileID: 1535910908}
-  - component: {fileID: 1535910913}
-  - component: {fileID: 1535910918}
   - component: {fileID: 1535910917}
   - component: {fileID: 1535910916}
   - component: {fileID: 1535910915}
@@ -1000,51 +1777,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!114 &1535910903
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1535910902}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 00bb44340bd430d44a098a5e36f4de2d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _persistentId: -730016745
-  renderer: {fileID: 1535910906}
-  group: {fileID: 1535910905}
-  _useUv0: 1
-  _useUv1: 0
-  _useUv2: 0
-  _useUv3: 0
-  _useColors: 1
-  _bakedTint: {r: 1, g: 1, b: 1, a: 1}
-  _useNormals: 0
-  _shader: {fileID: 4800000, guid: 692ffa38f03db184d8b27b0661d5bf0d, type: 3}
-  _atlas:
-    _border: 1
-    _padding: 0
-    _mipMap: 1
-    _filterMode: 1
-    _format: 5
-    _maxAtlasSize: 4096
-  _material: {fileID: 680288399}
-  _meshes: {fileID: 11400000, guid: a9b2a990e2cecd84588a98467576b536, type: 2}
-  _packedTextures: {fileID: 11400000, guid: 0527f845d18159e47a2b324b49fae574, type: 2}
-  _channelMapping:
-    _data:
-    - serializedVersion: 2
-      x: 0.015625
-      y: 0.015625
-      width: 0.53125
-      height: 0.53125
-    _lengths: 01000000ffffffffffffffffffffffff
-  _layer:
-    layerIndex: 0
-  _motionType: 1
-  _createMeshRenderers: 0
-  _renderers: []
 --- !u!114 &1535910904
 MonoBehaviour:
   m_ObjectHideFlags: 3
@@ -1113,34 +1845,6 @@ MonoBehaviour:
   - obj: {fileID: 0}
     filter: {fileID: 0}
     renderer: {fileID: 0}
---- !u!114 &1535910905
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1535910902}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b32d8e323bfd9df4d82051c22f44d792, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _persistentId: 601134982
-  _renderingMethod: {fileID: 1535910903}
-  _features:
-  - {fileID: 1535910909}
-  - {fileID: 1535910913}
-  - {fileID: 1535910918}
-  _renderer: {fileID: 1535910906}
-  _graphics:
-  - {fileID: 747764345}
-  _supportInfo:
-  - support: 0
-    message: 
-  - support: 0
-    message: 
-  - support: 0
-    message: 
-  _addRemoveSupported: 0
 --- !u!114 &1535910906
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1152,10 +1856,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: adb71699a7372344cb4e7a163c6c6922, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _selectedGroup: 1
+  _selectedGroup: 0
   _space: {fileID: 0}
   _groups:
-  - {fileID: 1535910905}
   - {fileID: 1535910917}
 --- !u!4 &1535910907
 Transform:
@@ -1185,22 +1888,6 @@ MonoBehaviour:
   parent: {fileID: 1535910908}
   space: {fileID: 1535910908}
   _radius: 3.28
---- !u!114 &1535910909
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1535910902}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 36ae2dc675d304041af3c95461f228e2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _persistentId: 1649510182
-  featureData:
-  - {fileID: 747764344}
-  propertyName: _MainTex
-  channel: 1
 --- !u!114 &1535910910
 MonoBehaviour:
   m_ObjectHideFlags: 3
@@ -1253,6 +1940,7 @@ MonoBehaviour:
   - {fileID: 1365773560}
   - {fileID: 1366916394}
   - {fileID: 1520670170}
+  - {fileID: 747764348}
   _space: 0
 --- !u!114 &1535910912
 MonoBehaviour:
@@ -1274,20 +1962,6 @@ MonoBehaviour:
   _globalTint: {r: 1, g: 1, b: 1, a: 1}
   _shader: {fileID: 4800000, guid: 45c3e855355db4d409f06f94b19ed52f, type: 3}
   _meshData: {fileID: 0}
---- !u!114 &1535910913
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1535910902}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f6ba66cc9da35149bbfcd9cac71cc62, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _persistentId: 206817518
-  featureData:
-  - {fileID: 747764349}
 --- !u!114 &1535910914
 MonoBehaviour:
   m_ObjectHideFlags: 3
@@ -1305,6 +1979,7 @@ MonoBehaviour:
   - {fileID: 1365773561}
   - {fileID: 1366916396}
   - {fileID: 1520670171}
+  - {fileID: 747764349}
 --- !u!114 &1535910915
 MonoBehaviour:
   m_ObjectHideFlags: 3
@@ -1322,6 +1997,7 @@ MonoBehaviour:
   - {fileID: 1365773556}
   - {fileID: 1366916392}
   - {fileID: 1520670168}
+  - {fileID: 747764344}
   propertyName: _MainTex
   channel: 1
 --- !u!114 &1535910916
@@ -1353,32 +2029,37 @@ MonoBehaviour:
     _filterMode: 1
     _format: 5
     _maxAtlasSize: 4096
-  _material: {fileID: 98819469}
-  _meshes: {fileID: 11400000, guid: f7743877bdc96b94cb22d1347bf36acd, type: 2}
-  _packedTextures: {fileID: 11400000, guid: 2124872ed9cc0924ea3213851caaf209, type: 2}
+  _material: {fileID: 180887270}
+  _meshes: {fileID: 11400000, guid: 5be69de268bd2a84fa6ec788890226d4, type: 2}
+  _packedTextures: {fileID: 11400000, guid: d095a4522ffbc5045a9b308d707c845f, type: 2}
   _channelMapping:
     _data:
     - serializedVersion: 2
       x: 0.015625
-      y: 0.015625
+      y: 0.2890625
       width: 0.5
-      height: 0.5
+      height: 0.25
     - serializedVersion: 2
       x: 0.015625
-      y: 0.015625
+      y: 0.2890625
       width: 0.5
-      height: 0.5
+      height: 0.25
     - serializedVersion: 2
       x: 0.015625
-      y: 0.015625
+      y: 0.2890625
       width: 0.5
-      height: 0.5
+      height: 0.25
     - serializedVersion: 2
       x: 0.015625
-      y: 0.015625
+      y: 0.2890625
       width: 0.5
-      height: 0.5
-    _lengths: 04000000ffffffffffffffffffffffff
+      height: 0.25
+    - serializedVersion: 2
+      x: 0.015625
+      y: 0.0078125
+      width: 0.53125
+      height: 0.265625
+    _lengths: 05000000ffffffffffffffffffffffff
 --- !u!114 &1535910917
 MonoBehaviour:
   m_ObjectHideFlags: 3
@@ -1402,6 +2083,7 @@ MonoBehaviour:
   - {fileID: 1365773557}
   - {fileID: 1366916395}
   - {fileID: 1520670169}
+  - {fileID: 747764345}
   _supportInfo:
   - support: 0
     message: 
@@ -1409,22 +2091,63 @@ MonoBehaviour:
     message: 
   - support: 0
     message: 
-  _addRemoveSupported: 1
---- !u!114 &1535910918
-MonoBehaviour:
-  m_ObjectHideFlags: 3
+  _addRemoveSupported: 0
+--- !u!1 &1557105950
+GameObject:
+  m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1535910902}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9ff0cf669bd50964a915784dbb766181, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _persistentId: 1284260834
-  featureData:
-  - {fileID: 747764348}
-  _space: 0
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1557105951}
+  m_Layer: 0
+  m_Name: GameObject (5)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1557105951
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1557105950}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 658088855}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1575491054
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1575491055}
+  m_Layer: 0
+  m_Name: GameObject (14)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1575491055
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1575491054}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 658088855}
+  m_RootOrder: 14
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!21 &1611082225
 Material:
   serializedVersion: 6
@@ -1435,14 +2158,14 @@ Material:
   m_Shader: {fileID: 4800000, guid: a770bdf1a8aeb824aa92fc5d9e2ffb55, type: 3}
   m_ShaderKeywords: LEAP_GUI_SPHERICAL LEAP_GUI_VERTEX_UV_0
   m_LightmapFlags: 5
+  m_EnableInstancingVariants: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}
+  disabledShaderPasses: []
   m_SavedProperties:
-    serializedVersion: 2
+    serializedVersion: 3
     m_TexEnvs:
-    - first:
-        name: _MainTex
-      second:
+    - _MainTex:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
@@ -1495,6 +2218,90 @@ Transform:
   m_Father: {fileID: 1535910907}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1677062621
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1677062622}
+  m_Layer: 0
+  m_Name: GameObject (13)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1677062622
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1677062621}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 658088855}
+  m_RootOrder: 13
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1828774120
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1828774121}
+  m_Layer: 0
+  m_Name: GameObject (16)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1828774121
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1828774120}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 658088855}
+  m_RootOrder: 16
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1863141676
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1863141677}
+  m_Layer: 0
+  m_Name: GameObject (29)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1863141677
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1863141676}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 658088855}
+  m_RootOrder: 29
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!21 &1882322863
 Material:
   serializedVersion: 6
@@ -1506,40 +2313,114 @@ Material:
   m_ShaderKeywords: LEAP_GUI_MOVEMENT_TRANSLATION LEAP_GUI_SPHERICAL LEAP_GUI_VERTEX_COLORS
     LEAP_GUI_VERTEX_NORMALS LEAP_GUI_VERTEX_UV_0
   m_LightmapFlags: 5
+  m_EnableInstancingVariants: 0
   m_CustomRenderQueue: -1
   stringTagMap: {}
+  disabledShaderPasses: []
   m_SavedProperties:
-    serializedVersion: 2
+    serializedVersion: 3
     m_TexEnvs:
-    - first:
-        name: _BumpMap
-      second:
+    - _BumpMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
-    - first:
-        name: _MainTex
-      second:
+    - _MainTex:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
-    - first:
-        name: _MainTex2
-      second:
+    - _MainTex2:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
-    - first:
-        name: _MetallicGlossMap
-      second:
+    - _MetallicGlossMap:
         m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     m_Floats:
-    - first:
-        name: _BumpScale
-      second: 1
-    - first:
-        name: _Smoothness
-      second: 1
+    - _BumpScale: 1
+    - _Smoothness: 1
     m_Colors: []
+--- !u!1 &2020924587
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2020924588}
+  m_Layer: 0
+  m_Name: GameObject (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2020924588
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2020924587}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 658088855}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2024734287
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2024734288}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2024734288
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2024734287}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 658088855}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2139915609
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2139915610}
+  m_Layer: 0
+  m_Name: GameObject (31)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2139915610
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2139915609}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 658088855}
+  m_RootOrder: 31
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/LeapMotionModules/GraphicRenderer/Scenes/FeatureTest.unity
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scenes/FeatureTest.unity
@@ -459,8 +459,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   graphic: {fileID: 465469650}
-  feature: {fileID: 1535910914}
-  texture: {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
+  feature: {fileID: 1535910903}
+  texture: {fileID: 2800000, guid: 93f4f81256c947642a93d907d828ee98, type: 3}
 --- !u!114 &465469648
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -490,7 +490,7 @@ MonoBehaviour:
   - {fileID: 465469647}
   _attachedGroup: {fileID: 1535910909}
   _preferredRendererType:
-    _fullName: Leap.Unity.GraphicalRenderer.LeapBakedRenderer
+    _fullName: Leap.Unity.GraphicalRenderer.LeapDynamicRenderer
   vertexColor: {r: 0.6911765, g: 0.6911765, b: 0.6911765, a: 1}
   _mesh: {fileID: 4300000, guid: 14e47e6e841b85146813b9d552dc3d37, type: 3}
   _remappableChannels: -1
@@ -783,8 +783,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   graphic: {fileID: 747764345}
-  feature: {fileID: 1535910914}
-  texture: {fileID: 2800000, guid: 93f4f81256c947642a93d907d828ee98, type: 3}
+  feature: {fileID: 1535910903}
+  texture: {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
 --- !u!114 &747764345
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -801,7 +801,7 @@ MonoBehaviour:
   - {fileID: 747764344}
   _attachedGroup: {fileID: 1535910909}
   _preferredRendererType:
-    _fullName: Leap.Unity.GraphicalRenderer.LeapBakedRenderer
+    _fullName: Leap.Unity.GraphicalRenderer.LeapDynamicRenderer
   vertexColor: {r: 1, g: 1, b: 1, a: 1}
   _mesh: {fileID: 4300000, guid: 14e47e6e841b85146813b9d552dc3d37, type: 3}
   _remappableChannels: -1
@@ -1323,8 +1323,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   graphic: {fileID: 1365773557}
-  feature: {fileID: 1535910914}
-  texture: {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
+  feature: {fileID: 1535910903}
+  texture: {fileID: 2800000, guid: 93f4f81256c947642a93d907d828ee98, type: 3}
 --- !u!114 &1365773557
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1341,7 +1341,7 @@ MonoBehaviour:
   - {fileID: 1365773556}
   _attachedGroup: {fileID: 1535910909}
   _preferredRendererType:
-    _fullName: Leap.Unity.GraphicalRenderer.LeapBakedRenderer
+    _fullName: Leap.Unity.GraphicalRenderer.LeapDynamicRenderer
   vertexColor: {r: 1, g: 0, b: 0, a: 1}
   _mesh: {fileID: 4300000, guid: 14e47e6e841b85146813b9d552dc3d37, type: 3}
   _remappableChannels: -1
@@ -1414,8 +1414,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   graphic: {fileID: 1366916395}
-  feature: {fileID: 1535910914}
-  texture: {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
+  feature: {fileID: 1535910903}
+  texture: {fileID: 2800000, guid: 93f4f81256c947642a93d907d828ee98, type: 3}
 --- !u!114 &1366916393
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1445,7 +1445,7 @@ MonoBehaviour:
   - {fileID: 1366916392}
   _attachedGroup: {fileID: 1535910909}
   _preferredRendererType:
-    _fullName: Leap.Unity.GraphicalRenderer.LeapBakedRenderer
+    _fullName: Leap.Unity.GraphicalRenderer.LeapDynamicRenderer
   vertexColor: {r: 0.6911765, g: 0.6911765, b: 0.6911765, a: 1}
   _mesh: {fileID: 4300000, guid: 14e47e6e841b85146813b9d552dc3d37, type: 3}
   _remappableChannels: -1
@@ -1479,8 +1479,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   graphic: {fileID: 1520670169}
-  feature: {fileID: 1535910914}
-  texture: {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
+  feature: {fileID: 1535910903}
+  texture: {fileID: 2800000, guid: 93f4f81256c947642a93d907d828ee98, type: 3}
 --- !u!114 &1520670169
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1497,7 +1497,7 @@ MonoBehaviour:
   - {fileID: 1520670168}
   _attachedGroup: {fileID: 1535910909}
   _preferredRendererType:
-    _fullName: Leap.Unity.GraphicalRenderer.LeapBakedRenderer
+    _fullName: Leap.Unity.GraphicalRenderer.LeapDynamicRenderer
   vertexColor: {r: 1, g: 0, b: 0, a: 1}
   _mesh: {fileID: 4300000, guid: 14e47e6e841b85146813b9d552dc3d37, type: 3}
   _remappableChannels: -1
@@ -1542,7 +1542,7 @@ GameObject:
   - component: {fileID: 1535910908}
   - component: {fileID: 1535910909}
   - component: {fileID: 1535910905}
-  - component: {fileID: 1535910914}
+  - component: {fileID: 1535910903}
   m_Layer: 0
   m_Name: GUI
   m_TagString: Untagged
@@ -1550,6 +1550,25 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!114 &1535910903
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1535910902}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 36ae2dc675d304041af3c95461f228e2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  featureData:
+  - {fileID: 747764344}
+  - {fileID: 1365773556}
+  - {fileID: 465469647}
+  - {fileID: 1366916392}
+  - {fileID: 1520670168}
+  propertyName: _MainTex
+  channel: 1
 --- !u!114 &1535910904
 MonoBehaviour:
   m_ObjectHideFlags: 3
@@ -1631,7 +1650,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 1535910902}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 00bb44340bd430d44a098a5e36f4de2d, type: 3}
+  m_Script: {fileID: 11500000, guid: e4e826f61fa76194f87130a5030b287d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   renderer: {fileID: 1535910906}
@@ -1643,7 +1662,7 @@ MonoBehaviour:
   _useColors: 0
   _bakedTint: {r: 1, g: 1, b: 1, a: 1}
   _useNormals: 0
-  _shader: {fileID: 4800000, guid: 692ffa38f03db184d8b27b0661d5bf0d, type: 3}
+  _shader: {fileID: 4800000, guid: a770bdf1a8aeb824aa92fc5d9e2ffb55, type: 3}
   _atlas:
     _border: 1
     _padding: 0
@@ -1651,25 +1670,25 @@ MonoBehaviour:
     _filterMode: 1
     _format: 5
     _maxAtlasSize: 4096
-  _material: {fileID: 1915229403}
-  _meshes: {fileID: 11400000, guid: 5dc4374b8e12c6249a7c4d53656cad9a, type: 2}
-  _packedTextures: {fileID: 11400000, guid: ab7e18de92f1bd841909148c41debbe2, type: 2}
+  _material: {fileID: 1577307384}
+  _meshes: {fileID: 11400000, guid: e26f1e6052047cd408a2ba525cfaf213, type: 2}
+  _packedTextures: {fileID: 11400000, guid: 188bec59d47bf1240b8cb63124ab3212, type: 2}
   _atlasUvs:
     _channel0:
       _keys:
-      - {fileID: 2800000, guid: 93f4f81256c947642a93d907d828ee98, type: 3}
       - {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
+      - {fileID: 2800000, guid: 93f4f81256c947642a93d907d828ee98, type: 3}
       _values:
-      - serializedVersion: 2
-        x: 0.015625
-        y: 0.2890625
-        width: 0.5
-        height: 0.25
       - serializedVersion: 2
         x: 0.015625
         y: 0.0078125
         width: 0.53125
         height: 0.265625
+      - serializedVersion: 2
+        x: 0.015625
+        y: 0.2890625
+        width: 0.5
+        height: 0.25
     _channel1:
       _keys: []
       _values: []
@@ -1700,14 +1719,6 @@ MonoBehaviour:
       y: 0
       width: 0
       height: 0
-  _layer:
-    layerIndex: 0
-  _motionType: 1
-  _createMeshRenderers: 1
-  _renderers:
-  - obj: {fileID: 1931788082}
-    filter: {fileID: 1931788084}
-    renderer: {fileID: 1931788083}
 --- !u!114 &1535910906
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1733,7 +1744,6 @@ Transform:
   m_LocalPosition: {x: 0, y: 2, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 1931788085}
   - {fileID: 1645781542}
   m_Father: {fileID: 0}
   m_RootOrder: 3
@@ -1765,7 +1775,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _renderingMethod: {fileID: 1535910905}
   _features:
-  - {fileID: 1535910914}
+  - {fileID: 1535910903}
   _renderer: {fileID: 1535910906}
   _graphics:
   - {fileID: 747764345}
@@ -1776,7 +1786,7 @@ MonoBehaviour:
   _supportInfo:
   - support: 0
     message: 
-  _addRemoveSupported: 0
+  _addRemoveSupported: 1
 --- !u!114 &1535910910
 MonoBehaviour:
   m_ObjectHideFlags: 3
@@ -1861,25 +1871,6 @@ MonoBehaviour:
   _globalTint: {r: 1, g: 1, b: 1, a: 1}
   _shader: {fileID: 4800000, guid: 45c3e855355db4d409f06f94b19ed52f, type: 3}
   _meshData: {fileID: 0}
---- !u!114 &1535910914
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1535910902}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 36ae2dc675d304041af3c95461f228e2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  featureData:
-  - {fileID: 747764344}
-  - {fileID: 1365773556}
-  - {fileID: 465469647}
-  - {fileID: 1366916392}
-  - {fileID: 1520670168}
-  propertyName: _MainTex
-  channel: 1
 --- !u!1 &1557105950
 GameObject:
   m_ObjectHideFlags: 0
@@ -1936,6 +1927,30 @@ Transform:
   m_Father: {fileID: 658088855}
   m_RootOrder: 14
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!21 &1577307384
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: Procedural Graphic Material
+  m_Shader: {fileID: 4800000, guid: a770bdf1a8aeb824aa92fc5d9e2ffb55, type: 3}
+  m_ShaderKeywords: GRAPHIC_RENDERER_VERTEX_UV_0
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 28705846552342888, guid: 188bec59d47bf1240b8cb63124ab3212,
+          type: 2}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats: []
+    m_Colors: []
 --- !u!21 &1611082225
 Material:
   serializedVersion: 6
@@ -2004,7 +2019,7 @@ Transform:
   - {fileID: 1366916391}
   - {fileID: 1520670173}
   m_Father: {fileID: 1535910907}
-  m_RootOrder: 1
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1677062621
 GameObject:
@@ -2128,103 +2143,6 @@ Material:
     - _BumpScale: 1
     - _Smoothness: 1
     m_Colors: []
---- !u!21 &1915229403
-Material:
-  serializedVersion: 6
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_Name: Procedural Graphic Material
-  m_Shader: {fileID: 4800000, guid: 692ffa38f03db184d8b27b0661d5bf0d, type: 3}
-  m_ShaderKeywords: GRAPHIC_RENDERER_MOVEMENT_TRANSLATION GRAPHIC_RENDERER_VERTEX_UV_0
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 28041122674155060, guid: ab7e18de92f1bd841909148c41debbe2,
-          type: 2}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _MainTex2:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Floats: []
-    m_Colors: []
---- !u!1 &1931788082
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 1931788085}
-  - component: {fileID: 1931788084}
-  - component: {fileID: 1931788083}
-  m_Layer: 0
-  m_Name: Graphic Renderer
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!23 &1931788083
-MeshRenderer:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1931788082}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_Materials:
-  - {fileID: 1915229403}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
---- !u!33 &1931788084
-MeshFilter:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1931788082}
-  m_Mesh: {fileID: 43090069795517828, guid: 5dc4374b8e12c6249a7c4d53656cad9a, type: 2}
---- !u!4 &1931788085
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1931788082}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 1535910907}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2020924587
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/LeapMotionModules/GraphicRenderer/Scenes/FeatureTest.unity
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scenes/FeatureTest.unity
@@ -248,31 +248,6 @@ Transform:
   m_Father: {fileID: 658088855}
   m_RootOrder: 12
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!21 &180887270
-Material:
-  serializedVersion: 6
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_Name: Procedural Graphic Material
-  m_Shader: {fileID: 4800000, guid: a770bdf1a8aeb824aa92fc5d9e2ffb55, type: 3}
-  m_ShaderKeywords: GRAPHIC_RENDERER_BLEND_SHAPES GRAPHIC_RENDERER_TINTING GRAPHIC_RENDERER_VERTEX_COLORS
-    GRAPHIC_RENDERER_VERTEX_UV_0
-  m_LightmapFlags: 5
-  m_EnableInstancingVariants: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 28296732769382202, guid: d095a4522ffbc5045a9b308d707c845f,
-          type: 2}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Floats: []
-    m_Colors: []
 --- !u!1 &196503149
 GameObject:
   m_ObjectHideFlags: 0
@@ -441,6 +416,33 @@ Transform:
   m_Father: {fileID: 658088855}
   m_RootOrder: 11
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!21 &457937449
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: Procedural Graphic Material
+  m_Shader: {fileID: 4800000, guid: 692ffa38f03db184d8b27b0661d5bf0d, type: 3}
+  m_ShaderKeywords: GRAPHIC_RENDERER_MOVEMENT_TRANSLATION GRAPHIC_RENDERER_VERTEX_UV_0
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex2:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats: []
+    m_Colors: []
 --- !u!1 &465469645
 GameObject:
   m_ObjectHideFlags: 0
@@ -451,9 +453,8 @@ GameObject:
   - component: {fileID: 465469646}
   - component: {fileID: 465469650}
   - component: {fileID: 465469648}
-  - component: {fileID: 465469647}
   - component: {fileID: 465469649}
-  - component: {fileID: 465469651}
+  - component: {fileID: 465469647}
   m_Layer: 0
   m_Name: Element (3)
   m_TagString: Untagged
@@ -482,13 +483,13 @@ MonoBehaviour:
   m_GameObject: {fileID: 465469645}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d2c8779b1bdf86c4dbcbe18f17e44e53, type: 3}
+  m_Script: {fileID: 11500000, guid: b051eb69afb505b479d2ea649875e390, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _persistentId: -1268515355
+  _persistentId: 1062947571
   graphic: {fileID: 465469650}
-  feature: {fileID: 1535910915}
-  texture: {fileID: 2800000, guid: 93f4f81256c947642a93d907d828ee98, type: 3}
+  feature: {fileID: 1535910903}
+  sprite: {fileID: 21300000, guid: 7941f01ab879cfa4495b7e425293ddad, type: 3}
 --- !u!114 &465469648
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -504,24 +505,15 @@ MonoBehaviour:
   space: {fileID: 1535910908}
 --- !u!114 &465469649
 MonoBehaviour:
-  m_ObjectHideFlags: 3
+  m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 465469645}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 438437f012b34d043919ad395e42c066, type: 3}
+  m_Script: {fileID: 11500000, guid: c437e41a5ae81fd468510f087ba4a70a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _persistentId: 2042463595
-  graphic: {fileID: 465469650}
-  feature: {fileID: 1535910911}
-  _amount: 0
-  _type: 2
-  _scale: 1.1
-  _translation: {x: 0, y: 0, z: 0.1}
-  _rotation: {x: 0, y: 0, z: 5}
-  _mesh: {fileID: 0}
 --- !u!114 &465469650
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -536,29 +528,12 @@ MonoBehaviour:
   _anchor: {fileID: 0}
   _featureData:
   - {fileID: 465469647}
-  - {fileID: 465469651}
-  - {fileID: 465469649}
-  _attachedGroup: {fileID: 1535910917}
+  _attachedGroup: {fileID: 1535910909}
   _preferredRendererType:
-    _fullName: Leap.Unity.GraphicalRenderer.LeapDynamicRenderer
+    _fullName: Leap.Unity.GraphicalRenderer.LeapBakedRenderer
   vertexColor: {r: 0.6911765, g: 0.6911765, b: 0.6911765, a: 1}
   _mesh: {fileID: 4300000, guid: 14e47e6e841b85146813b9d552dc3d37, type: 3}
   _remappableChannels: -1
---- !u!114 &465469651
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 465469645}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b2088ff06a92b2d4590f9803e38f508e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _persistentId: 887211607
-  graphic: {fileID: 465469650}
-  feature: {fileID: 1535910914}
-  _color: {r: 1, g: 1, b: 1, a: 1}
 --- !u!1 &635359835
 GameObject:
   m_ObjectHideFlags: 0
@@ -828,9 +803,8 @@ GameObject:
   - component: {fileID: 747764346}
   - component: {fileID: 747764345}
   - component: {fileID: 747764347}
-  - component: {fileID: 747764344}
   - component: {fileID: 747764348}
-  - component: {fileID: 747764349}
+  - component: {fileID: 747764344}
   m_Layer: 0
   m_Name: Element
   m_TagString: Untagged
@@ -846,13 +820,13 @@ MonoBehaviour:
   m_GameObject: {fileID: 747764343}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d2c8779b1bdf86c4dbcbe18f17e44e53, type: 3}
+  m_Script: {fileID: 11500000, guid: b051eb69afb505b479d2ea649875e390, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _persistentId: 1469803470
+  _persistentId: -974240100
   graphic: {fileID: 747764345}
-  feature: {fileID: 1535910915}
-  texture: {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
+  feature: {fileID: 1535910903}
+  sprite: {fileID: 21300000, guid: 7941f01ab879cfa4495b7e425293ddad, type: 3}
 --- !u!114 &747764345
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -867,11 +841,9 @@ MonoBehaviour:
   _anchor: {fileID: 0}
   _featureData:
   - {fileID: 747764344}
-  - {fileID: 747764349}
-  - {fileID: 747764348}
-  _attachedGroup: {fileID: 1535910917}
+  _attachedGroup: {fileID: 1535910909}
   _preferredRendererType:
-    _fullName: Leap.Unity.GraphicalRenderer.LeapDynamicRenderer
+    _fullName: Leap.Unity.GraphicalRenderer.LeapBakedRenderer
   vertexColor: {r: 1, g: 1, b: 1, a: 1}
   _mesh: {fileID: 4300000, guid: 14e47e6e841b85146813b9d552dc3d37, type: 3}
   _remappableChannels: -1
@@ -903,39 +875,15 @@ MonoBehaviour:
   space: {fileID: 1535910908}
 --- !u!114 &747764348
 MonoBehaviour:
-  m_ObjectHideFlags: 3
+  m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 747764343}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 438437f012b34d043919ad395e42c066, type: 3}
+  m_Script: {fileID: 11500000, guid: c437e41a5ae81fd468510f087ba4a70a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _persistentId: 1925012024
-  graphic: {fileID: 747764345}
-  feature: {fileID: 1535910911}
-  _amount: 0
-  _type: 1
-  _scale: 1.1
-  _translation: {x: 0, y: 0, z: 0.1}
-  _rotation: {x: 0, y: 0, z: 90}
-  _mesh: {fileID: 0}
---- !u!114 &747764349
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 747764343}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b2088ff06a92b2d4590f9803e38f508e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _persistentId: 837394651
-  graphic: {fileID: 747764345}
-  feature: {fileID: 1535910914}
-  _color: {r: 1, g: 1, b: 1, a: 1}
 --- !u!1 &751201669
 GameObject:
   m_ObjectHideFlags: 0
@@ -1286,6 +1234,75 @@ Transform:
   m_Father: {fileID: 658088855}
   m_RootOrder: 24
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1133138201
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1133138204}
+  - component: {fileID: 1133138203}
+  - component: {fileID: 1133138202}
+  m_Layer: 0
+  m_Name: Graphic Renderer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!23 &1133138202
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1133138201}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_Materials:
+  - {fileID: 457937449}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+--- !u!33 &1133138203
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1133138201}
+  m_Mesh: {fileID: 43039757939608306, guid: 20061cc287d9a4b47b9ed5b22a197028, type: 2}
+--- !u!4 &1133138204
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1133138201}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1535910907}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1158511273
 GameObject:
   m_ObjectHideFlags: 0
@@ -1408,9 +1425,8 @@ GameObject:
   - component: {fileID: 1365773558}
   - component: {fileID: 1365773557}
   - component: {fileID: 1365773559}
-  - component: {fileID: 1365773556}
   - component: {fileID: 1365773560}
-  - component: {fileID: 1365773561}
+  - component: {fileID: 1365773556}
   m_Layer: 0
   m_Name: Element (1)
   m_TagString: Untagged
@@ -1426,13 +1442,13 @@ MonoBehaviour:
   m_GameObject: {fileID: 1365773555}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d2c8779b1bdf86c4dbcbe18f17e44e53, type: 3}
+  m_Script: {fileID: 11500000, guid: b051eb69afb505b479d2ea649875e390, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _persistentId: -1418167835
+  _persistentId: 700270146
   graphic: {fileID: 1365773557}
-  feature: {fileID: 1535910915}
-  texture: {fileID: 2800000, guid: 93f4f81256c947642a93d907d828ee98, type: 3}
+  feature: {fileID: 1535910903}
+  sprite: {fileID: 21300000, guid: 7941f01ab879cfa4495b7e425293ddad, type: 3}
 --- !u!114 &1365773557
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1447,11 +1463,9 @@ MonoBehaviour:
   _anchor: {fileID: 0}
   _featureData:
   - {fileID: 1365773556}
-  - {fileID: 1365773561}
-  - {fileID: 1365773560}
-  _attachedGroup: {fileID: 1535910917}
+  _attachedGroup: {fileID: 1535910909}
   _preferredRendererType:
-    _fullName: Leap.Unity.GraphicalRenderer.LeapDynamicRenderer
+    _fullName: Leap.Unity.GraphicalRenderer.LeapBakedRenderer
   vertexColor: {r: 1, g: 0, b: 0, a: 1}
   _mesh: {fileID: 4300000, guid: 14e47e6e841b85146813b9d552dc3d37, type: 3}
   _remappableChannels: -1
@@ -1483,39 +1497,15 @@ MonoBehaviour:
   space: {fileID: 1535910908}
 --- !u!114 &1365773560
 MonoBehaviour:
-  m_ObjectHideFlags: 3
+  m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1365773555}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 438437f012b34d043919ad395e42c066, type: 3}
+  m_Script: {fileID: 11500000, guid: c437e41a5ae81fd468510f087ba4a70a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _persistentId: -1122332203
-  graphic: {fileID: 1365773557}
-  feature: {fileID: 1535910911}
-  _amount: 0
-  _type: 2
-  _scale: 1.1
-  _translation: {x: 0, y: 0, z: 0.1}
-  _rotation: {x: 0, y: 0, z: 5}
-  _mesh: {fileID: 0}
---- !u!114 &1365773561
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1365773555}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b2088ff06a92b2d4590f9803e38f508e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _persistentId: 1229508320
-  graphic: {fileID: 1365773557}
-  feature: {fileID: 1535910914}
-  _color: {r: 1, g: 1, b: 1, a: 1}
 --- !u!1 &1366916390
 GameObject:
   m_ObjectHideFlags: 0
@@ -1526,9 +1516,8 @@ GameObject:
   - component: {fileID: 1366916391}
   - component: {fileID: 1366916395}
   - component: {fileID: 1366916393}
-  - component: {fileID: 1366916392}
   - component: {fileID: 1366916394}
-  - component: {fileID: 1366916396}
+  - component: {fileID: 1366916392}
   m_Layer: 0
   m_Name: Element (4)
   m_TagString: Untagged
@@ -1557,13 +1546,13 @@ MonoBehaviour:
   m_GameObject: {fileID: 1366916390}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d2c8779b1bdf86c4dbcbe18f17e44e53, type: 3}
+  m_Script: {fileID: 11500000, guid: b051eb69afb505b479d2ea649875e390, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _persistentId: 809056282
+  _persistentId: 250649627
   graphic: {fileID: 1366916395}
-  feature: {fileID: 1535910915}
-  texture: {fileID: 2800000, guid: 93f4f81256c947642a93d907d828ee98, type: 3}
+  feature: {fileID: 1535910903}
+  sprite: {fileID: 21300000, guid: 7941f01ab879cfa4495b7e425293ddad, type: 3}
 --- !u!114 &1366916393
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1579,24 +1568,15 @@ MonoBehaviour:
   space: {fileID: 1535910908}
 --- !u!114 &1366916394
 MonoBehaviour:
-  m_ObjectHideFlags: 3
+  m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1366916390}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 438437f012b34d043919ad395e42c066, type: 3}
+  m_Script: {fileID: 11500000, guid: c437e41a5ae81fd468510f087ba4a70a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _persistentId: -432041286
-  graphic: {fileID: 1366916395}
-  feature: {fileID: 1535910911}
-  _amount: 0
-  _type: 2
-  _scale: 1.1
-  _translation: {x: 0, y: 0, z: 0.1}
-  _rotation: {x: 0, y: 0, z: 5}
-  _mesh: {fileID: 0}
 --- !u!114 &1366916395
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1611,29 +1591,12 @@ MonoBehaviour:
   _anchor: {fileID: 0}
   _featureData:
   - {fileID: 1366916392}
-  - {fileID: 1366916396}
-  - {fileID: 1366916394}
-  _attachedGroup: {fileID: 1535910917}
+  _attachedGroup: {fileID: 1535910909}
   _preferredRendererType:
-    _fullName: Leap.Unity.GraphicalRenderer.LeapDynamicRenderer
+    _fullName: Leap.Unity.GraphicalRenderer.LeapBakedRenderer
   vertexColor: {r: 0.6911765, g: 0.6911765, b: 0.6911765, a: 1}
   _mesh: {fileID: 4300000, guid: 14e47e6e841b85146813b9d552dc3d37, type: 3}
   _remappableChannels: -1
---- !u!114 &1366916396
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1366916390}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b2088ff06a92b2d4590f9803e38f508e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _persistentId: 446487046
-  graphic: {fileID: 1366916395}
-  feature: {fileID: 1535910914}
-  _color: {r: 1, g: 1, b: 1, a: 1}
 --- !u!1 &1520670167
 GameObject:
   m_ObjectHideFlags: 0
@@ -1644,9 +1607,8 @@ GameObject:
   - component: {fileID: 1520670173}
   - component: {fileID: 1520670169}
   - component: {fileID: 1520670172}
-  - component: {fileID: 1520670168}
   - component: {fileID: 1520670170}
-  - component: {fileID: 1520670171}
+  - component: {fileID: 1520670168}
   m_Layer: 0
   m_Name: Element (5)
   m_TagString: Untagged
@@ -1662,13 +1624,13 @@ MonoBehaviour:
   m_GameObject: {fileID: 1520670167}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d2c8779b1bdf86c4dbcbe18f17e44e53, type: 3}
+  m_Script: {fileID: 11500000, guid: b051eb69afb505b479d2ea649875e390, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _persistentId: 1861243575
+  _persistentId: -368488964
   graphic: {fileID: 1520670169}
-  feature: {fileID: 1535910915}
-  texture: {fileID: 2800000, guid: 93f4f81256c947642a93d907d828ee98, type: 3}
+  feature: {fileID: 1535910903}
+  sprite: {fileID: 21300000, guid: 7941f01ab879cfa4495b7e425293ddad, type: 3}
 --- !u!114 &1520670169
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1683,49 +1645,23 @@ MonoBehaviour:
   _anchor: {fileID: 0}
   _featureData:
   - {fileID: 1520670168}
-  - {fileID: 1520670171}
-  - {fileID: 1520670170}
-  _attachedGroup: {fileID: 1535910917}
+  _attachedGroup: {fileID: 1535910909}
   _preferredRendererType:
-    _fullName: Leap.Unity.GraphicalRenderer.LeapDynamicRenderer
+    _fullName: Leap.Unity.GraphicalRenderer.LeapBakedRenderer
   vertexColor: {r: 1, g: 0, b: 0, a: 1}
   _mesh: {fileID: 4300000, guid: 14e47e6e841b85146813b9d552dc3d37, type: 3}
   _remappableChannels: -1
 --- !u!114 &1520670170
 MonoBehaviour:
-  m_ObjectHideFlags: 3
+  m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1520670167}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 438437f012b34d043919ad395e42c066, type: 3}
+  m_Script: {fileID: 11500000, guid: c437e41a5ae81fd468510f087ba4a70a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _persistentId: 2017957383
-  graphic: {fileID: 1520670169}
-  feature: {fileID: 1535910911}
-  _amount: 0
-  _type: 2
-  _scale: 1.1
-  _translation: {x: 0, y: 0, z: 0.1}
-  _rotation: {x: 0, y: 0, z: 5}
-  _mesh: {fileID: 0}
---- !u!114 &1520670171
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1520670167}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b2088ff06a92b2d4590f9803e38f508e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _persistentId: 1988191106
-  graphic: {fileID: 1520670169}
-  feature: {fileID: 1535910914}
-  _color: {r: 1, g: 1, b: 1, a: 1}
 --- !u!114 &1520670172
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1765,11 +1701,9 @@ GameObject:
   - component: {fileID: 1535910910}
   - component: {fileID: 1535910912}
   - component: {fileID: 1535910908}
-  - component: {fileID: 1535910917}
-  - component: {fileID: 1535910916}
-  - component: {fileID: 1535910915}
-  - component: {fileID: 1535910911}
-  - component: {fileID: 1535910914}
+  - component: {fileID: 1535910909}
+  - component: {fileID: 1535910905}
+  - component: {fileID: 1535910903}
   m_Layer: 0
   m_Name: GUI
   m_TagString: Untagged
@@ -1777,6 +1711,26 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
+--- !u!114 &1535910903
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1535910902}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eb8619b4d0e4d744183adf2e5fb82581, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _persistentId: -817993344
+  featureData:
+  - {fileID: 747764344}
+  - {fileID: 1365773556}
+  - {fileID: 465469647}
+  - {fileID: 1366916392}
+  - {fileID: 1520670168}
+  propertyName: _MainTex
+  channel: 1
 --- !u!114 &1535910904
 MonoBehaviour:
   m_ObjectHideFlags: 3
@@ -1809,34 +1763,40 @@ MonoBehaviour:
   _material: {fileID: 1882322863}
   _meshes: {fileID: 0}
   _packedTextures: {fileID: 0}
-  _channelMapping:
-    _data:
+  _atlasUvs:
+    _channel0:
+      _keys: []
+      _values: []
+    _channel1:
+      _keys: []
+      _values: []
+    _channel2:
+      _keys: []
+      _values: []
+    _channel3:
+      _keys: []
+      _values: []
+    _nullRects:
     - serializedVersion: 2
-      x: 0.015625
-      y: 0.0078125
-      width: 0.53125
-      height: 0.265625
+      x: 0
+      y: 0
+      width: 0
+      height: 0
     - serializedVersion: 2
-      x: 0.015625
-      y: 0.2890625
-      width: 0.5
-      height: 0.25
+      x: 0
+      y: 0
+      width: 0
+      height: 0
     - serializedVersion: 2
-      x: 0.015625
-      y: 0.2890625
-      width: 0.5
-      height: 0.25
+      x: 0
+      y: 0
+      width: 0
+      height: 0
     - serializedVersion: 2
-      x: 0.015625
-      y: 0.2890625
-      width: 0.5
-      height: 0.25
-    - serializedVersion: 2
-      x: 0.015625
-      y: 0.2890625
-      width: 0.5
-      height: 0.25
-    _lengths: 05000000ffffffffffffffffffffffff
+      x: 0
+      y: 0
+      width: 0
+      height: 0
   _layer:
     layerIndex: 0
   _motionType: 1
@@ -1845,6 +1805,86 @@ MonoBehaviour:
   - obj: {fileID: 0}
     filter: {fileID: 0}
     renderer: {fileID: 0}
+--- !u!114 &1535910905
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1535910902}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 00bb44340bd430d44a098a5e36f4de2d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _persistentId: -1596528111
+  renderer: {fileID: 1535910906}
+  group: {fileID: 1535910909}
+  _useUv0: 1
+  _useUv1: 0
+  _useUv2: 0
+  _useUv3: 0
+  _useColors: 0
+  _bakedTint: {r: 1, g: 1, b: 1, a: 1}
+  _useNormals: 0
+  _shader: {fileID: 4800000, guid: 692ffa38f03db184d8b27b0661d5bf0d, type: 3}
+  _atlas:
+    _border: 1
+    _padding: 0
+    _mipMap: 1
+    _filterMode: 1
+    _format: 5
+    _maxAtlasSize: 4096
+  _material: {fileID: 457937449}
+  _meshes: {fileID: 11400000, guid: 20061cc287d9a4b47b9ed5b22a197028, type: 2}
+  _packedTextures: {fileID: 11400000, guid: c3cda0075b79b9149b8aa3e9e039d031, type: 2}
+  _atlasUvs:
+    _channel0:
+      _keys:
+      - {fileID: 21300000, guid: 7941f01ab879cfa4495b7e425293ddad, type: 3}
+      _values:
+      - serializedVersion: 2
+        x: 0
+        y: 0
+        width: 0
+        height: 0
+    _channel1:
+      _keys: []
+      _values: []
+    _channel2:
+      _keys: []
+      _values: []
+    _channel3:
+      _keys: []
+      _values: []
+    _nullRects:
+    - serializedVersion: 2
+      x: 0
+      y: 0
+      width: 0
+      height: 0
+    - serializedVersion: 2
+      x: 0
+      y: 0
+      width: 0
+      height: 0
+    - serializedVersion: 2
+      x: 0
+      y: 0
+      width: 0
+      height: 0
+    - serializedVersion: 2
+      x: 0
+      y: 0
+      width: 0
+      height: 0
+  _layer:
+    layerIndex: 0
+  _motionType: 1
+  _createMeshRenderers: 1
+  _renderers:
+  - obj: {fileID: 1133138201}
+    filter: {fileID: 1133138203}
+    renderer: {fileID: 1133138202}
 --- !u!114 &1535910906
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1859,7 +1899,7 @@ MonoBehaviour:
   _selectedGroup: 0
   _space: {fileID: 0}
   _groups:
-  - {fileID: 1535910917}
+  - {fileID: 1535910909}
 --- !u!4 &1535910907
 Transform:
   m_ObjectHideFlags: 0
@@ -1870,6 +1910,7 @@ Transform:
   m_LocalPosition: {x: 0, y: 2, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
+  - {fileID: 1133138204}
   - {fileID: 1645781542}
   m_Father: {fileID: 0}
   m_RootOrder: 3
@@ -1888,6 +1929,32 @@ MonoBehaviour:
   parent: {fileID: 1535910908}
   space: {fileID: 1535910908}
   _radius: 3.28
+--- !u!114 &1535910909
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1535910902}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b32d8e323bfd9df4d82051c22f44d792, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _persistentId: 1152296847
+  _renderingMethod: {fileID: 1535910905}
+  _features:
+  - {fileID: 1535910903}
+  _renderer: {fileID: 1535910906}
+  _graphics:
+  - {fileID: 747764345}
+  - {fileID: 1365773557}
+  - {fileID: 465469650}
+  - {fileID: 1366916395}
+  - {fileID: 1520670169}
+  _supportInfo:
+  - support: 0
+    message: 
+  _addRemoveSupported: 0
 --- !u!114 &1535910910
 MonoBehaviour:
   m_ObjectHideFlags: 3
@@ -1920,28 +1987,40 @@ MonoBehaviour:
   _material: {fileID: 1611082225}
   _meshes: {fileID: 0}
   _packedTextures: {fileID: 0}
-  _channelMapping:
-    _data: []
-    _lengths: 00000000ffffffffffffffffffffffff
---- !u!114 &1535910911
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1535910902}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9ff0cf669bd50964a915784dbb766181, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _persistentId: -1813548717
-  featureData:
-  - {fileID: 465469649}
-  - {fileID: 1365773560}
-  - {fileID: 1366916394}
-  - {fileID: 1520670170}
-  - {fileID: 747764348}
-  _space: 0
+  _atlasUvs:
+    _channel0:
+      _keys: []
+      _values: []
+    _channel1:
+      _keys: []
+      _values: []
+    _channel2:
+      _keys: []
+      _values: []
+    _channel3:
+      _keys: []
+      _values: []
+    _nullRects:
+    - serializedVersion: 2
+      x: 0
+      y: 0
+      width: 0
+      height: 0
+    - serializedVersion: 2
+      x: 0
+      y: 0
+      width: 0
+      height: 0
+    - serializedVersion: 2
+      x: 0
+      y: 0
+      width: 0
+      height: 0
+    - serializedVersion: 2
+      x: 0
+      y: 0
+      width: 0
+      height: 0
 --- !u!114 &1535910912
 MonoBehaviour:
   m_ObjectHideFlags: 3
@@ -1962,136 +2041,6 @@ MonoBehaviour:
   _globalTint: {r: 1, g: 1, b: 1, a: 1}
   _shader: {fileID: 4800000, guid: 45c3e855355db4d409f06f94b19ed52f, type: 3}
   _meshData: {fileID: 0}
---- !u!114 &1535910914
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1535910902}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 6f6ba66cc9da35149bbfcd9cac71cc62, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _persistentId: 734237572
-  featureData:
-  - {fileID: 465469651}
-  - {fileID: 1365773561}
-  - {fileID: 1366916396}
-  - {fileID: 1520670171}
-  - {fileID: 747764349}
---- !u!114 &1535910915
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1535910902}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 36ae2dc675d304041af3c95461f228e2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _persistentId: 1275456438
-  featureData:
-  - {fileID: 465469647}
-  - {fileID: 1365773556}
-  - {fileID: 1366916392}
-  - {fileID: 1520670168}
-  - {fileID: 747764344}
-  propertyName: _MainTex
-  channel: 1
---- !u!114 &1535910916
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1535910902}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e4e826f61fa76194f87130a5030b287d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _persistentId: -1585157893
-  renderer: {fileID: 1535910906}
-  group: {fileID: 1535910917}
-  _useUv0: 1
-  _useUv1: 0
-  _useUv2: 0
-  _useUv3: 0
-  _useColors: 1
-  _bakedTint: {r: 1, g: 1, b: 1, a: 1}
-  _useNormals: 0
-  _shader: {fileID: 4800000, guid: a770bdf1a8aeb824aa92fc5d9e2ffb55, type: 3}
-  _atlas:
-    _border: 1
-    _padding: 0
-    _mipMap: 1
-    _filterMode: 1
-    _format: 5
-    _maxAtlasSize: 4096
-  _material: {fileID: 180887270}
-  _meshes: {fileID: 11400000, guid: 5be69de268bd2a84fa6ec788890226d4, type: 2}
-  _packedTextures: {fileID: 11400000, guid: d095a4522ffbc5045a9b308d707c845f, type: 2}
-  _channelMapping:
-    _data:
-    - serializedVersion: 2
-      x: 0.015625
-      y: 0.2890625
-      width: 0.5
-      height: 0.25
-    - serializedVersion: 2
-      x: 0.015625
-      y: 0.2890625
-      width: 0.5
-      height: 0.25
-    - serializedVersion: 2
-      x: 0.015625
-      y: 0.2890625
-      width: 0.5
-      height: 0.25
-    - serializedVersion: 2
-      x: 0.015625
-      y: 0.2890625
-      width: 0.5
-      height: 0.25
-    - serializedVersion: 2
-      x: 0.015625
-      y: 0.0078125
-      width: 0.53125
-      height: 0.265625
-    _lengths: 05000000ffffffffffffffffffffffff
---- !u!114 &1535910917
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1535910902}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b32d8e323bfd9df4d82051c22f44d792, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _persistentId: 616374406
-  _renderingMethod: {fileID: 1535910916}
-  _features:
-  - {fileID: 1535910915}
-  - {fileID: 1535910914}
-  - {fileID: 1535910911}
-  _renderer: {fileID: 1535910906}
-  _graphics:
-  - {fileID: 465469650}
-  - {fileID: 1365773557}
-  - {fileID: 1366916395}
-  - {fileID: 1520670169}
-  - {fileID: 747764345}
-  _supportInfo:
-  - support: 0
-    message: 
-  - support: 0
-    message: 
-  - support: 0
-    message: 
-  _addRemoveSupported: 0
 --- !u!1 &1557105950
 GameObject:
   m_ObjectHideFlags: 0
@@ -2216,7 +2165,7 @@ Transform:
   - {fileID: 1366916391}
   - {fileID: 1520670173}
   m_Father: {fileID: 1535910907}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1677062621
 GameObject:

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/EditTimeApis/LeapGraphicRendererEditorApi.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/EditTimeApis/LeapGraphicRendererEditorApi.cs
@@ -31,7 +31,7 @@ namespace Leap.Unity.GraphicalRenderer {
       }
 
       public void OnValidate() {
-        //TODO, handle drag-drop for groups!
+        validateSpaceComponent();
       }
 
       public void OnDestroy() {

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/ISupportsAddRemove.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/ISupportsAddRemove.cs
@@ -2,7 +2,15 @@
 namespace Leap.Unity.GraphicalRenderer {
 
   public interface ISupportsAddRemove {
-    void OnAddGraphic();
-    void OnRemoveGraphic();
+    /// <summary>
+    /// The graphic to add.  It is always added to the end of
+    /// a list.
+    /// </summary>
+    void OnAddGraphic(LeapGraphic graphic);
+
+    /// <summary>
+    /// The graphic to remove, in addition to it's previous index.
+    /// </summary>
+    void OnRemoveGraphic(LeapGraphic graphic, int index);
   }
 }

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/ISupportsAddRemove.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/ISupportsAddRemove.cs
@@ -6,7 +6,7 @@ namespace Leap.Unity.GraphicalRenderer {
     /// The graphic to add.  It is always added to the end of
     /// a list.
     /// </summary>
-    void OnAddGraphic(LeapGraphic graphic);
+    void OnAddGraphic(LeapGraphic graphic, int index);
 
     /// <summary>
     /// The graphic to remove, in addition to it's previous index.

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/LeapGraphicGroup.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/LeapGraphicGroup.cs
@@ -124,6 +124,7 @@ namespace Leap.Unity.GraphicalRenderer {
         }
       }
 
+      int newIndex = _graphics.Count;
       _graphics.Add(graphic);
 
       LeapSpaceAnchor anchor = _renderer.space == null ? null : LeapSpaceAnchor.GetAnchor(graphic.transform);
@@ -142,7 +143,7 @@ namespace Leap.Unity.GraphicalRenderer {
       if (_renderingMethod is ISupportsAddRemove)
 #endif
       {
-        (_renderingMethod as ISupportsAddRemove).OnAddGraphic(graphic);
+        (_renderingMethod as ISupportsAddRemove).OnAddGraphic(graphic, newIndex);
       }
 
       return true;

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/LeapGraphicGroup.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/LeapGraphicGroup.cs
@@ -139,12 +139,11 @@ namespace Leap.Unity.GraphicalRenderer {
         _renderer.editor.ScheduleEditorUpdate();
       }
 
-      if (_renderingMethod is ISupportsAddRemove) {
-        (_renderingMethod as ISupportsAddRemove).OnAddGraphic();
-      }
-#else
-    (_renderer as ISupportsAddRemove).OnAddGraphic();
+      if (_renderingMethod is ISupportsAddRemove)
 #endif
+      {
+        (_renderingMethod as ISupportsAddRemove).OnAddGraphic(graphic);
+      }
 
       return true;
     }
@@ -156,12 +155,13 @@ namespace Leap.Unity.GraphicalRenderer {
         return false;
       }
 
-      if (!_graphics.Contains(graphic)) {
+      int graphicIndex = _graphics.IndexOf(graphic);
+      if (graphicIndex < 0) {
         return false;
       }
 
       graphic.OnDetachedFromGroup();
-      _graphics.Remove(graphic);
+      _graphics.RemoveAt(graphicIndex);
 
       //TODO: this is gonna need to be optimized
       RebuildFeatureData();
@@ -172,12 +172,11 @@ namespace Leap.Unity.GraphicalRenderer {
         _renderer.editor.ScheduleEditorUpdate();
       }
 
-      if (_renderingMethod is ISupportsAddRemove) {
-        (_renderingMethod as ISupportsAddRemove).OnRemoveGraphic();
-      }
-#else
-    (_renderer as ISupportsAddRemove).OnRemoveGraphic();
+      if (_renderingMethod is ISupportsAddRemove)
 #endif
+      {
+        (_renderingMethod as ISupportsAddRemove).OnRemoveGraphic(graphic, graphicIndex);
+      }
 
       return true;
     }

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/LeapGraphicGroup.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/LeapGraphicGroup.cs
@@ -138,9 +138,7 @@ namespace Leap.Unity.GraphicalRenderer {
 #if UNITY_EDITOR
       if (!Application.isPlaying) {
         _renderer.editor.ScheduleEditorUpdate();
-      }
-
-      if (_renderingMethod is ISupportsAddRemove)
+      } else
 #endif
       {
         (_renderingMethod as ISupportsAddRemove).OnAddGraphic(graphic, newIndex);
@@ -171,9 +169,7 @@ namespace Leap.Unity.GraphicalRenderer {
 #if UNITY_EDITOR
       if (!Application.isPlaying) {
         _renderer.editor.ScheduleEditorUpdate();
-      }
-
-      if (_renderingMethod is ISupportsAddRemove)
+      } else
 #endif
       {
         (_renderingMethod as ISupportsAddRemove).OnRemoveGraphic(graphic, graphicIndex);

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/LeapGraphicRenderer.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/LeapGraphicRenderer.cs
@@ -79,10 +79,6 @@ namespace Leap.Unity.GraphicalRenderer {
 
     #region UNITY CALLBACKS
     private void OnValidate() {
-      if (_space == null) {
-        _space = GetComponent<LeapSpace>();
-      }
-
 #if UNITY_EDITOR
       editor.OnValidate();
 #endif

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/LeapRendereringMethod.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/LeapRendereringMethod.cs
@@ -82,7 +82,7 @@ namespace Leap.Unity.GraphicalRenderer {
 
     protected void CreateOrSave<T>(ref T t, string assetName) where T : SceneTiedAsset {
       T newT = t;
-      if (SceneTiedAsset.CreateOrSave(gameObject, 
+      if (SceneTiedAsset.CreateOrSave(this, 
                                       ref newT,
                                       DATA_FOLDER_NAME,
                                       assetName)) {

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/LeapRendereringMethod.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/LeapRendereringMethod.cs
@@ -82,11 +82,10 @@ namespace Leap.Unity.GraphicalRenderer {
 
     protected void CreateOrSave<T>(ref T t, string assetName) where T : SceneTiedAsset {
       T newT = t;
-      if (SceneTiedAsset.CreateOrSave(ref newT,
-                                      gameObject.scene,
+      if (SceneTiedAsset.CreateOrSave(gameObject, 
+                                      ref newT,
                                       DATA_FOLDER_NAME,
-                                      assetName,
-                                      _persistentId)) {
+                                      assetName)) {
         Undo.RecordObject(this, "Updated graphic data");
         t = newT;
         EditorUtility.SetDirty(this);

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/RenderingMethods/AssetData/RendererMeshData.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/RenderingMethods/AssetData/RendererMeshData.cs
@@ -45,6 +45,12 @@ namespace Leap.Unity.GraphicalRenderer {
 #endif
     }
 
+    public void RemoveMesh(int index) {
+      Mesh mesh = meshes[index];
+      meshes.RemoveAt(index);
+      DestroyImmediate(mesh, allowDestroyingAssets: true);
+    }
+
     public int Count {
       get {
         return meshes.Count;

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/RenderingMethods/LeapBakedRenderer.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/RenderingMethods/LeapBakedRenderer.cs
@@ -97,7 +97,10 @@ namespace Leap.Unity.GraphicalRenderer {
       if (!_createMeshRenderers) {
         using (new ProfilerSample("Draw Meshes")) {
           for (int i = 0; i < _meshes.Count; i++) {
-            Graphics.DrawMesh(_meshes[i], renderer.transform.localToWorldMatrix, _material, _layer);
+            Mesh mesh = _meshes[i];
+            if (mesh != null) {
+              Graphics.DrawMesh(_meshes[i], renderer.transform.localToWorldMatrix, _material, _layer);
+            }
           }
         }
       }
@@ -124,6 +127,7 @@ namespace Leap.Unity.GraphicalRenderer {
         while (_renderers.Count > _meshes.Count) {
           _renderers.RemoveLast().Destroy();
         }
+
         while (_renderers.Count < _meshes.Count) {
           _renderers.Add(new MeshRendererContainer(transform));
         }
@@ -164,23 +168,23 @@ namespace Leap.Unity.GraphicalRenderer {
     protected override void buildTopology() {
       //If the next graphic is going to put us over the limit, finish the current mesh
       //and start a new one.
-      if (_verts.Count + _currGraphic.mesh.vertexCount > MeshUtil.MAX_VERT_COUNT) {
+      if (_generation.verts.Count + _generation.graphic.mesh.vertexCount > MeshUtil.MAX_VERT_COUNT) {
         finishMesh();
         beginMesh();
       }
 
       switch (_motionType) {
         case MotionType.None:
-          _noMotion_transformer = _currGraphic.transformer;
+          _noMotion_transformer = _generation.graphic.transformer;
           _noMotion_graphicVertToLocalVert = renderer.transform.worldToLocalMatrix *
-                                             _currGraphic.transform.localToWorldMatrix;
+                                             _generation.graphic.transform.localToWorldMatrix;
           break;
         case MotionType.Translation:
-          _translation_graphicVertToMeshVert = Matrix4x4.TRS(-renderer.transform.InverseTransformPoint(_currGraphic.transform.position),
+          _translation_graphicVertToMeshVert = Matrix4x4.TRS(-renderer.transform.InverseTransformPoint(_generation.graphic.transform.position),
                                                              Quaternion.identity,
                                                              Vector3.one) *
                                                renderer.transform.worldToLocalMatrix *
-                                               _currGraphic.transform.localToWorldMatrix;
+                                               _generation.graphic.transform.localToWorldMatrix;
 
           break;
         default:
@@ -195,7 +199,7 @@ namespace Leap.Unity.GraphicalRenderer {
 
       //For the baked renderer, the mesh really never accurately represents it's visual position 
       //or size, so just disable culling entirely by making the bound gigantic.
-      _currMesh.bounds = new Bounds(Vector3.zero, Vector3.one * 100000);
+      _generation.mesh.bounds = new Bounds(Vector3.zero, Vector3.one * 100000);
     }
 
     protected override bool doesRequireSpecialUv3() {

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/RenderingMethods/LeapDynamicRenderer.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/RenderingMethods/LeapDynamicRenderer.cs
@@ -18,18 +18,15 @@ namespace Leap.Unity.GraphicalRenderer {
     private List<Vector4> _curved_graphicParameters = new List<Vector4>();
     #endregion
 
-    public void OnAddGraphic() {
-      //TODO
-      if (Application.isPlaying) {
-        throw new NotImplementedException();
-      }
+    public void OnAddGraphic(LeapGraphic graphic) {
+      beginMesh();
+      _currGraphic = graphic as LeapMeshGraphicBase;
+      _currIndex = _meshes.Count;
+      finishMesh();
     }
 
-    public void OnRemoveGraphic() {
-      //TODO
-      if (Application.isPlaying) {
-        throw new NotImplementedException();
-      }
+    public void OnRemoveGraphic(LeapGraphic graphic, int graphicIndex) {
+      _meshes.RemoveMesh(graphicIndex);
     }
 
     public override SupportInfo GetSpaceSupportInfo(LeapSpace space) {

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/RenderingMethods/LeapDynamicRenderer.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/RenderingMethods/LeapDynamicRenderer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using UnityEngine;
+using Leap.Unity.Query;
 using Leap.Unity.Space;
 
 namespace Leap.Unity.GraphicalRenderer {
@@ -11,6 +12,9 @@ namespace Leap.Unity.GraphicalRenderer {
 
     #region PRIVATE VARIABLES
 
+    private Dictionary<LeapGraphic, int> _graphicToId = new Dictionary<LeapGraphic, int>();
+    private Stack<int> _freeIds = new Stack<int>();
+
     //Curved space
     private const string CURVED_PARAMETERS = LeapGraphicRenderer.PROPERTY_PREFIX + "Curved_GraphicParameters";
     private List<Matrix4x4> _curved_worldToAnchor = new List<Matrix4x4>();
@@ -18,14 +22,30 @@ namespace Leap.Unity.GraphicalRenderer {
     private List<Vector4> _curved_graphicParameters = new List<Vector4>();
     #endregion
 
-    public void OnAddGraphic(LeapGraphic graphic) {
+    public void OnAddGraphic(LeapGraphic graphic, int newIndex) {
+      int id;
+      if (_freeIds.Count > 0) {
+        id = _freeIds.Pop();
+      } else {
+        id = newIndex;
+      }
+
       beginMesh();
-      _currGraphic = graphic as LeapMeshGraphicBase;
-      _currIndex = _meshes.Count;
+      _generation.graphic = graphic as LeapMeshGraphicBase;
+      _generation.graphicIndex = newIndex;
+      _generation.graphicId = id;
+      buildGraphic();
       finishMesh();
+
+      _graphicToId[graphic] = id;
     }
 
     public void OnRemoveGraphic(LeapGraphic graphic, int graphicIndex) {
+      int id = _graphicToId[graphic];
+      _freeIds.Push(id);
+
+      _graphicToId.Remove(graphic);
+
       _meshes.RemoveMesh(graphicIndex);
     }
 
@@ -37,6 +57,22 @@ namespace Leap.Unity.GraphicalRenderer {
       } else {
         return SupportInfo.Error("Dynamic Renderer does not support " + space.GetType().Name);
       }
+    }
+
+    public override void OnEnableRenderer() {
+      for (int i = 0; i < group.graphics.Count; i++) {
+        _graphicToId[group.graphics[i]] = i;
+      }
+
+      base.OnEnableRenderer();
+    }
+
+    public override void OnUpdateRendererEditor(bool isHeavyUpdate) {
+      for (int i = 0; i < group.graphics.Count; i++) {
+        _graphicToId[group.graphics[i]] = i;
+      }
+
+      base.OnUpdateRendererEditor(isHeavyUpdate);
     }
 
     public override void OnUpdateRenderer() {
@@ -128,13 +164,13 @@ namespace Leap.Unity.GraphicalRenderer {
 
     protected override Vector3 blendShapeDelta(Vector3 shapeVert, Vector3 originalVert) {
       //TODO, optimize this, i'm sure it could be optimized.
-      Vector3 worldVert = _currGraphic.transform.TransformPoint(shapeVert);
+      Vector3 worldVert = _generation.graphic.transform.TransformPoint(shapeVert);
       Vector3 localVert = renderer.transform.InverseTransformPoint(worldVert);
-      shapeVert = localVert - renderer.transform.InverseTransformPoint(_currGraphic.transform.position);
+      shapeVert = localVert - renderer.transform.InverseTransformPoint(_generation.graphic.transform.position);
 
-      Vector3 worldVert2 = _currGraphic.transform.TransformPoint(originalVert);
+      Vector3 worldVert2 = _generation.graphic.transform.TransformPoint(originalVert);
       Vector3 localVert2 = renderer.transform.InverseTransformPoint(worldVert2);
-      originalVert = localVert2 - renderer.transform.InverseTransformPoint(_currGraphic.transform.position);
+      originalVert = localVert2 - renderer.transform.InverseTransformPoint(_generation.graphic.transform.position);
 
       return shapeVert - originalVert;
     }

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/RenderingMethods/LeapMesherBase.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/RenderingMethods/LeapMesherBase.cs
@@ -374,7 +374,6 @@ namespace Leap.Unity.GraphicalRenderer {
     protected virtual void prepareMeshes() {
       _meshes.Clear();
       _generation.Reset();
-      _atlasUvs = new AtlasUvs();
     }
 
     protected virtual void prepareMaterial() {
@@ -413,11 +412,9 @@ namespace Leap.Unity.GraphicalRenderer {
               minY = Mathf.Min(minY, uvs[j].y);
               maxX = Mathf.Max(maxX, uvs[j].x);
               maxY = Mathf.Max(maxY, uvs[j].y);
-              Debug.Log(uvs[j]);
             }
 
             Rect rect = Rect.MinMaxRect(minX, minY, maxX, maxY);
-            Debug.Log(rect);
             _atlasUvs.SetRect(spriteFeature.channel.Index(), sprite, rect);
           }
         }

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/Utility/LeapGraphicComponentBase.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/Utility/LeapGraphicComponentBase.cs
@@ -16,14 +16,14 @@ namespace Leap.Unity.GraphicalRenderer {
     protected virtual void OnValidate() {
       if (_persistentId == 0) {
         _persistentId = new Hash() {
-        this,
-        gameObject,
-        name,
-        transform.position,
-        transform.rotation,
-        transform.localScale,
-        Random.Range(int.MinValue, int.MaxValue),
-      };
+          this,
+          gameObject,
+          name,
+          transform.position,
+          transform.rotation,
+          transform.localScale,
+          Random.Range(int.MinValue, int.MaxValue),
+        };
       }
 
       var attatched = GetComponent<AttachedComponent>();

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/Utility/LeapGraphicComponentBase.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/Utility/LeapGraphicComponentBase.cs
@@ -6,26 +6,11 @@ namespace Leap.Unity.GraphicalRenderer {
   public class LeapGraphicComponentBase<AttachedComponent> : MonoBehaviour
   where AttachedComponent : Component {
 
-    [SerializeField, HideInInspector]
-    protected int _persistentId;
-
     protected virtual void Awake() {
       OnValidate();
     }
 
     protected virtual void OnValidate() {
-      if (_persistentId == 0) {
-        _persistentId = new Hash() {
-          this,
-          gameObject,
-          name,
-          transform.position,
-          transform.rotation,
-          transform.localScale,
-          Random.Range(int.MinValue, int.MaxValue),
-        };
-      }
-
       var attatched = GetComponent<AttachedComponent>();
       if (attatched == null) {
         InternalUtility.Destroy(this);

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/Utility/SceneTiedAsset.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/Utility/SceneTiedAsset.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Assertions;
 using UnityEngine.SceneManagement;
@@ -9,15 +10,16 @@ using Leap.Unity.Query;
 
 namespace Leap.Unity.GraphicalRenderer {
 
+
   public class SceneTiedAsset : ScriptableObject {
 
     [SerializeField]
-    private int _referenceId;
+    private bool _isSavedAsset;
 
 #if UNITY_EDITOR
     public bool isSavedAsset {
       get {
-        return _referenceId != 0;
+        return _isSavedAsset;
       }
     }
 #endif
@@ -26,16 +28,34 @@ namespace Leap.Unity.GraphicalRenderer {
 
     protected virtual void OnAssetSaved() { }
 
-#if UNITY_EDITOR
-    public static bool CreateOrSave<T>(ref T t,
-                                       Scene scene,
-                                       string folderSuffix,
-                                       string assetName,
-                                       int referenceId) where T : SceneTiedAsset {
-      bool didCreate = false;
-      string assetFolder = null;
+    private static class AssetRef<T> {
+      private static Dictionary<Object, T> _to = new Dictionary<Object, T>();
+      private static Dictionary<T, Object> _from = new Dictionary<T, Object>();
 
-      Assert.AreNotEqual(referenceId, 0);
+      public static bool TryGet(Object key, out T value) {
+        return _to.TryGetValue(key, out value);
+      }
+
+      public static bool TryGet(T key, out Object value) {
+        return _from.TryGetValue(key, out value);
+      }
+
+      public static void Put(Object key, T value) {
+        Assert.IsTrue(key != null);
+        Assert.IsTrue(value != null);
+        _to[key] = value;
+        _from[value] = key;
+      }
+    }
+
+#if UNITY_EDITOR
+    public static bool CreateOrSave<T>(GameObject holder,
+                                       ref T t,
+                                       string folderSuffix,
+                                       string assetName) where T : SceneTiedAsset {
+      bool didChange = false;
+      string assetFolder = null;
+      var scene = holder.scene;
 
       if (scene.IsValid() && !string.IsNullOrEmpty(scene.path)) {
         string sceneDirectory = Path.GetDirectoryName(scene.path);
@@ -44,27 +64,30 @@ namespace Leap.Unity.GraphicalRenderer {
       }
 
       if (t == null) {
-        if (assetFolder != null && AssetDatabase.IsValidFolder(assetFolder)) {
-          string filter = assetName + " t:" + typeof(T).Name;
-          string[] folder = new string[] { assetFolder };
-          string[] guids = AssetDatabase.FindAssets(filter, folder);
-
-          //Use the first asset that has a matching asset id
-          t = guids.Query().Select(g => AssetDatabase.GUIDToAssetPath(g)).
-                            Where(p => !string.IsNullOrEmpty(p)).
-                            Select(p => AssetDatabase.LoadAssetAtPath<T>(p)).
-                            NonNull().
-                            FirstOrDefault(a => a._referenceId == referenceId);
-        }
+        //Try to get the asset from the asset ref map
+        AssetRef<T>.TryGet(holder, out t);
 
         //If t is still null, just create it!
         if (t == null) {
           t = CreateInstance<T>();
           t.name = assetName;
           t.hideFlags = HideFlags.HideAndDontSave;
+
+          AssetRef<T>.Put(holder, t);
         }
 
-        didCreate = true;
+        didChange = true;
+      } else {
+        Object otherHolder;
+        if (AssetRef<T>.TryGet(t, out otherHolder)) {
+          if (otherHolder != holder) {
+            t = Instantiate(t);
+            t._isSavedAsset = false;
+            didChange = true;
+
+            AssetRef<T>.Put(holder, t);
+          }
+        }
       }
 
       if (assetFolder != null && !t.isSavedAsset) {
@@ -76,13 +99,13 @@ namespace Leap.Unity.GraphicalRenderer {
         assetPath = AssetDatabase.GenerateUniqueAssetPath(assetPath);
 
         t.hideFlags = HideFlags.None;
-        t._referenceId = referenceId;
+        t._isSavedAsset = true;
         AssetDatabase.CreateAsset(t, assetPath);
         t.OnAssetSaved();
         AssetDatabase.SaveAssets();
       }
 
-      return didCreate;
+      return didChange;
     }
 
     public static void Delete<T>(ref T t) where T : SceneTiedAsset {

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/Utility/SceneTiedAsset.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/Utility/SceneTiedAsset.cs
@@ -33,13 +33,13 @@ namespace Leap.Unity.GraphicalRenderer {
     }
 
 #if UNITY_EDITOR
-    public static bool CreateOrSave<T>(GameObject holder,
+    public static bool CreateOrSave<T>(Component holder,
                                        ref T t,
                                        string folderSuffix,
                                        string assetName) where T : SceneTiedAsset {
       bool didChange = false;
       string assetFolder = null;
-      var scene = holder.scene;
+      var scene = holder.gameObject.scene;
 
       if (scene.IsValid() && !string.IsNullOrEmpty(scene.path)) {
         string sceneDirectory = Path.GetDirectoryName(scene.path);

--- a/Assets/LeapMotionModules/GraphicRenderer/Textures/BorderBorder.png.meta
+++ b/Assets/LeapMotionModules/GraphicRenderer/Textures/BorderBorder.png.meta
@@ -40,7 +40,7 @@ TextureImporter:
   alignment: 0
   spritePivot: {x: 0.5, y: 0.5}
   spriteBorder: {x: 8, y: 8, z: 8, w: 8}
-  spritePixelsToUnits: 50
+  spritePixelsToUnits: 500
   alphaUsage: 1
   alphaIsTransparency: 1
   spriteTessellationDetail: -1
@@ -68,7 +68,7 @@ TextureImporter:
     overridden: 0
   - buildTarget: Android
     maxTextureSize: 2048
-    textureFormat: -1
+    textureFormat: 34
     textureCompression: 1
     compressionQuality: 50
     crunchedCompression: 0

--- a/Assets/LeapMotionModules/GraphicRenderer/Textures/Circle.bmp.meta
+++ b/Assets/LeapMotionModules/GraphicRenderer/Textures/Circle.bmp.meta
@@ -30,7 +30,7 @@ TextureImporter:
     filterMode: 0
     aniso: -1
     mipBias: -1
-    wrapMode: 0
+    wrapMode: 1
   nPOTScale: 0
   lightmap: 0
   compressionQuality: 50
@@ -68,7 +68,7 @@ TextureImporter:
     overridden: 0
   - buildTarget: Android
     maxTextureSize: 2048
-    textureFormat: 47
+    textureFormat: 34
     textureCompression: 1
     compressionQuality: 50
     crunchedCompression: 0

--- a/Assets/LeapMotionModules/GraphicRenderer/Textures/CircleTransparent.png.meta
+++ b/Assets/LeapMotionModules/GraphicRenderer/Textures/CircleTransparent.png.meta
@@ -68,7 +68,7 @@ TextureImporter:
     overridden: 0
   - buildTarget: Android
     maxTextureSize: 2048
-    textureFormat: 47
+    textureFormat: 34
     textureCompression: 1
     compressionQuality: 50
     crunchedCompression: 0

--- a/Assets/LeapMotionModules/GraphicRenderer/Textures/Plus.bmp.meta
+++ b/Assets/LeapMotionModules/GraphicRenderer/Textures/Plus.bmp.meta
@@ -68,7 +68,7 @@ TextureImporter:
     overridden: 0
   - buildTarget: Android
     maxTextureSize: 2048
-    textureFormat: 47
+    textureFormat: 34
     textureCompression: 1
     compressionQuality: 50
     crunchedCompression: 0

--- a/Assets/LeapMotionModules/GraphicRenderer/Textures/TestBorder.bmp.meta
+++ b/Assets/LeapMotionModules/GraphicRenderer/Textures/TestBorder.bmp.meta
@@ -68,7 +68,7 @@ TextureImporter:
     overridden: 0
   - buildTarget: Android
     maxTextureSize: 2048
-    textureFormat: 47
+    textureFormat: 34
     textureCompression: 1
     compressionQuality: 50
     crunchedCompression: 0

--- a/Assets/LeapMotionModules/Interaction/Examples/Buttons/Buttons_ElementData.meta
+++ b/Assets/LeapMotionModules/Interaction/Examples/Buttons/Buttons_ElementData.meta
@@ -1,9 +1,0 @@
-fileFormatVersion: 2
-guid: ca47c2d80c41fde4f8a10788fd6ccc51
-folderAsset: yes
-timeCreated: 1491265800
-licenseType: Free
-DefaultImporter:
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -3,7 +3,7 @@
 --- !u!129 &1
 PlayerSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 8
+  serializedVersion: 11
   productGUID: 7095a052d2dfd6642a958de988530851
   AndroidProfiler: 0
   defaultScreenOrientation: 2
@@ -14,21 +14,46 @@ PlayerSettings:
   productName: OrionCoreAssets
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
-  m_SplashScreenStyle: 0
-  m_ShowUnitySplashScreen: 0
+  m_SplashScreenBackgroundColor: {r: 0.13333334, g: 0.17254902, b: 0.21176471, a: 1}
+  m_ShowUnitySplashScreen: 1
+  m_ShowUnitySplashLogo: 1
+  m_SplashScreenOverlayOpacity: 1
+  m_SplashScreenAnimation: 1
+  m_SplashScreenLogoStyle: 1
+  m_SplashScreenDrawMode: 0
+  m_SplashScreenBackgroundAnimationZoom: 1
+  m_SplashScreenLogoAnimationZoom: 1
+  m_SplashScreenBackgroundLandscapeAspect: 1
+  m_SplashScreenBackgroundPortraitAspect: 1
+  m_SplashScreenBackgroundLandscapeUvs:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  m_SplashScreenBackgroundPortraitUvs:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  m_SplashScreenLogos: []
+  m_SplashScreenBackgroundLandscape: {fileID: 0}
+  m_SplashScreenBackgroundPortrait: {fileID: 0}
   m_VirtualRealitySplashScreen: {fileID: 0}
+  m_HolographicTrackingLossScreen: {fileID: 0}
   defaultScreenWidth: 1024
   defaultScreenHeight: 768
   defaultScreenWidthWeb: 960
   defaultScreenHeightWeb: 600
-  m_RenderingPath: 1
-  m_MobileRenderingPath: 1
+  m_StereoRenderingPath: 0
   m_ActiveColorSpace: 0
   m_MTRendering: 1
   m_MobileMTRendering: 1
   m_StackTraceTypes: 010000000100000001000000010000000100000001000000
   iosShowActivityIndicatorOnLoading: -1
   androidShowActivityIndicatorOnLoading: -1
+  tizenShowActivityIndicatorOnLoading: -1
   iosAppInBackgroundBehavior: 0
   displayResolutionDialog: 0
   iosAllowHTTPDownload: 1
@@ -43,7 +68,7 @@ PlayerSettings:
   defaultIsNativeResolution: 1
   runInBackground: 1
   captureSingleScreen: 0
-  Override IPod Music: 0
+  muteOtherAudioSources: 0
   Prepare IOS For Recording: 0
   submitAnalytics: 1
   usePlayerLog: 0
@@ -60,6 +85,7 @@ PlayerSettings:
   xboxEnableFitness: 0
   visibleInBackground: 1
   allowFullscreenSwitch: 1
+  graphicsJobMode: 0
   macFullscreenMode: 2
   d3d9FullscreenMode: 1
   d3d11FullscreenMode: 1
@@ -70,12 +96,10 @@ PlayerSettings:
   n3dsDisableStereoscopicView: 0
   n3dsEnableSharedListOpt: 1
   n3dsEnableVSync: 0
-  uiUse16BitDepthBuffer: 0
   ignoreAlphaClear: 0
   xboxOneResolution: 0
   xboxOneMonoLoggingLevel: 0
   xboxOneLoggingLevel: 1
-  ps3SplashScreen: {fileID: 0}
   videoMemoryForVertexBuffers: 0
   psp2PowerMode: 0
   psp2AcquireBGM: 1
@@ -94,35 +118,53 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleIdentifier: com.leapmotion.oriongearvr
   bundleVersion: 1.0
   preloadedAssets: []
-  metroEnableIndependentInputSource: 0
+  metroInputSource: 0
+  m_HolographicPauseOnTrackingLoss: 1
   xboxOneDisableKinectGpuReservation: 0
-  singlePassStereoRendering: 0
+  xboxOneEnable7thCore: 0
+  vrSettings:
+    cardboard:
+      depthFormat: 0
+      enableTransitionView: 0
+    daydream:
+      depthFormat: 0
+      useSustainedPerformanceMode: 0
+    hololens:
+      depthFormat: 1
   protectGraphicsMemory: 0
+  useHDRDisplay: 0
+  applicationIdentifier:
+    Android: com.leapmotion.oriongearvr
+    Standalone: unity.LeapMotion.OrionCoreAssets
+    Tizen: com.leapmotion.oriongearvr
+    iOS: com.leapmotion.oriongearvr
+    tvOS: com.leapmotion.oriongearvr
+  buildNumber:
+    iOS: 0
   AndroidBundleVersionCode: 1
   AndroidMinSdkVersion: 19
+  AndroidTargetSdkVersion: 0
   AndroidPreferredInstallLocation: 1
   aotOptions: 
-  apiCompatibilityLevel: 2
   stripEngineCode: 1
   iPhoneStrippingLevel: 0
   iPhoneScriptCallOptimization: 0
-  iPhoneBuildNumber: 0
   ForceInternetPermission: 0
   ForceSDCardPermission: 0
   CreateWallpaper: 0
   APKExpansionFiles: 0
-  preloadShaders: 0
+  keepLoadedShadersAlive: 0
   StripUnusedMeshComponents: 0
   VertexChannelCompressionMask:
     serializedVersion: 2
     m_Bits: 238
   iPhoneSdkVersion: 988
-  iPhoneTargetOSVersion: 22
+  iOSTargetOSVersionString: 6.0
   tvOSSdkVersion: 0
-  tvOSTargetOSVersion: 900
+  tvOSRequireExtendedGameController: 0
+  tvOSTargetOSVersionString: 9.0
   uIPrerenderedIcon: 0
   uIRequiresPersistentWiFi: 0
   uIRequiresFullScreen: 1
@@ -143,6 +185,7 @@ PlayerSettings:
   tvOSSmallIconLayers: []
   tvOSLargeIconLayers: []
   tvOSTopShelfImageLayers: []
+  tvOSTopShelfImageWideLayers: []
   iOSLaunchScreenType: 0
   iOSLaunchScreenPortrait: {fileID: 0}
   iOSLaunchScreenLandscape: {fileID: 0}
@@ -162,6 +205,14 @@ PlayerSettings:
   iOSLaunchScreeniPadCustomXibPath: 
   iOSDeviceRequirements: []
   iOSURLSchemes: []
+  iOSBackgroundModes: 0
+  iOSMetalForceHardShadows: 0
+  metalEditorSupport: 1
+  metalAPIValidation: 1
+  appleDeveloperTeamID: 
+  iOSManualSigningProvisioningProfileID: 
+  tvOSManualSigningProvisioningProfileID: 
+  appleEnableAutomaticSigning: 0
   AndroidTargetDevice: 0
   AndroidSplashScreenScale: 0
   androidSplashScreen: {fileID: 0}
@@ -185,6 +236,63 @@ PlayerSettings:
       m_Height: 128
   m_BuildTargetBatching: []
   m_BuildTargetGraphicsAPIs: []
+  m_BuildTargetVRSettings:
+  - m_BuildTarget: Android
+    m_Enabled: 0
+    m_Devices:
+    - Oculus
+  - m_BuildTarget: Metro
+    m_Enabled: 0
+    m_Devices: []
+  - m_BuildTarget: N3DS
+    m_Enabled: 0
+    m_Devices: []
+  - m_BuildTarget: PS3
+    m_Enabled: 0
+    m_Devices: []
+  - m_BuildTarget: PS4
+    m_Enabled: 0
+    m_Devices:
+    - PlayStationVR
+  - m_BuildTarget: PSM
+    m_Enabled: 0
+    m_Devices: []
+  - m_BuildTarget: PSP2
+    m_Enabled: 0
+    m_Devices: []
+  - m_BuildTarget: SamsungTV
+    m_Enabled: 0
+    m_Devices: []
+  - m_BuildTarget: Standalone
+    m_Enabled: 1
+    m_Devices:
+    - Oculus
+  - m_BuildTarget: Tizen
+    m_Enabled: 0
+    m_Devices: []
+  - m_BuildTarget: WebGL
+    m_Enabled: 0
+    m_Devices: []
+  - m_BuildTarget: WebPlayer
+    m_Enabled: 0
+    m_Devices: []
+  - m_BuildTarget: WiiU
+    m_Enabled: 0
+    m_Devices: []
+  - m_BuildTarget: Xbox360
+    m_Enabled: 0
+    m_Devices: []
+  - m_BuildTarget: XboxOne
+    m_Enabled: 0
+    m_Devices: []
+  - m_BuildTarget: iOS
+    m_Enabled: 0
+    m_Devices: []
+  - m_BuildTarget: tvOS
+    m_Enabled: 0
+    m_Devices: []
+  openGLRequireES31: 0
+  openGLRequireES31AEP: 0
   webPlayerTemplate: APPLICATION:Default
   m_TemplateCustomTags: {}
   wiiUTitleID: 0005000011000000
@@ -203,40 +311,124 @@ PlayerSettings:
   wiiUSystemHeapSize: 128
   wiiUTVStartupScreen: {fileID: 0}
   wiiUGamePadStartupScreen: {fileID: 0}
+  wiiUDrcBufferDisabled: 0
   wiiUProfilerLibPath: 
   actionOnDotNetUnhandledException: 1
   enableInternalProfiler: 0
   logObjCUncaughtExceptions: 1
   enableCrashReportAPI: 0
+  cameraUsageDescription: 
   locationUsageDescription: 
-  XboxTitleId: 
-  XboxImageXexPath: 
-  XboxSpaPath: 
-  XboxGenerateSpa: 0
-  XboxDeployKinectResources: 0
-  XboxSplashScreen: {fileID: 0}
-  xboxEnableSpeech: 0
-  xboxAdditionalTitleMemorySize: 0
-  xboxDeployKinectHeadOrientation: 0
-  xboxDeployKinectHeadPosition: 0
-  ps3TitleConfigPath: 
-  ps3DLCConfigPath: 
-  ps3ThumbnailPath: 
-  ps3BackgroundPath: 
-  ps3SoundPath: 
-  ps3NPAgeRating: 12
-  ps3TrophyCommId: 
-  ps3NpCommunicationPassphrase: 
-  ps3TrophyPackagePath: 
-  ps3BootCheckMaxSaveGameSizeKB: 128
-  ps3TrophyCommSig: 
-  ps3SaveGameSlots: 1
-  ps3TrialMode: 0
-  ps3VideoMemoryForAudio: 0
-  ps3EnableVerboseMemoryStats: 0
-  ps3UseSPUForUmbra: 0
-  ps3EnableMoveSupport: 1
-  ps3DisableDolbyEncoding: 0
+  microphoneUsageDescription: 
+  switchNetLibKey: 
+  switchSocketMemoryPoolSize: 6144
+  switchSocketAllocatorPoolSize: 128
+  switchSocketConcurrencyLimit: 14
+  switchUseCPUProfiler: 0
+  switchApplicationID: 0x0005000C10000001
+  switchNSODependencies: 
+  switchTitleNames_0: 
+  switchTitleNames_1: 
+  switchTitleNames_2: 
+  switchTitleNames_3: 
+  switchTitleNames_4: 
+  switchTitleNames_5: 
+  switchTitleNames_6: 
+  switchTitleNames_7: 
+  switchTitleNames_8: 
+  switchTitleNames_9: 
+  switchTitleNames_10: 
+  switchTitleNames_11: 
+  switchTitleNames_12: 
+  switchTitleNames_13: 
+  switchTitleNames_14: 
+  switchPublisherNames_0: 
+  switchPublisherNames_1: 
+  switchPublisherNames_2: 
+  switchPublisherNames_3: 
+  switchPublisherNames_4: 
+  switchPublisherNames_5: 
+  switchPublisherNames_6: 
+  switchPublisherNames_7: 
+  switchPublisherNames_8: 
+  switchPublisherNames_9: 
+  switchPublisherNames_10: 
+  switchPublisherNames_11: 
+  switchPublisherNames_12: 
+  switchPublisherNames_13: 
+  switchPublisherNames_14: 
+  switchIcons_0: {fileID: 0}
+  switchIcons_1: {fileID: 0}
+  switchIcons_2: {fileID: 0}
+  switchIcons_3: {fileID: 0}
+  switchIcons_4: {fileID: 0}
+  switchIcons_5: {fileID: 0}
+  switchIcons_6: {fileID: 0}
+  switchIcons_7: {fileID: 0}
+  switchIcons_8: {fileID: 0}
+  switchIcons_9: {fileID: 0}
+  switchIcons_10: {fileID: 0}
+  switchIcons_11: {fileID: 0}
+  switchIcons_12: {fileID: 0}
+  switchIcons_13: {fileID: 0}
+  switchIcons_14: {fileID: 0}
+  switchSmallIcons_0: {fileID: 0}
+  switchSmallIcons_1: {fileID: 0}
+  switchSmallIcons_2: {fileID: 0}
+  switchSmallIcons_3: {fileID: 0}
+  switchSmallIcons_4: {fileID: 0}
+  switchSmallIcons_5: {fileID: 0}
+  switchSmallIcons_6: {fileID: 0}
+  switchSmallIcons_7: {fileID: 0}
+  switchSmallIcons_8: {fileID: 0}
+  switchSmallIcons_9: {fileID: 0}
+  switchSmallIcons_10: {fileID: 0}
+  switchSmallIcons_11: {fileID: 0}
+  switchSmallIcons_12: {fileID: 0}
+  switchSmallIcons_13: {fileID: 0}
+  switchSmallIcons_14: {fileID: 0}
+  switchManualHTML: 
+  switchAccessibleURLs: 
+  switchLegalInformation: 
+  switchMainThreadStackSize: 1048576
+  switchPresenceGroupId: 0x0005000C10000001
+  switchLogoHandling: 0
+  switchReleaseVersion: 0
+  switchDisplayVersion: 1.0.0
+  switchStartupUserAccount: 0
+  switchTouchScreenUsage: 0
+  switchSupportedLanguagesMask: 0
+  switchLogoType: 0
+  switchApplicationErrorCodeCategory: 
+  switchUserAccountSaveDataSize: 0
+  switchUserAccountSaveDataJournalSize: 0
+  switchAttribute: 0
+  switchCardSpecSize: 4
+  switchCardSpecClock: 25
+  switchRatingsMask: 0
+  switchRatingsInt_0: 0
+  switchRatingsInt_1: 0
+  switchRatingsInt_2: 0
+  switchRatingsInt_3: 0
+  switchRatingsInt_4: 0
+  switchRatingsInt_5: 0
+  switchRatingsInt_6: 0
+  switchRatingsInt_7: 0
+  switchRatingsInt_8: 0
+  switchRatingsInt_9: 0
+  switchRatingsInt_10: 0
+  switchRatingsInt_11: 0
+  switchLocalCommunicationIds_0: 0x0005000C10000001
+  switchLocalCommunicationIds_1: 
+  switchLocalCommunicationIds_2: 
+  switchLocalCommunicationIds_3: 
+  switchLocalCommunicationIds_4: 
+  switchLocalCommunicationIds_5: 
+  switchLocalCommunicationIds_6: 
+  switchLocalCommunicationIds_7: 
+  switchParentalControl: 0
+  switchAllowsScreenshot: 1
+  switchDataLossConfirmation: 0
   ps4NPAgeRating: 12
   ps4NPTitleSecret: 
   ps4NPTrophyPackPath: 
@@ -248,7 +440,9 @@ PlayerSettings:
   ps4AppType: 0
   ps4ParamSfxPath: 
   ps4VideoOutPixelFormat: 0
-  ps4VideoOutResolution: 4
+  ps4VideoOutInitialWidth: 1920
+  ps4VideoOutBaseModeInitialWidth: 1920
+  ps4VideoOutReprojectionRate: 120
   ps4PronunciationXMLPath: 
   ps4PronunciationSIGPath: 
   ps4BackgroundImagePath: 
@@ -270,6 +464,7 @@ PlayerSettings:
   ps4ApplicationParam4: 0
   ps4DownloadDataSize: 0
   ps4GarlicHeapSize: 2048
+  ps4ProGarlicHeapSize: 2560
   ps4Passcode: frAQBc8Wsa1xVPfvJcrgRYwTiizs2trQ
   ps4UseDebugIl2cppLibs: 0
   ps4pnSessions: 1
@@ -277,9 +472,12 @@ PlayerSettings:
   ps4pnFriends: 1
   ps4pnGameCustomData: 1
   playerPrefsSupport: 0
+  restrictedAudioUsageRights: 0
+  ps4UseResolutionFallback: 0
   ps4ReprojectionSupport: 0
   ps4UseAudio3dBackend: 0
   ps4SocialScreenEnabled: 0
+  ps4ScriptOptimizationLevel: 3
   ps4Audio3dVirtualSpeakerCount: 14
   ps4attribCpuUsage: 0
   ps4PatchPkgPath: 
@@ -292,6 +490,9 @@ PlayerSettings:
   ps4attribShareSupport: 0
   ps4attribExclusiveVR: 0
   ps4disableAutoHideSplash: 0
+  ps4videoRecordingFeaturesUsed: 0
+  ps4contentSearchFeaturesUsed: 0
+  ps4attribEyeToEyeDistanceSettingVR: 0
   ps4IncludedModules: []
   monoEnv: 
   psp2Splashimage: {fileID: 0}
@@ -342,8 +543,40 @@ PlayerSettings:
   psp2InfoBarColor: 0
   psp2UseDebugIl2cppLibs: 0
   psmSplashimage: {fileID: 0}
+  splashScreenBackgroundSourceLandscape: {fileID: 0}
+  splashScreenBackgroundSourcePortrait: {fileID: 0}
   spritePackerPolicy: 
+  webGLMemorySize: 256
+  webGLExceptionSupport: 1
+  webGLNameFilesAsHashes: 0
+  webGLDataCaching: 0
+  webGLDebugSymbols: 0
+  webGLEmscriptenArgs: 
+  webGLModulesDirectory: 
+  webGLTemplate: APPLICATION:Default
+  webGLAnalyzeBuildSize: 0
+  webGLUseEmbeddedResources: 0
+  webGLUseWasm: 0
+  webGLCompressionFormat: 1
   scriptingDefineSymbols: {}
+  platformArchitecture:
+    iOS: 2
+    tvOS: 1
+  scriptingBackend:
+    Android: 0
+    Metro: 2
+    Standalone: 0
+    WebGL: 1
+    WebPlayer: 0
+    iOS: 1
+    tvOS: 1
+  incrementalIl2cppBuild:
+    iOS: 1
+    tvOS: 0
+  additionalIl2CppArgs: 
+  apiCompatibilityLevelPerPlatform: {}
+  m_RenderingPath: 1
+  m_MobileRenderingPath: 1
   metroPackageName: LeapMotionCoreAssets
   metroPackageVersion: 
   metroCertificatePath: 
@@ -375,6 +608,8 @@ PlayerSettings:
   tizenSigningProfileName: 
   tizenGPSPermissions: 0
   tizenMicrophonePermissions: 0
+  tizenDeploymentTarget: 
+  tizenDeploymentTargetType: -1
   tizenMinOSVersion: 0
   n3dsUseExtSaveData: 0
   n3dsCompressStaticMem: 1
@@ -405,148 +640,35 @@ PlayerSettings:
   XboxOnePackageEncryption: 0
   XboxOnePackageUpdateGranularity: 2
   XboxOneDescription: 
+  XboxOneLanguage:
+  - enus
+  XboxOneCapability: []
+  XboxOneGameRating: {}
   XboxOneIsContentPackage: 0
   XboxOneEnableGPUVariability: 0
   XboxOneSockets: {}
   XboxOneSplashScreen: {fileID: 0}
   XboxOneAllowedProductIds: []
   XboxOnePersistentLocalStorageSize: 0
-  intPropertyNames:
-  - Android::ScriptingBackend
-  - Metro::ScriptingBackend
-  - Standalone::ScriptingBackend
-  - WebGL::ScriptingBackend
-  - WebGL::audioCompressionFormat
-  - WebGL::exceptionSupport
-  - WebGL::memorySize
-  - WebPlayer::ScriptingBackend
-  - iOS::Architecture
-  - iOS::EnableIncrementalBuildSupportForIl2cpp
-  - iOS::ScriptingBackend
-  - tvOS::Architecture
-  - tvOS::EnableIncrementalBuildSupportForIl2cpp
-  - tvOS::ScriptingBackend
-  Android::ScriptingBackend: 0
-  Metro::ScriptingBackend: 2
-  Standalone::ScriptingBackend: 0
-  WebGL::ScriptingBackend: 1
-  WebGL::audioCompressionFormat: 4
-  WebGL::exceptionSupport: 1
-  WebGL::memorySize: 256
-  WebPlayer::ScriptingBackend: 0
-  iOS::Architecture: 2
-  iOS::EnableIncrementalBuildSupportForIl2cpp: 1
-  iOS::ScriptingBackend: 1
-  tvOS::Architecture: 1
-  tvOS::EnableIncrementalBuildSupportForIl2cpp: 0
-  tvOS::ScriptingBackend: 1
-  boolPropertyNames:
-  - Android::VR::enable
-  - Metro::VR::enable
-  - N3DS::VR::enable
-  - PS3::VR::enable
-  - PS4::VR::enable
-  - PSM::VR::enable
-  - PSP2::VR::enable
-  - SamsungTV::VR::enable
-  - Standalone::VR::enable
-  - Tizen::VR::enable
-  - WebGL::VR::enable
-  - WebGL::analyzeBuildSize
-  - WebGL::dataCaching
-  - WebGL::useEmbeddedResources
-  - WebPlayer::VR::enable
-  - WiiU::VR::enable
-  - Xbox360::VR::enable
-  - XboxOne::VR::enable
-  - XboxOne::enus
-  - iOS::VR::enable
-  - tvOS::VR::enable
-  Android::VR::enable: 0
-  Metro::VR::enable: 0
-  N3DS::VR::enable: 0
-  PS3::VR::enable: 0
-  PS4::VR::enable: 0
-  PSM::VR::enable: 0
-  PSP2::VR::enable: 0
-  SamsungTV::VR::enable: 0
-  Standalone::VR::enable: 1
-  Tizen::VR::enable: 0
-  WebGL::VR::enable: 0
-  WebGL::analyzeBuildSize: 0
-  WebGL::dataCaching: 0
-  WebGL::useEmbeddedResources: 0
-  WebPlayer::VR::enable: 0
-  WiiU::VR::enable: 0
-  Xbox360::VR::enable: 0
-  XboxOne::VR::enable: 0
-  XboxOne::enus: 1
-  iOS::VR::enable: 0
-  tvOS::VR::enable: 0
-  stringPropertyNames:
-  - Analytics_ServiceEnabled::Analytics_ServiceEnabled
-  - Build_ServiceEnabled::Build_ServiceEnabled
-  - Collab_ServiceEnabled::Collab_ServiceEnabled
-  - ErrorHub_ServiceEnabled::ErrorHub_ServiceEnabled
-  - Game_Performance_ServiceEnabled::Game_Performance_ServiceEnabled
-  - Hub_ServiceEnabled::Hub_ServiceEnabled
-  - Purchasing_ServiceEnabled::Purchasing_ServiceEnabled
-  - UNet_ServiceEnabled::UNet_ServiceEnabled
-  - Unity_Ads_ServiceEnabled::Unity_Ads_ServiceEnabled
-  - WebGL::emscriptenArgs
-  - WebGL::template
-  - additionalIl2CppArgs::additionalIl2CppArgs
-  Analytics_ServiceEnabled::Analytics_ServiceEnabled: False
-  Build_ServiceEnabled::Build_ServiceEnabled: False
-  Collab_ServiceEnabled::Collab_ServiceEnabled: False
-  ErrorHub_ServiceEnabled::ErrorHub_ServiceEnabled: False
-  Game_Performance_ServiceEnabled::Game_Performance_ServiceEnabled: False
-  Hub_ServiceEnabled::Hub_ServiceEnabled: False
-  Purchasing_ServiceEnabled::Purchasing_ServiceEnabled: False
-  UNet_ServiceEnabled::UNet_ServiceEnabled: False
-  Unity_Ads_ServiceEnabled::Unity_Ads_ServiceEnabled: False
-  WebGL::emscriptenArgs: 
-  WebGL::template: APPLICATION:Default
-  additionalIl2CppArgs::additionalIl2CppArgs: 
-  vectorPropertyNames:
-  - Android::VR::enabledDevices
-  - Metro::VR::enabledDevices
-  - N3DS::VR::enabledDevices
-  - PS3::VR::enabledDevices
-  - PS4::VR::enabledDevices
-  - PSM::VR::enabledDevices
-  - PSP2::VR::enabledDevices
-  - SamsungTV::VR::enabledDevices
-  - Standalone::VR::enabledDevices
-  - Tizen::VR::enabledDevices
-  - WebGL::VR::enabledDevices
-  - WebPlayer::VR::enabledDevices
-  - WiiU::VR::enabledDevices
-  - Xbox360::VR::enabledDevices
-  - XboxOne::VR::enabledDevices
-  - iOS::VR::enabledDevices
-  - tvOS::VR::enabledDevices
-  Android::VR::enabledDevices:
-  - Oculus
-  Metro::VR::enabledDevices: []
-  N3DS::VR::enabledDevices: []
-  PS3::VR::enabledDevices: []
-  PS4::VR::enabledDevices:
-  - PlayStationVR
-  PSM::VR::enabledDevices: []
-  PSP2::VR::enabledDevices: []
-  SamsungTV::VR::enabledDevices: []
-  Standalone::VR::enabledDevices:
-  - Oculus
-  Tizen::VR::enabledDevices: []
-  WebGL::VR::enabledDevices: []
-  WebPlayer::VR::enabledDevices: []
-  WiiU::VR::enabledDevices: []
-  Xbox360::VR::enabledDevices: []
-  XboxOne::VR::enabledDevices: []
-  iOS::VR::enabledDevices: []
-  tvOS::VR::enabledDevices: []
+  xboxOneScriptCompiler: 0
+  vrEditorSettings:
+    daydream:
+      daydreamIconForeground: {fileID: 0}
+      daydreamIconBackground: {fileID: 0}
+  cloudServicesEnabled:
+    Analytics: 0
+    Build: 0
+    Collab: 0
+    ErrorHub: 0
+    Game_Performance: 0
+    Hub: 0
+    Purchasing: 0
+    UNet: 0
+    Unity_Ads: 0
+  facebookSdkVersion: 7.9.1
+  apiCompatibilityLevel: 2
   cloudProjectId: 
   projectName: 
   organizationId: 
   cloudEnabled: 0
+  enableNewInputSystem: 0


### PR DESCRIPTION
Elements could not be added or removed from the dynamic renderer at runtime!  Supporting this was more annoying than initially expected, but ended up working out ok.  Basically what i had to end up doing is to separate the notion of index out from id, and instead of mapping from index to atlas coordinate, map from texture to atlas coordinate. 

Second change was upgrading the scene tying of assets to be more robust.  It now catches the case where you duplicate a renderer, and correctly duplicates the asset as well.  Currently only supports one asset of a given type per component, but could be upgraded in the future if needed.

To test:
 - [x] Verify this doesn't cause havoc.
 - [x] Verify that you can enable/disable elements at runtime for a Dynamic renderer without fear.
 - [x] Verify that duplicating the main graphic renderer object doesn't freak out anymore.