### PR TITLE
Upgrade capsule hand to use Graphics.DrawMesh instead

### DIFF
--- a/Assets/LeapMotion/Prefabs/HandModelsNonHuman/CapsuleHand_L.prefab
+++ b/Assets/LeapMotion/Prefabs/HandModelsNonHuman/CapsuleHand_L.prefab
@@ -5,11 +5,11 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 464466}
-  - 114: {fileID: 11407378}
-  - 114: {fileID: 11478924}
+  - component: {fileID: 464466}
+  - component: {fileID: 11407378}
+  - component: {fileID: 11478924}
   m_Layer: 0
   m_Name: CapsuleHand_L
   m_TagString: Untagged
@@ -23,13 +23,13 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 188576}
-  m_LocalRotation: {x: 0.00000011520229, y: 0.70710695, z: 0.7071066, w: 0.00000011520235}
+  m_LocalRotation: {x: 0.000000115202326, y: -0.7071067, z: -0.7071068, w: -0.00000011520231}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: -89.980194, y: 180, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: -89.980194, y: 180, z: 0}
 --- !u!114 &11407378
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -41,6 +41,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a04122797dd84ca43a07055f12d91e0f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  group:
+    GroupName: 
+    _handPool: {fileID: 0}
+    LeftModel: {fileID: 0}
+    IsLeftToBeSpawned: 0
+    RightModel: {fileID: 0}
+    IsRightToBeSpawned: 0
+    modelList: []
+    modelsCheckedOut: []
+    IsEnabled: 1
+    CanDuplicate: 0
+    HandPostProcesses:
+      m_PersistentCalls:
+        m_Calls: []
+      m_TypeName: Leap.Unity.Hands+HandEvent, Assembly-CSharp, Version=0.0.0.0, Culture=neutral,
+        PublicKeyToken=null
   handedness: 0
   _showArm: 1
   _material: {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/LeapMotion/Prefabs/HandModelsNonHuman/CapsuleHand_R.prefab
+++ b/Assets/LeapMotion/Prefabs/HandModelsNonHuman/CapsuleHand_R.prefab
@@ -5,11 +5,11 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 464466}
-  - 114: {fileID: 11407378}
-  - 114: {fileID: 11478924}
+  - component: {fileID: 464466}
+  - component: {fileID: 11407378}
+  - component: {fileID: 11478924}
   m_Layer: 0
   m_Name: CapsuleHand_R
   m_TagString: Untagged
@@ -23,13 +23,13 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 188576}
-  m_LocalRotation: {x: 0.00000011520229, y: 0.70710695, z: 0.7071066, w: 0.00000011520235}
+  m_LocalRotation: {x: 0.000000115202326, y: -0.7071067, z: -0.7071068, w: -0.00000011520231}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: -89.980194, y: 180, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: -89.980194, y: 180, z: 0}
 --- !u!114 &11407378
 MonoBehaviour:
   m_ObjectHideFlags: 1
@@ -41,6 +41,22 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a04122797dd84ca43a07055f12d91e0f, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  group:
+    GroupName: 
+    _handPool: {fileID: 0}
+    LeftModel: {fileID: 0}
+    IsLeftToBeSpawned: 0
+    RightModel: {fileID: 0}
+    IsRightToBeSpawned: 0
+    modelList: []
+    modelsCheckedOut: []
+    IsEnabled: 1
+    CanDuplicate: 0
+    HandPostProcesses:
+      m_PersistentCalls:
+        m_Calls: []
+      m_TypeName: Leap.Unity.Hands+HandEvent, Assembly-CSharp, Version=0.0.0.0, Culture=neutral,
+        PublicKeyToken=null
   handedness: 1
   _showArm: 1
   _material: {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}

--- a/Assets/LeapMotion/Scenes/Leap_Hands_Demo_VR.unity
+++ b/Assets/LeapMotion/Scenes/Leap_Hands_Demo_VR.unity
@@ -1,19 +1,19 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
 --- !u!29 &1
