### PR TITLE
Do a light rebuild regularly

### DIFF
--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/LeapGraphicFeature.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/LeapGraphicFeature.cs
@@ -7,11 +7,20 @@ using Leap.Unity.Query;
 namespace Leap.Unity.GraphicalRenderer {
 
   public abstract class LeapGraphicFeatureBase : LeapGraphicComponentBase<LeapGraphicRenderer> {
+
+    [NonSerialized]
     private bool _isDirty = true; //everything defaults dirty at the start!
 
     public bool isDirty {
       get {
-        return _isDirty;
+#if UNITY_EDITOR
+        if (!Application.isPlaying) {
+          return true;
+        } else
+#endif
+        {
+          return _isDirty;
+        }
       }
       set {
         _isDirty = value;


### PR DESCRIPTION
Do a light rebuild of the graphic renderer regularly to ensure that things stay valid.  In particular materials have a tendency to forget the arrays that have been set, resulting in any per-element data becoming invalid.  