### PR TITLE
Fix subtle bug in RingBuffer

### DIFF
--- a/Assets/LeapMotion/Scripts/DataStructures/RingBuffer.cs
+++ b/Assets/LeapMotion/Scripts/DataStructures/RingBuffer.cs
@@ -6,7 +6,7 @@ public class RingBuffer<T> {
 
   private T[] arr;
   private int firstIdx = 0;
-  private int lastIdx = 0;
+  private int lastIdx = -1;
 
   public RingBuffer(int bufferSize) {
     arr = new T[bufferSize];


### PR DESCRIPTION
Initial state of RingBuffer needs to match state of Clear() with starting lastIdx -1, otherwise the first time the RingBuffer is filled, it will report being full one Add() too early.