-SceneSettings:
+OcclusionCullingSettings:
   m_ObjectHideFlags: 0
-  m_PVSData: 
-  m_PVSObjectsArray: []
-  m_PVSPortalsArray: []
+  serializedVersion: 2
   m_OcclusionBakeSettings:
     smallestOccluder: 5
     smallestHole: 0.25
     backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
 --- !u!104 &2
 RenderSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 7
+  serializedVersion: 8
   m_Fog: 0
   m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   m_FogMode: 3
@@ -25,6 +25,7 @@ RenderSettings:
   m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
   m_AmbientIntensity: 1
   m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
   m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
   m_HaloStrength: 0.5
   m_FlareStrength: 1
@@ -37,11 +38,11 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44692546, g: 0.49678695, b: 0.5750854, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 7
+  serializedVersion: 9
   m_GIWorkflowMode: 0
   m_GISettings:
     serializedVersion: 2
@@ -53,7 +54,7 @@ LightmapSettings:
     m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 1
   m_LightmapEditorSettings:
-    serializedVersion: 4
+    serializedVersion: 8
     m_Resolution: 2
     m_BakeResolution: 40
     m_TextureWidth: 1024
@@ -66,29 +67,46 @@ LightmapSettings:
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 1
     m_TextureCompression: 1
-    m_DirectLightInLightProbes: 1
     m_FinalGather: 0
     m_FinalGatherFiltering: 1
     m_FinalGatherRayCount: 1024
     m_ReflectionCompression: 2
+    m_MixedBakeMode: 1
+    m_BakeBackend: 0
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 500
+    m_PVRBounces: 2
+    m_PVRFiltering: 0
+    m_PVRFilteringMode: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousColorSigma: 1
+    m_PVRFilteringAtrousNormalSigma: 1
+    m_PVRFilteringAtrousPositionSigma: 1
   m_LightingDataAsset: {fileID: 0}
-  m_RuntimeCPUUsage: 25
+  m_ShadowMaskMode: 2
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
   m_ObjectHideFlags: 0
   m_BuildSettings:
     serializedVersion: 2
+    agentTypeID: 0
     agentRadius: 0.5
     agentHeight: 2
     agentSlope: 45
     agentClimb: 0.4
     ledgeDropHeight: 0
     maxJumpAcrossDistance: 0
-    accuratePlacement: 0
     minRegionArea: 2
-    cellSize: 0.16666667
     manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
   m_NavMeshData: {fileID: 0}
 --- !u!4 &44000905 stripped
 Transform:
@@ -99,12 +117,12 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 117698, guid: 18d6bf9063dcb1842be63f411fd9fc26, type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 1576743646}
-  - 114: {fileID: 72891528}
-  - 114: {fileID: 72891527}
-  - 114: {fileID: 72891526}
+  - component: {fileID: 1576743646}
+  - component: {fileID: 72891528}
+  - component: {fileID: 72891527}
+  - component: {fileID: 72891526}
   m_Layer: 0
   m_Name: LeapHandController
   m_TagString: Untagged
@@ -136,6 +154,11 @@ MonoBehaviour:
     modelsCheckedOut: []
     IsEnabled: 1
     CanDuplicate: 1
+    HandPostProcesses:
+      m_PersistentCalls:
+        m_Calls: []
+      m_TypeName: Leap.Unity.Hands+HandEvent, Assembly-CSharp, Version=0.0.0.0, Culture=neutral,
+        PublicKeyToken=null
   - GroupName: Physics_Hands
     _handPool: {fileID: 0}
     LeftModel: {fileID: 1414805578}
@@ -146,6 +169,11 @@ MonoBehaviour:
     modelsCheckedOut: []
     IsEnabled: 1
     CanDuplicate: 1
