### PR TITLE
Inherit features and added promp

### DIFF
--- a/Assets/LeapMotion/Scripts/Utils/Utils.cs
+++ b/Assets/LeapMotion/Scripts/Utils/Utils.cs
@@ -59,6 +59,55 @@ namespace Leap.Unity {
       array = newArray;
     }
 
+    /// <summary>
+    /// Returns whether or not two lists contain the same elements ignoring order.
+    /// </summary>
+    public static bool AreEqualUnordered<T>(IList<T> a, IList<T> b) {
+      var _count = Pool<Dictionary<T, int>>.Spawn();
+      try {
+        int _nullCount = 0;
+
+        foreach (var i in a) {
+          if (i == null) {
+            _nullCount++;
+          } else {
+            int count;
+            if (!_count.TryGetValue(i, out count)) {
+              count = 0;
+            }
+            _count[i] = count + 1;
+          }
+        }
+
+        foreach (var i in b) {
+          if (i == null) {
+            _nullCount--;
+          } else {
+            int count;
+            if (!_count.TryGetValue(i, out count)) {
+              return false;
+            }
+            _count[i] = count - 1;
+          }
+        }
+
+        if (_nullCount != 0) {
+          return false;
+        }
+
+        foreach (var pair in _count) {
+          if (pair.Value != 0) {
+            return false;
+          }
+        }
+
+        return true;
+      } finally {
+        _count.Clear();
+        Pool<Dictionary<T, int>>.Recycle(_count);
+      }
+    }
+
     #endregion
 
     #region Math Utils
@@ -105,7 +154,7 @@ namespace Leap.Unity {
         }
       }
     }
-    
+
     #endregion
 
     #region Orientation Utils

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/Editor/LeapGraphicGroupEditor.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/Editor/LeapGraphicGroupEditor.cs
@@ -51,7 +51,7 @@ namespace Leap.Unity.GraphicalRenderer {
         _addRenderingMethodMenu.AddItem(new GUIContent(LeapGraphicTagAttribute.GetTag(renderingMethod)),
                                         false,
                                         () => {
-                                          target.editor.ChangeRenderingMethod(renderingMethod);
+                                          target.editor.ChangeRenderingMethod(renderingMethod, addFeatures: false);
                                           serializedObject.Update();
                                           CreateCachedEditor(target.renderingMethod, null, ref _rendererEditor);
                                           target.renderer.editor.ScheduleEditorUpdate();

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/Editor/LeapGraphicPreferences.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/Editor/LeapGraphicPreferences.cs
@@ -12,6 +12,8 @@ namespace Leap.Unity.GraphicalRenderer {
     public const string LEAP_GRAPHIC_SHADER_FOLDER = "Assets/LeapMotionModules/GraphicRenderer/Shaders/";
     private static Regex _graphicMaxRegex = new Regex(@"^#define\s+GRAPHIC_MAX\s+(\d+)\s*$");
 
+    public const string PROMPT_WHEN_GROUP_CHANGE_KEY = "LeapGraphicRenderer_ShouldPromptWhenGroupChange";
+
     private static int _cachedGraphicMax = -1; //-1 signals dirty
     public static int graphicMax {
       get {
@@ -32,8 +34,27 @@ namespace Leap.Unity.GraphicalRenderer {
       }
     }
 
+    public static bool promptWhenGroupChange {
+      get {
+        return EditorPrefs.GetBool(PROMPT_WHEN_GROUP_CHANGE_KEY, true);
+      }
+      set {
+        EditorPrefs.SetBool(PROMPT_WHEN_GROUP_CHANGE_KEY, value);
+      }
+    }
+
     [PreferenceItem("Leap Graphics")]
     private static void preferencesGUI() {
+      drawGraphicMaxField();
+
+      GUIContent prompContent = new GUIContent("Prompt When Group Changed", "Should the system prompt the user when they change the group of a graphic to a group with different features.");
+      bool newPromptValue = EditorGUILayout.Toggle(prompContent, promptWhenGroupChange);
+      if (promptWhenGroupChange != newPromptValue) {
+        promptWhenGroupChange = newPromptValue;
+      }
+    }
+
+    private static void drawGraphicMaxField() {
       int graphicMax;
       string errorMessage;
       string path;

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/LeapGraphicFeature.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/LeapGraphicFeature.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 using System.Collections.Generic;
 using UnityEngine;
 using Leap.Unity.Query;
@@ -92,5 +93,17 @@ namespace Leap.Unity.GraphicalRenderer {
         feature.isDirty = true;
       }
     }
+
+#if UNITY_EDITOR
+    public static Type GetFeatureType(Type dataObjType) {
+      var allTypes = Assembly.GetAssembly(dataObjType).GetTypes();
+      return allTypes.Query().
+                      Where(t => t.IsSubclassOf(typeof(LeapGraphicFeatureBase)) &&
+                                 t != typeof(LeapGraphicFeatureBase) &&
+                                !t.IsAbstract &&
+                                 t.BaseType.GetGenericArguments()[0] == dataObjType).
+                      FirstOrDefault();
+    }
+#endif
   }
 }


### PR DESCRIPTION
When adding a new renderer, it will now inherit the features of the graphics that are already present.  It will take the union of all features, so if graphic A has feature X, and graphic B has feature Y, the rendering method will gain features X and Y.  

When changing the group of a graphic, pop a dialog box if the new group has a different feature set than the current group (which could result in data loss).  This dialog box can also be turned off in the preferences, but is enabled by default.