+    HandPostProcesses:
+      m_PersistentCalls:
+        m_Calls: []
+      m_TypeName: Leap.Unity.Hands+HandEvent, Assembly-CSharp, Version=0.0.0.0, Culture=neutral,
+        PublicKeyToken=null
 --- !u!114 &72891527
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -160,11 +188,10 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _isHeadMounted: 1
   _temporalWarping: {fileID: 1928180895}
-  _reuseFramesForPhysics: 0
+  _frameOptimization: 0
   _overrideDeviceType: 1
   _overrideDeviceTypeWith: 1
-  _useInterpolation: 1
-  _interpolationDelay: 15
+  _updateHandInPrecull: 0
 --- !u!114 &72891528
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -182,13 +209,13 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 101514, guid: 18d6bf9063dcb1842be63f411fd9fc26, type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 266907292}
-  - 81: {fileID: 266907297}
-  - 20: {fileID: 266907296}
-  - 114: {fileID: 266907295}
-  - 114: {fileID: 266907293}
+  - component: {fileID: 266907292}
+  - component: {fileID: 266907297}
+  - component: {fileID: 266907296}
+  - component: {fileID: 266907295}
+  - component: {fileID: 266907293}
   m_Layer: 0
   m_Name: CenterEyeAnchor
   m_TagString: MainCamera
@@ -205,11 +232,11 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1928180894}
   m_Father: {fileID: 1805543667}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &266907293
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -269,6 +296,8 @@ Camera:
   m_TargetDisplay: 0
   m_TargetEye: 3
   m_HDR: 0
+  m_AllowMSAA: 1
+  m_ForceIntoRT: 0
   m_OcclusionCulling: 1
   m_StereoConvergence: 10
   m_StereoSeparation: 0.022
@@ -286,9 +315,9 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 395650195}
+  - component: {fileID: 395650195}
   m_Layer: 0
   m_Name: HandModels
   m_TagString: Untagged
@@ -305,7 +334,6 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 983145289}
   - {fileID: 44000905}
@@ -313,6 +341,7 @@ Transform:
   - {fileID: 869913656}
   m_Father: {fileID: 1805543667}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &599167946
 Prefab:
   m_ObjectHideFlags: 0
@@ -2466,14 +2495,6 @@ Prefab:
       propertyPath: m_RootOrder
       value: 2
       objectReference: {fileID: 0}
-    - target: {fileID: 464466, guid: 869d20cdda15af24aab9e72b5f2eec78, type: 2}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -89.980194
-      objectReference: {fileID: 0}
-    - target: {fileID: 464466, guid: 869d20cdda15af24aab9e72b5f2eec78, type: 2}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 180
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 869d20cdda15af24aab9e72b5f2eec78, type: 2}
   m_IsPrefabParent: 0
@@ -2492,19 +2513,19 @@ Transform:
   m_LocalRotation: {x: 0.000000115202326, y: -0.7071067, z: -0.7071068, w: -0.00000011520231}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: -89.980194, y: 180, z: 0}
   m_Children: []
   m_Father: {fileID: 1928180894}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: -89.980194, y: 180, z: 0}
 --- !u!1 &1805543666
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 142376, guid: 18d6bf9063dcb1842be63f411fd9fc26, type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 1805543667}
-  - 114: {fileID: 1805543668}
+  - component: {fileID: 1805543667}
+  - component: {fileID: 1805543668}
   m_Layer: 0
   m_Name: LMHeadMountedRig
   m_TagString: Untagged
@@ -2521,12 +2542,12 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 266907292}
   - {fileID: 395650195}
   m_Father: {fileID: 0}
   m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1805543668
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2546,10 +2567,10 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 111148, guid: 18d6bf9063dcb1842be63f411fd9fc26, type: 2}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 1928180894}
-  - 114: {fileID: 1928180895}
+  - component: {fileID: 1928180894}
+  - component: {fileID: 1928180895}
   m_Layer: 0
   m_Name: LeapSpace
   m_TagString: Untagged
@@ -2566,11 +2587,11 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1576743646}
   m_Father: {fileID: 266907292}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1928180895
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2635,14 +2656,6 @@ Prefab:
       propertyPath: m_RootOrder
       value: 3
       objectReference: {fileID: 0}
-    - target: {fileID: 464466, guid: 39d18871c11b53c4082d8202e3db68a3, type: 2}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -89.980194
-      objectReference: {fileID: 0}
-    - target: {fileID: 464466, guid: 39d18871c11b53c4082d8202e3db68a3, type: 2}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 180
-      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 39d18871c11b53c4082d8202e3db68a3, type: 2}
   m_IsPrefabParent: 0
@@ -2651,10 +2664,10 @@ GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  serializedVersion: 4
+  serializedVersion: 5
   m_Component:
-  - 4: {fileID: 1966885504}
-  - 108: {fileID: 1966885503}
+  - component: {fileID: 1966885504}
+  - component: {fileID: 1966885503}
   m_Layer: 0
   m_Name: Directional Light
   m_TagString: Untagged
@@ -2669,7 +2682,7 @@ Light:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1966885502}
   m_Enabled: 1
-  serializedVersion: 7
+  serializedVersion: 8
   m_Type: 1
   m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
   m_Intensity: 1
@@ -2694,6 +2707,8 @@ Light:
   m_Lightmapping: 4
   m_AreaSize: {x: 1, y: 1}
   m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
   m_ShadowRadius: 0
   m_ShadowAngle: 0
 --- !u!4 &1966885504
@@ -2705,7 +2720,7 @@ Transform:
   m_LocalRotation: {x: 0.40821794, y: -0.23456973, z: 0.109381676, w: 0.87542605}
   m_LocalPosition: {x: 0, y: 3, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_Children: []
   m_Father: {fileID: 0}
   m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/LeapMotion/Scripts/Hands/CapsuleHand.cs
+++ b/Assets/LeapMotion/Scripts/Hands/CapsuleHand.cs
@@ -1,13 +1,12 @@
 ﻿using UnityEngine;
 using System.Collections;
 using System.Collections.Generic;
-using Leap;
-using System;
+using Leap.Unity.Attributes;
 
 namespace Leap.Unity {
   /** A basic Leap hand model constructed dynamically vs. using pre-existing geometry*/
   public class CapsuleHand : IHandModel {
-
+    private const float CYLINDER_MESH_RESOLUTION = 0.1f; //in centimeters, meshes within this resolution will be re-used
     private const int THUMB_BASE_INDEX = (int)Finger.FingerType.TYPE_THUMB * 4;
     private const int PINKY_BASE_INDEX = (int)Finger.FingerType.TYPE_PINKY * 4;
 
@@ -32,28 +31,13 @@ namespace Leap.Unity {
     [SerializeField]
     private Mesh _sphereMesh;
 
+    [MinValue(3)]
     [SerializeField]
     private int _cylinderResolution = 12;
 
-    private bool _hasGeneratedMeshes = false;
-    private Material jointMat;
-
-    [SerializeField, HideInInspector]
-    private List<Transform> _serializedTransforms;
-
-    private Transform[] _jointSpheres;
-    private Transform mockThumbJointSphere;
-    private Transform palmPositionSphere;
-
-    private Transform wristPositionSphere;
-
-    private List<Renderer> _armRenderers;
-    private List<Transform> _cylinderTransforms;
-    private List<Transform> _sphereATransforms;
-    private List<Transform> _sphereBTransforms;
-
-    private Transform armFrontLeft, armFrontRight, armBackLeft, armBackRight;
-    private Hand hand_;
+    private Material _sphereMat;
+    private Hand _hand;
+    private Vector3[] _spherePositions;
 
     public override ModelType HandModelType {
       get {
@@ -73,257 +57,162 @@ namespace Leap.Unity {
     }
 
     public override Hand GetLeapHand() {
-      return hand_;
+      return _hand;
     }
 
     public override void SetLeapHand(Hand hand) {
-      hand_ = hand;
-    }
-
-    void OnValidate() {
-      //Resolution must be at least 3!
-      _cylinderResolution = Mathf.Max(3, _cylinderResolution);
-
-      //Update visibility on validate so that the user can toggle in real-time
-      if (_armRenderers != null) {
-        updateArmVisibility();
-      }
+      _hand = hand;
     }
 
     public override void InitHand() {
       if (_material != null) {
-        jointMat = new Material(_material);
-        jointMat.hideFlags = HideFlags.DontSaveInEditor;
+        _sphereMat = new Material(_material);
+        _sphereMat.hideFlags = HideFlags.DontSaveInEditor;
       }
+    }
 
-      if (_serializedTransforms != null) {
-        for (int i = 0; i < _serializedTransforms.Count; i++) {
-          var obj = _serializedTransforms[i];
-          if (obj != null) {
-            DestroyImmediate(obj.gameObject);
-          }
-        }
-        _serializedTransforms.Clear();
-      } else {
-        _serializedTransforms = new List<Transform>();
-      }
-
-      _jointSpheres = new Transform[4 * 5];
-      _armRenderers = new List<Renderer>();
-      _cylinderTransforms = new List<Transform>();
-      _sphereATransforms = new List<Transform>();
-      _sphereBTransforms = new List<Transform>();
-
-      createSpheres();
-      createCylinders();
-
-      updateArmVisibility();
-
-      _hasGeneratedMeshes = false;
+    private void OnValidate() {
+      _meshMap.Clear();
     }
 
     public override void BeginHand() {
       base.BeginHand();
 
-      if (hand_.IsLeft) {
-        jointMat.color = _leftColorList[_leftColorIndex];
+      if (_hand.IsLeft) {
+        _sphereMat.color = _leftColorList[_leftColorIndex];
         _leftColorIndex = (_leftColorIndex + 1) % _leftColorList.Length;
       } else {
-        jointMat.color = _rightColorList[_rightColorIndex];
+        _sphereMat.color = _rightColorList[_rightColorIndex];
         _rightColorIndex = (_rightColorIndex + 1) % _rightColorList.Length;
       }
     }
 
     public override void UpdateHand() {
-      //Update the spheres first
-      updateSpheres();
+      if (_spherePositions == null) {
+        _spherePositions = new Vector3[4 * 5];
+      }
 
-      //Update Arm only if we need to
+      if (_sphereMat == null) {
+        _sphereMat = new Material(_material);
+        _sphereMat.hideFlags = HideFlags.DontSaveInEditor;
+      }
+
+      //Update all joint spheres in the fingers
+      foreach (var finger in _hand.Fingers) {
+        for (int j = 0; j < 4; j++) {
+          int key = getFingerJointIndex((int)finger.Type, j);
+
+          Vector3 position = finger.Bone((Bone.BoneType)j).NextJoint.ToVector3();
+          _spherePositions[key] = position;
+
+          drawSphere(position);
+        }
+      }
+
+      //Now we just have a few more spheres for the hands
+      //PalmPos, WristPos, and mockThumbJointPos, which is derived and not taken from the frame obj
+
+      Vector3 palmPosition = _hand.PalmPosition.ToVector3();
+      drawSphere(palmPosition, PALM_RADIUS);
+
+      Vector3 wristPos = _hand.PalmPosition.ToVector3();
+      drawSphere(wristPos);
+
+      Vector3 thumbBaseToPalm = _spherePositions[THUMB_BASE_INDEX] - _hand.PalmPosition.ToVector3();
+      Vector3 mockThumbJointPos = _hand.PalmPosition.ToVector3() + Vector3.Reflect(thumbBaseToPalm, _hand.Basis.xBasis.ToVector3());
+      drawSphere(mockThumbJointPos);
+
+      //If we want to show the arm, do the calculations and display the meshes
       if (_showArm) {
-        updateArm();
+        var arm = _hand.Arm;
+        Vector3 right = arm.Basis.xBasis.ToVector3() * arm.Width * 0.7f * 0.5f;
+        Vector3 wrist = arm.WristPosition.ToVector3();
+        Vector3 elbow = arm.ElbowPosition.ToVector3();
+
+        float armLength = Vector3.Distance(wrist, elbow);
+        wrist -= arm.Direction.ToVector3() * armLength * 0.05f;
+
+        Vector3 armFrontRight = wrist + right;
+        Vector3 armFrontLeft = wrist - right;
+        Vector3 armBackRight = elbow + right;
+        Vector3 armBackLeft = elbow - right;
+
+        drawSphere(armFrontRight);
+        drawSphere(armFrontLeft);
+        drawSphere(armBackLeft);
+        drawSphere(armBackRight);
+
+        drawCylinder(armFrontLeft, armFrontRight);
+        drawCylinder(armBackLeft, armBackRight);
+        drawCylinder(armFrontLeft, armBackLeft);
+        drawCylinder(armFrontRight, armBackRight);
       }
 
-      //The cylinder transforms are deterimined by the spheres they are connected to
-      updateCylinders();
-    }
-
-    //Transform updating methods
-
-    private void updateSpheres() {
-      //Update all spheres
-      List<Finger> fingers = hand_.Fingers;
-      for (int i = 0; i < fingers.Count; i++) {
-        Finger finger = fingers[i];
-        for (int j = 0; j < 4; j++) {
-          int key = getFingerJointIndex((int)finger.Type, j);
-          Transform sphere = _jointSpheres[key];
-          sphere.position = finger.Bone((Bone.BoneType)j).NextJoint.ToVector3();
-        }
-      }
-
-      palmPositionSphere.position = hand_.PalmPosition.ToVector3();
-
-      Vector3 wristPos = hand_.PalmPosition.ToVector3();
-      wristPositionSphere.position = wristPos;
-
-      Transform thumbBase = _jointSpheres[THUMB_BASE_INDEX];
-
-      Vector3 thumbBaseToPalm = thumbBase.position - hand_.PalmPosition.ToVector3();
-      mockThumbJointSphere.position = hand_.PalmPosition.ToVector3() + Vector3.Reflect(thumbBaseToPalm, hand_.Basis.xBasis.ToVector3());
-    }
-
-    private void updateArm() {
-      var arm = hand_.Arm;
-      Vector3 right = arm.Basis.xBasis.ToVector3() * arm.Width * 0.7f * 0.5f;
-      Vector3 wrist = arm.WristPosition.ToVector3();
-      Vector3 elbow = arm.ElbowPosition.ToVector3();
-
-      float armLength = Vector3.Distance(wrist, elbow);
-      wrist -= arm.Direction.ToVector3() * armLength * 0.05f;
-
-      armFrontRight.position = wrist + right;
-      armFrontLeft.position = wrist - right;
-      armBackRight.position = elbow + right;
-      armBackLeft.position = elbow - right;
-    }
-
-    private void updateCylinders() {
-      for (int i = 0; i < _cylinderTransforms.Count; i++) {
-        Transform cylinder = _cylinderTransforms[i];
-        Transform sphereA = _sphereATransforms[i];
-        Transform sphereB = _sphereBTransforms[i];
-
-        Vector3 delta = sphereA.position - sphereB.position;
-
-        if (!_hasGeneratedMeshes) {
-          MeshFilter filter = cylinder.GetComponent<MeshFilter>();
-          filter.sharedMesh = generateCylinderMesh(delta.magnitude / transform.lossyScale.x);
-        }
-
-        cylinder.position = sphereA.position;
-
-        if (delta.sqrMagnitude <= Mathf.Epsilon) {
-          //Two spheres are at the same location, no rotation will be found
-          continue;
-        }
-
-        cylinder.LookAt(sphereB);
-      }
-
-      _hasGeneratedMeshes = true;
-    }
-
-    private void updateArmVisibility() {
-      for (int i = 0; i < _armRenderers.Count; i++) {
-        _armRenderers[i].enabled = _showArm;
-      }
-    }
-
-    //Geometry creation methods
-
-    private void createSpheres() {
-      //Create spheres for finger joints
-      List<Finger> fingers = hand_.Fingers;
-      for (int i = 0; i < fingers.Count; i++) {
-        Finger finger = fingers[i];
-        for (int j = 0; j < 4; j++) {
-          int key = getFingerJointIndex((int)finger.Type, j);
-          _jointSpheres[key] = createSphere("Joint", SPHERE_RADIUS);
-        }
-      }
-
-      mockThumbJointSphere = createSphere("MockJoint", SPHERE_RADIUS);
-      palmPositionSphere = createSphere("PalmPosition", PALM_RADIUS);
-      wristPositionSphere = createSphere("WristPosition", SPHERE_RADIUS);
-
-      armFrontLeft = createSphere("ArmFrontLeft", SPHERE_RADIUS, true);
-      armFrontRight = createSphere("ArmFrontRight", SPHERE_RADIUS, true);
-      armBackLeft = createSphere("ArmBackLeft", SPHERE_RADIUS, true);
-      armBackRight = createSphere("ArmBackRight", SPHERE_RADIUS, true);
-    }
-
-    private void createCylinders() {
-      //Create cylinders between finger joints
+      //Draw cylinders between finger joints
       for (int i = 0; i < 5; i++) {
         for (int j = 0; j < 3; j++) {
           int keyA = getFingerJointIndex(i, j);
           int keyB = getFingerJointIndex(i, j + 1);
 
-          Transform sphereA = _jointSpheres[keyA];
-          Transform sphereB = _jointSpheres[keyB];
+          Vector3 posA = _spherePositions[keyA];
+          Vector3 posB = _spherePositions[keyB];
 
-          createCylinder("Finger Joint", sphereA, sphereB);
+          drawCylinder(posA, posB);
         }
       }
 
-      //Create cylinders between finger knuckles
+      //Draw cylinders between finger knuckles
       for (int i = 0; i < 4; i++) {
         int keyA = getFingerJointIndex(i, 0);
         int keyB = getFingerJointIndex(i + 1, 0);
 
-        Transform sphereA = _jointSpheres[keyA];
-        Transform sphereB = _jointSpheres[keyB];
+        Vector3 posA = _spherePositions[keyA];
+        Vector3 posB = _spherePositions[keyB];
 
-        createCylinder("Hand Joints", sphereA, sphereB);
+        drawCylinder(posA, posB);
       }
 
-      //Create the rest of the hand
-      Transform thumbBase = _jointSpheres[THUMB_BASE_INDEX];
-      Transform pinkyBase = _jointSpheres[PINKY_BASE_INDEX];
-      createCylinder("Hand Bottom", thumbBase, mockThumbJointSphere);
-      createCylinder("Hand Side", pinkyBase, mockThumbJointSphere);
+      //Draw the rest of the hand
+      drawCylinder(mockThumbJointPos, THUMB_BASE_INDEX);
+      drawCylinder(mockThumbJointPos, PINKY_BASE_INDEX);
+    }
 
-      createCylinder("ArmFront", armFrontLeft, armFrontRight, true);
-      createCylinder("ArmBack", armBackLeft, armBackRight, true);
-      createCylinder("ArmLeft", armFrontLeft, armBackLeft, true);
-      createCylinder("ArmRight", armFrontRight, armBackRight, true);
+    private void drawSphere(Vector3 position, float radius = SPHERE_RADIUS) {
+      //multiply radius by 2 because the default unity sphere has a radius of 0.5 meters at scale 1.
+      Graphics.DrawMesh(_sphereMesh, Matrix4x4.TRS(position, Quaternion.identity, Vector3.one * radius * 2.0f), _sphereMat, 0);
+    }
+
+    private void drawCylinder(Vector3 a, Vector3 b) {
+      float length = (a - b).magnitude;
+
+      Graphics.DrawMesh(getCylinderMesh(length),
+                        Matrix4x4.TRS(a, Quaternion.LookRotation(b - a), Vector3.one),
+                        _material,
+                        gameObject.layer);
+    }
+
+    private void drawCylinder(int a, int b) {
+      drawCylinder(_spherePositions[a], _spherePositions[b]);
+    }
+
+    private void drawCylinder(Vector3 a, int b) {
+      drawCylinder(a, _spherePositions[b]);
     }
 
     private int getFingerJointIndex(int fingerIndex, int jointIndex) {
       return fingerIndex * 4 + jointIndex;
     }
 
-    private Transform createSphere(string name, float radius, bool isPartOfArm = false) {
-      GameObject sphere = new GameObject(name);
-      _serializedTransforms.Add(sphere.transform);
+    private Dictionary<int, Mesh> _meshMap = new Dictionary<int, Mesh>();
+    private Mesh getCylinderMesh(float length) {
+      int lengthKey = Mathf.RoundToInt(length * 100 / CYLINDER_MESH_RESOLUTION);
 
-      sphere.AddComponent<MeshFilter>().mesh = _sphereMesh;
-      sphere.AddComponent<MeshRenderer>().sharedMaterial = jointMat;
-      sphere.transform.parent = transform;
-      sphere.transform.localScale = Vector3.one * radius * 2;
-
-      sphere.hideFlags = HideFlags.DontSave | HideFlags.HideInHierarchy | HideFlags.HideInInspector;
-      sphere.layer = gameObject.layer;
-
-      if (isPartOfArm) {
-        _armRenderers.Add(sphere.GetComponent<Renderer>());
+      Mesh mesh;
+      if (_meshMap.TryGetValue(lengthKey, out mesh)) {
+        return mesh;
       }
 
-      return sphere.transform;
-    }
-
-    private void createCylinder(string name, Transform jointA, Transform jointB, bool isPartOfArm = false) {
-      GameObject cylinder = new GameObject(name);
-      _serializedTransforms.Add(cylinder.transform);
-
-      cylinder.AddComponent<MeshFilter>();
-      cylinder.AddComponent<MeshRenderer>().sharedMaterial = _material;
-      cylinder.transform.parent = transform;
-
-      _cylinderTransforms.Add(cylinder.transform);
-      _sphereATransforms.Add(jointA);
-      _sphereBTransforms.Add(jointB);
-
-      cylinder.gameObject.layer = gameObject.layer;
-      cylinder.hideFlags = HideFlags.DontSave | HideFlags.HideInHierarchy | HideFlags.HideInInspector;
-
-      if (isPartOfArm) {
-        _armRenderers.Add(cylinder.GetComponent<Renderer>());
-      }
-    }
-
-    private Mesh generateCylinderMesh(float length) {
-      Mesh mesh = new Mesh();
+      mesh = new Mesh();
       mesh.name = "GeneratedCylinder";
       mesh.hideFlags = HideFlags.DontSave;
 
@@ -363,6 +252,8 @@ namespace Leap.Unity {
       mesh.RecalculateBounds();
       mesh.RecalculateNormals();
       mesh.UploadMeshData(true);
+
+      _meshMap[lengthKey] = mesh;
 
       return mesh;
     }

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 5.6.0f3
+m_EditorVersion: 5.6.0f1


### PR DESCRIPTION
Drastically simplified how CapsuleHand works.  Now instead of procedurally creating invisible game objects and adding mesh renderers to them, just use Graphics.DrawMesh!  No more state to keep track of, so things got a lot simpler.  This fixes those tricky edge-case bugs where the serialization happens in an unexpected order, leading to the internal state becoming invalid.

This also fixes a longstanding bug with capsule hand, where they would only calculate the mesh for the cylinders once!  Now they are dynamically created, cached, and reused when they are needed, even if the hand changes shape over time.