### PR TITLE
Bugfixes / sprite usability / curved example

### DIFF
--- a/Assets/LeapMotion/Scripts/Query/Where.cs
+++ b/Assets/LeapMotion/Scripts/Query/Where.cs
@@ -36,5 +36,9 @@ namespace Leap.Unity.Query {
     public QueryWrapper<QueryType, WhereOp<QueryType, QueryOp>> NonNull() {
       return Where(obj => obj != null);
     }
+
+    public QueryWrapper<QueryType, WhereOp<QueryType, QueryOp>> ValidUnityObjs() {
+      return Where(obj => (obj as UnityEngine.Object) != null);
+    }
   }
 }

--- a/Assets/LeapMotion/Scripts/Utils/Utils.cs
+++ b/Assets/LeapMotion/Scripts/Utils/Utils.cs
@@ -123,6 +123,10 @@ namespace Leap.Unity {
       return false;
     }
 
+    public static float Area(this Rect rect) {
+      return rect.width * rect.height;
+    }
+
     #endregion
 
     #region Math Utils

--- a/Assets/LeapMotionModules/GraphicRenderer/Scenes/Curved Space Examples.unity
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scenes/Curved Space Examples.unity
@@ -108,306 +108,61 @@ NavMeshSettings:
     tileSize: 256
     accuratePlacement: 0
   m_NavMeshData: {fileID: 0}
---- !u!1 &19133424
+--- !u!1 &560921526
 GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   serializedVersion: 5
   m_Component:
-  - component: {fileID: 19133427}
-  - component: {fileID: 19133426}
-  - component: {fileID: 19133425}
+  - component: {fileID: 560921527}
+  - component: {fileID: 560921528}
+  - component: {fileID: 560921529}
   m_Layer: 0
-  m_Name: Panel
+  m_Name: GameObject (1)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!114 &19133425
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 19133424}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d2c8779b1bdf86c4dbcbe18f17e44e53, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  graphic: {fileID: 19133426}
-  feature: {fileID: 652095307}
-  texture: {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
---- !u!114 &19133426
-MonoBehaviour:
+--- !u!4 &560921527
+Transform:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 19133424}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 57cf8ea40c7f8fc4fa6a3afb12becedb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _anchor: {fileID: 652095308}
-  _featureData:
-  - {fileID: 19133425}
-  _attachedGroup: {fileID: 652095309}
-  _preferredRendererType:
-    _fullName: Leap.Unity.GraphicalRenderer.LeapDynamicRenderer
-  vertexColor: {r: 1, g: 1, b: 1, a: 1}
-  _sourceData: {fileID: 19133425}
-  _resolutionType: 1
-  _resolution_vert_x: 5
-  _resolution_vert_y: 3
-  _resolution_verts_per_meter: {x: 20, y: 20}
-  _size: {x: 0.2399, y: 0.1311}
-  _nineSliced: 0
---- !u!224 &19133427
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 19133424}
+  m_GameObject: {fileID: 560921526}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 266862084}
-  - {fileID: 191866187}
-  - {fileID: 1694938864}
-  - {fileID: 195769539}
+  m_Children: []
   m_Father: {fileID: 652095311}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0.2399, y: 0.1311}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &191866184
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 191866187}
-  - component: {fileID: 191866186}
-  - component: {fileID: 191866185}
-  m_Layer: 0
-  m_Name: Panel (2)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &191866185
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 191866184}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d2c8779b1bdf86c4dbcbe18f17e44e53, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  graphic: {fileID: 191866186}
-  feature: {fileID: 652095307}
-  texture: {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
---- !u!114 &191866186
+--- !u!114 &560921528
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 191866184}
+  m_GameObject: {fileID: 560921526}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 57cf8ea40c7f8fc4fa6a3afb12becedb, type: 3}
+  m_Script: {fileID: 11500000, guid: 0df85c45a8c550248bd0a01169f8eeb8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _anchor: {fileID: 652095308}
-  _featureData:
-  - {fileID: 191866185}
-  _attachedGroup: {fileID: 652095309}
-  _preferredRendererType:
-    _fullName: Leap.Unity.GraphicalRenderer.LeapDynamicRenderer
-  vertexColor: {r: 1, g: 1, b: 1, a: 1}
-  _sourceData: {fileID: 191866185}
-  _resolutionType: 1
-  _resolution_vert_x: 0
-  _resolution_vert_y: 0
-  _resolution_verts_per_meter: {x: 20, y: 20}
-  _size: {x: 0.025, y: 0.024999999}
-  _nineSliced: 0
---- !u!224 &191866187
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 191866184}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.002}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 19133427}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0.030000001, y: 0.03}
-  m_SizeDelta: {x: 0.025, y: 0.024999999}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &195769536
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 195769539}
-  - component: {fileID: 195769538}
-  - component: {fileID: 195769537}
-  m_Layer: 0
-  m_Name: Panel (4)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &195769537
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 195769536}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d2c8779b1bdf86c4dbcbe18f17e44e53, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  graphic: {fileID: 195769538}
-  feature: {fileID: 652095307}
-  texture: {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
---- !u!114 &195769538
+  prefab: {fileID: 1892722084810738, guid: e63b4091afde9744ab1744624068734c, type: 2}
+--- !u!114 &560921529
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 195769536}
+  m_GameObject: {fileID: 560921526}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 57cf8ea40c7f8fc4fa6a3afb12becedb, type: 3}
+  m_Script: {fileID: 11500000, guid: 1b7dca36e8e5c88459b2626007befebc, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _anchor: {fileID: 652095308}
-  _featureData:
-  - {fileID: 195769537}
-  _attachedGroup: {fileID: 652095309}
-  _preferredRendererType:
-    _fullName: Leap.Unity.GraphicalRenderer.LeapDynamicRenderer
-  vertexColor: {r: 1, g: 1, b: 1, a: 1}
-  _sourceData: {fileID: 195769537}
-  _resolutionType: 1
-  _resolution_vert_x: 1
-  _resolution_vert_y: 0
-  _resolution_verts_per_meter: {x: 20, y: 20}
-  _size: {x: 0.025000006, y: 0.025}
-  _nineSliced: 0
---- !u!224 &195769539
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 195769536}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.002}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 19133427}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 1, y: 1}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -0.03, y: -0.030000001}
-  m_SizeDelta: {x: 0.025000006, y: 0.025}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &266862083
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 266862084}
-  - component: {fileID: 266862085}
-  - component: {fileID: 266862086}
-  m_Layer: 0
-  m_Name: Panel (1)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &266862084
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 266862083}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.002}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 19133427}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 0.030000001, y: -0.03}
-  m_SizeDelta: {x: 0.025, y: 0.025}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &266862085
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 266862083}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 57cf8ea40c7f8fc4fa6a3afb12becedb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _anchor: {fileID: 652095308}
-  _featureData:
-  - {fileID: 266862086}
-  _attachedGroup: {fileID: 652095309}
-  _preferredRendererType:
-    _fullName: Leap.Unity.GraphicalRenderer.LeapDynamicRenderer
-  vertexColor: {r: 1, g: 1, b: 1, a: 1}
-  _sourceData: {fileID: 266862086}
-  _resolutionType: 1
-  _resolution_vert_x: 0
-  _resolution_vert_y: 0
-  _resolution_verts_per_meter: {x: 20, y: 20}
-  _size: {x: 0.025, y: 0.025}
-  _nineSliced: 0
---- !u!114 &266862086
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 266862083}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d2c8779b1bdf86c4dbcbe18f17e44e53, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  graphic: {fileID: 266862085}
-  feature: {fileID: 652095307}
-  texture: {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
+  parent: {fileID: 652095308}
+  space: {fileID: 652095308}
 --- !u!1 &652095305
 GameObject:
   m_ObjectHideFlags: 0
@@ -457,7 +212,7 @@ MonoBehaviour:
     _format: 5
     _maxAtlasSize: 4096
     _extraTextures: []
-  _material: {fileID: 935407115}
+  _material: {fileID: 734205479}
   _meshes: {fileID: 11400000, guid: 4fd6614690fb4e24e8d492c97f79eb16, type: 2}
   _packedTextures: {fileID: 11400000, guid: 777eae74292749e419af1609ff26f4ef, type: 2}
   _atlasUvs:
@@ -511,12 +266,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 36ae2dc675d304041af3c95461f228e2, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  featureData:
-  - {fileID: 19133425}
-  - {fileID: 266862086}
-  - {fileID: 191866185}
-  - {fileID: 1694938866}
-  - {fileID: 195769537}
+  featureData: []
   propertyName: _MainTex
   channel: 1
 --- !u!114 &652095308
@@ -548,16 +298,11 @@ MonoBehaviour:
   _features:
   - {fileID: 652095307}
   _renderer: {fileID: 652095310}
-  _graphics:
-  - {fileID: 19133426}
-  - {fileID: 266862085}
-  - {fileID: 191866186}
-  - {fileID: 1694938865}
-  - {fileID: 195769538}
+  _graphics: []
   _supportInfo:
   - support: 0
     message: 
-  _addRemoveSupported: 0
+  _addRemoveSupported: 1
 --- !u!114 &652095310
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -583,11 +328,11 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 19133427}
+  - {fileID: 560921527}
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!21 &935407115
+--- !u!21 &734205479
 Material:
   serializedVersion: 6
   m_ObjectHideFlags: 0
@@ -605,7 +350,7 @@ Material:
     serializedVersion: 3
     m_TexEnvs:
     - _MainTex:
-        m_Texture: {fileID: 28089171662022380, guid: 777eae74292749e419af1609ff26f4ef,
+        m_Texture: {fileID: 28359733727383112, guid: 777eae74292749e419af1609ff26f4ef,
           type: 2}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
@@ -719,80 +464,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
---- !u!1 &1694938863
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 1694938864}
-  - component: {fileID: 1694938865}
-  - component: {fileID: 1694938866}
-  m_Layer: 0
-  m_Name: Panel (3)
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1694938864
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1694938863}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.002}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 19133427}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 1, y: 0}
-  m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: -0.03, y: 0.030000001}
-  m_SizeDelta: {x: 0.025000006, y: 0.024999999}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1694938865
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1694938863}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 57cf8ea40c7f8fc4fa6a3afb12becedb, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _anchor: {fileID: 652095308}
-  _featureData:
-  - {fileID: 1694938866}
-  _attachedGroup: {fileID: 652095309}
-  _preferredRendererType:
-    _fullName: Leap.Unity.GraphicalRenderer.LeapDynamicRenderer
-  vertexColor: {r: 1, g: 1, b: 1, a: 1}
-  _sourceData: {fileID: 1694938866}
-  _resolutionType: 1
-  _resolution_vert_x: 1
-  _resolution_vert_y: 0
-  _resolution_verts_per_meter: {x: 20, y: 20}
-  _size: {x: 0.025000006, y: 0.024999999}
-  _nineSliced: 0
---- !u!114 &1694938866
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1694938863}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d2c8779b1bdf86c4dbcbe18f17e44e53, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  graphic: {fileID: 1694938865}
-  feature: {fileID: 652095307}
-  texture: {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
 --- !u!1 &2102241332
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/LeapMotionModules/GraphicRenderer/Scenes/Curved Space Examples.unity
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scenes/Curved Space Examples.unity
@@ -1,0 +1,504 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 8
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_GIWorkflowMode: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_TemporalCoherenceThreshold: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 1
+  m_LightmapEditorSettings:
+    serializedVersion: 8
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_TextureWidth: 1024
+    m_TextureHeight: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 3
+    m_BakeBackend: 0
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 500
+    m_PVRBounces: 2
+    m_PVRFiltering: 0
+    m_PVRFilteringMode: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousColorSigma: 1
+    m_PVRFilteringAtrousNormalSigma: 1
+    m_PVRFilteringAtrousPositionSigma: 1
+  m_LightingDataAsset: {fileID: 0}
+  m_ShadowMaskMode: 2
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &19133424
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 19133427}
+  - component: {fileID: 19133426}
+  - component: {fileID: 19133425}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &19133425
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 19133424}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d2c8779b1bdf86c4dbcbe18f17e44e53, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  graphic: {fileID: 19133426}
+  feature: {fileID: 652095306}
+  texture: {fileID: 0}
+--- !u!114 &19133426
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 19133424}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8fb726b2ea51dd94d8601fa443872ec2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _anchor: {fileID: 0}
+  _featureData:
+  - {fileID: 19133425}
+  _attachedGroup: {fileID: 652095309}
+  _preferredRendererType:
+    _fullName: Leap.Unity.GraphicalRenderer.LeapDynamicRenderer
+  vertexColor: {r: 1, g: 1, b: 1, a: 1}
+  _mesh: {fileID: 4300000, guid: 14e47e6e841b85146813b9d552dc3d37, type: 3}
+  _remappableChannels: -1
+--- !u!4 &19133427
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 19133424}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 652095311}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!21 &548879904
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: Procedural Graphic Material
+  m_Shader: {fileID: 4800000, guid: f8e996b2e23d82847b27d2e0fcfa6a65, type: 3}
+  m_ShaderKeywords: GRAPHIC_RENDERER_VERTEX_COLORS GRAPHIC_RENDERER_VERTEX_NORMALS
+    GRAPHIC_RENDERER_VERTEX_UV_0
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 28454722775756910, guid: f764ee8b40e4cf842bfbed9666ae5097,
+          type: 2}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats: []
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+--- !u!1 &652095305
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 652095311}
+  - component: {fileID: 652095310}
+  - component: {fileID: 652095309}
+  - component: {fileID: 652095307}
+  - component: {fileID: 652095306}
+  m_Layer: 0
+  m_Name: Renderer (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &652095306
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 652095305}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 36ae2dc675d304041af3c95461f228e2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  featureData:
+  - {fileID: 19133425}
+  propertyName: _MainTex
+  channel: 1
+--- !u!114 &652095307
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 652095305}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e4e826f61fa76194f87130a5030b287d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  renderer: {fileID: 652095310}
+  group: {fileID: 652095309}
+  _useUv0: 1
+  _useUv1: 0
+  _useUv2: 0
+  _useUv3: 0
+  _useColors: 1
+  _bakedTint: {r: 1, g: 1, b: 1, a: 1}
+  _useNormals: 1
+  _shader: {fileID: 4800000, guid: f8e996b2e23d82847b27d2e0fcfa6a65, type: 3}
+  _atlas:
+    _border: 0
+    _padding: 0
+    _mipMap: 1
+    _filterMode: 1
+    _format: 5
+    _maxAtlasSize: 4096
+    _extraTextures: []
+  _material: {fileID: 548879904}
+  _meshes: {fileID: 11400000, guid: f41bb1228ad443f49bc43b0dadb2d547, type: 2}
+  _packedTextures: {fileID: 11400000, guid: f764ee8b40e4cf842bfbed9666ae5097, type: 2}
+  _atlasUvs:
+    _channel0:
+      _keys: []
+      _values: []
+    _channel1:
+      _keys: []
+      _values: []
+    _channel2:
+      _keys: []
+      _values: []
+    _channel3:
+      _keys: []
+      _values: []
+    _nullRects:
+    - serializedVersion: 2
+      x: 0.25
+      y: 0.25
+      width: 0.25
+      height: 0.25
+    - serializedVersion: 2
+      x: 0
+      y: 0
+      width: 0
+      height: 0
+    - serializedVersion: 2
+      x: 0
+      y: 0
+      width: 0
+      height: 0
+    - serializedVersion: 2
+      x: 0
+      y: 0
+      width: 0
+      height: 0
+--- !u!114 &652095309
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 652095305}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b32d8e323bfd9df4d82051c22f44d792, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _renderingMethod: {fileID: 652095307}
+  _features:
+  - {fileID: 652095306}
+  _renderer: {fileID: 652095310}
+  _graphics:
+  - {fileID: 19133426}
+  _supportInfo:
+  - support: 0
+    message: 
+  _addRemoveSupported: 1
+--- !u!114 &652095310
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 652095305}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: adb71699a7372344cb4e7a163c6c6922, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _selectedGroup: 0
+  _space: {fileID: 0}
+  _groups:
+  - {fileID: 652095309}
+--- !u!4 &652095311
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 652095305}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 19133427}
+  m_Father: {fileID: 0}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1372800847
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1372800849}
+  - component: {fileID: 1372800848}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &1372800848
+Light:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1372800847}
+  m_Enabled: 1
+  serializedVersion: 8
+  m_Type: 1
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_Lightmapping: 4
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &1372800849
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1372800847}
+  m_LocalRotation: {x: 0.40821788, y: -0.23456968, z: 0.10938163, w: 0.8754261}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &2102241332
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 2102241337}
+  - component: {fileID: 2102241336}
+  - component: {fileID: 2102241335}
+  - component: {fileID: 2102241334}
+  - component: {fileID: 2102241333}
+  m_Layer: 0
+  m_Name: Main Camera
+  m_TagString: MainCamera
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!81 &2102241333
+AudioListener:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2102241332}
+  m_Enabled: 1
+--- !u!124 &2102241334
+Behaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2102241332}
+  m_Enabled: 1
+--- !u!92 &2102241335
+Behaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2102241332}
+  m_Enabled: 1
+--- !u!20 &2102241336
+Camera:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2102241332}
+  m_Enabled: 1
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: -1
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+  m_StereoMirrorMode: 0
+--- !u!4 &2102241337
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 2102241332}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/LeapMotionModules/GraphicRenderer/Scenes/Curved Space Examples.unity
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scenes/Curved Space Examples.unity
@@ -119,7 +119,7 @@ GameObject:
   - component: {fileID: 19133426}
   - component: {fileID: 19133425}
   m_Layer: 0
-  m_Name: GameObject
+  m_Name: Panel
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -137,8 +137,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   graphic: {fileID: 19133426}
-  feature: {fileID: 652095306}
-  texture: {fileID: 0}
+  feature: {fileID: 652095307}
+  texture: {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
 --- !u!114 &19133426
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -147,20 +147,25 @@ MonoBehaviour:
   m_GameObject: {fileID: 19133424}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8fb726b2ea51dd94d8601fa443872ec2, type: 3}
+  m_Script: {fileID: 11500000, guid: 57cf8ea40c7f8fc4fa6a3afb12becedb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _anchor: {fileID: 0}
+  _anchor: {fileID: 652095308}
   _featureData:
   - {fileID: 19133425}
   _attachedGroup: {fileID: 652095309}
   _preferredRendererType:
     _fullName: Leap.Unity.GraphicalRenderer.LeapDynamicRenderer
   vertexColor: {r: 1, g: 1, b: 1, a: 1}
-  _mesh: {fileID: 4300000, guid: 14e47e6e841b85146813b9d552dc3d37, type: 3}
-  _remappableChannels: -1
---- !u!4 &19133427
-Transform:
+  _sourceData: {fileID: 19133425}
+  _resolutionType: 1
+  _resolution_vert_x: 5
+  _resolution_vert_y: 3
+  _resolution_verts_per_meter: {x: 20, y: 20}
+  _size: {x: 0.2399, y: 0.1311}
+  _nineSliced: 0
+--- !u!224 &19133427
+RectTransform:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
@@ -168,36 +173,241 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 266862084}
+  - {fileID: 191866187}
+  - {fileID: 1694938864}
+  - {fileID: 195769539}
   m_Father: {fileID: 652095311}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!21 &548879904
-Material:
-  serializedVersion: 6
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0.2399, y: 0.1311}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &191866184
+GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_Name: Procedural Graphic Material
-  m_Shader: {fileID: 4800000, guid: f8e996b2e23d82847b27d2e0fcfa6a65, type: 3}
-  m_ShaderKeywords: GRAPHIC_RENDERER_VERTEX_COLORS GRAPHIC_RENDERER_VERTEX_NORMALS
-    GRAPHIC_RENDERER_VERTEX_UV_0
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 28454722775756910, guid: f764ee8b40e4cf842bfbed9666ae5097,
-          type: 2}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Floats: []
-    m_Colors:
-    - _Color: {r: 1, g: 1, b: 1, a: 1}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 191866187}
+  - component: {fileID: 191866186}
+  - component: {fileID: 191866185}
+  m_Layer: 0
+  m_Name: Panel (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &191866185
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 191866184}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d2c8779b1bdf86c4dbcbe18f17e44e53, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  graphic: {fileID: 191866186}
+  feature: {fileID: 652095307}
+  texture: {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
+--- !u!114 &191866186
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 191866184}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 57cf8ea40c7f8fc4fa6a3afb12becedb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _anchor: {fileID: 652095308}
+  _featureData:
+  - {fileID: 191866185}
+  _attachedGroup: {fileID: 652095309}
+  _preferredRendererType:
+    _fullName: Leap.Unity.GraphicalRenderer.LeapDynamicRenderer
+  vertexColor: {r: 1, g: 1, b: 1, a: 1}
+  _sourceData: {fileID: 191866185}
+  _resolutionType: 1
+  _resolution_vert_x: 0
+  _resolution_vert_y: 0
+  _resolution_verts_per_meter: {x: 20, y: 20}
+  _size: {x: 0.025, y: 0.024999999}
+  _nineSliced: 0
+--- !u!224 &191866187
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 191866184}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.002}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 19133427}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0.030000001, y: 0.03}
+  m_SizeDelta: {x: 0.025, y: 0.024999999}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &195769536
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 195769539}
+  - component: {fileID: 195769538}
+  - component: {fileID: 195769537}
+  m_Layer: 0
+  m_Name: Panel (4)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &195769537
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 195769536}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d2c8779b1bdf86c4dbcbe18f17e44e53, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  graphic: {fileID: 195769538}
+  feature: {fileID: 652095307}
+  texture: {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
+--- !u!114 &195769538
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 195769536}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 57cf8ea40c7f8fc4fa6a3afb12becedb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _anchor: {fileID: 652095308}
+  _featureData:
+  - {fileID: 195769537}
+  _attachedGroup: {fileID: 652095309}
+  _preferredRendererType:
+    _fullName: Leap.Unity.GraphicalRenderer.LeapDynamicRenderer
+  vertexColor: {r: 1, g: 1, b: 1, a: 1}
+  _sourceData: {fileID: 195769537}
+  _resolutionType: 1
+  _resolution_vert_x: 1
+  _resolution_vert_y: 0
+  _resolution_verts_per_meter: {x: 20, y: 20}
+  _size: {x: 0.025000006, y: 0.025}
+  _nineSliced: 0
+--- !u!224 &195769539
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 195769536}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.002}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 19133427}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -0.03, y: -0.030000001}
+  m_SizeDelta: {x: 0.025000006, y: 0.025}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &266862083
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 266862084}
+  - component: {fileID: 266862085}
+  - component: {fileID: 266862086}
+  m_Layer: 0
+  m_Name: Panel (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &266862084
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 266862083}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.002}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 19133427}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0.030000001, y: -0.03}
+  m_SizeDelta: {x: 0.025, y: 0.025}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &266862085
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 266862083}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 57cf8ea40c7f8fc4fa6a3afb12becedb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _anchor: {fileID: 652095308}
+  _featureData:
+  - {fileID: 266862086}
+  _attachedGroup: {fileID: 652095309}
+  _preferredRendererType:
+    _fullName: Leap.Unity.GraphicalRenderer.LeapDynamicRenderer
+  vertexColor: {r: 1, g: 1, b: 1, a: 1}
+  _sourceData: {fileID: 266862086}
+  _resolutionType: 1
+  _resolution_vert_x: 0
+  _resolution_vert_y: 0
+  _resolution_verts_per_meter: {x: 20, y: 20}
+  _size: {x: 0.025, y: 0.025}
+  _nineSliced: 0
+--- !u!114 &266862086
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 266862083}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d2c8779b1bdf86c4dbcbe18f17e44e53, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  graphic: {fileID: 266862085}
+  feature: {fileID: 652095307}
+  texture: {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
 --- !u!1 &652095305
 GameObject:
   m_ObjectHideFlags: 0
@@ -208,6 +418,7 @@ GameObject:
   - component: {fileID: 652095311}
   - component: {fileID: 652095310}
   - component: {fileID: 652095309}
+  - component: {fileID: 652095308}
   - component: {fileID: 652095307}
   - component: {fileID: 652095306}
   m_Layer: 0
@@ -225,21 +436,6 @@ MonoBehaviour:
   m_GameObject: {fileID: 652095305}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 36ae2dc675d304041af3c95461f228e2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  featureData:
-  - {fileID: 19133425}
-  propertyName: _MainTex
-  channel: 1
---- !u!114 &652095307
-MonoBehaviour:
-  m_ObjectHideFlags: 3
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 652095305}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: e4e826f61fa76194f87130a5030b287d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
@@ -249,10 +445,10 @@ MonoBehaviour:
   _useUv1: 0
   _useUv2: 0
   _useUv3: 0
-  _useColors: 1
+  _useColors: 0
   _bakedTint: {r: 1, g: 1, b: 1, a: 1}
-  _useNormals: 1
-  _shader: {fileID: 4800000, guid: f8e996b2e23d82847b27d2e0fcfa6a65, type: 3}
+  _useNormals: 0
+  _shader: {fileID: 4800000, guid: 474347a7dd23a1743b7bdfa349be986b, type: 3}
   _atlas:
     _border: 0
     _padding: 0
@@ -261,13 +457,19 @@ MonoBehaviour:
     _format: 5
     _maxAtlasSize: 4096
     _extraTextures: []
-  _material: {fileID: 548879904}
-  _meshes: {fileID: 11400000, guid: f41bb1228ad443f49bc43b0dadb2d547, type: 2}
-  _packedTextures: {fileID: 11400000, guid: f764ee8b40e4cf842bfbed9666ae5097, type: 2}
+  _material: {fileID: 935407115}
+  _meshes: {fileID: 11400000, guid: 4fd6614690fb4e24e8d492c97f79eb16, type: 2}
+  _packedTextures: {fileID: 11400000, guid: 777eae74292749e419af1609ff26f4ef, type: 2}
   _atlasUvs:
     _channel0:
-      _keys: []
-      _values: []
+      _keys:
+      - {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
+      _values:
+      - serializedVersion: 2
+        x: 0
+        y: 0
+        width: 0.53125
+        height: 0.53125
     _channel1:
       _keys: []
       _values: []
@@ -279,11 +481,6 @@ MonoBehaviour:
       _values: []
     _nullRects:
     - serializedVersion: 2
-      x: 0.25
-      y: 0.25
-      width: 0.25
-      height: 0.25
-    - serializedVersion: 2
       x: 0
       y: 0
       width: 0
@@ -298,6 +495,44 @@ MonoBehaviour:
       y: 0
       width: 0
       height: 0
+    - serializedVersion: 2
+      x: 0
+      y: 0
+      width: 0
+      height: 0
+--- !u!114 &652095307
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 652095305}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 36ae2dc675d304041af3c95461f228e2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  featureData:
+  - {fileID: 19133425}
+  - {fileID: 266862086}
+  - {fileID: 191866185}
+  - {fileID: 1694938866}
+  - {fileID: 195769537}
+  propertyName: _MainTex
+  channel: 1
+--- !u!114 &652095308
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 652095305}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9261239b711172441b484496a58d001c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  parent: {fileID: 652095308}
+  space: {fileID: 652095308}
+  _radius: 1.39
 --- !u!114 &652095309
 MonoBehaviour:
   m_ObjectHideFlags: 3
@@ -309,16 +544,20 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b32d8e323bfd9df4d82051c22f44d792, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _renderingMethod: {fileID: 652095307}
+  _renderingMethod: {fileID: 652095306}
   _features:
-  - {fileID: 652095306}
+  - {fileID: 652095307}
   _renderer: {fileID: 652095310}
   _graphics:
   - {fileID: 19133426}
+  - {fileID: 266862085}
+  - {fileID: 191866186}
+  - {fileID: 1694938865}
+  - {fileID: 195769538}
   _supportInfo:
   - support: 0
     message: 
-  _addRemoveSupported: 1
+  _addRemoveSupported: 0
 --- !u!114 &652095310
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -331,7 +570,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _selectedGroup: 0
-  _space: {fileID: 0}
+  _space: {fileID: 652095308}
   _groups:
   - {fileID: 652095309}
 --- !u!4 &652095311
@@ -347,6 +586,73 @@ Transform:
   - {fileID: 19133427}
   m_Father: {fileID: 0}
   m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!21 &935407115
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: Procedural Graphic Material
+  m_Shader: {fileID: 4800000, guid: 474347a7dd23a1743b7bdfa349be986b, type: 3}
+  m_ShaderKeywords: GRAPHIC_RENDERER_CYLINDRICAL GRAPHIC_RENDERER_VERTEX_UV_0
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 28089171662022380, guid: 777eae74292749e419af1609ff26f4ef,
+          type: 2}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats: []
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+--- !u!1 &1195100962
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1195100964}
+  - component: {fileID: 1195100963}
+  m_Layer: 0
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1195100963
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1195100962}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8f17e566afcdd3a4e8e3c311a9117fc0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  value: 4.33
+  sprite: {fileID: 21300000, guid: e87252e5ff761c14e9b56d41ed27f8cb, type: 3}
+--- !u!4 &1195100964
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1195100962}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.000899176}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1372800847
 GameObject:
@@ -413,6 +719,80 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &1694938863
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1694938864}
+  - component: {fileID: 1694938865}
+  - component: {fileID: 1694938866}
+  m_Layer: 0
+  m_Name: Panel (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1694938864
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1694938863}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.002}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 19133427}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: -0.03, y: 0.030000001}
+  m_SizeDelta: {x: 0.025000006, y: 0.024999999}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1694938865
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1694938863}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 57cf8ea40c7f8fc4fa6a3afb12becedb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _anchor: {fileID: 652095308}
+  _featureData:
+  - {fileID: 1694938866}
+  _attachedGroup: {fileID: 652095309}
+  _preferredRendererType:
+    _fullName: Leap.Unity.GraphicalRenderer.LeapDynamicRenderer
+  vertexColor: {r: 1, g: 1, b: 1, a: 1}
+  _sourceData: {fileID: 1694938866}
+  _resolutionType: 1
+  _resolution_vert_x: 1
+  _resolution_vert_y: 0
+  _resolution_verts_per_meter: {x: 20, y: 20}
+  _size: {x: 0.025000006, y: 0.024999999}
+  _nineSliced: 0
+--- !u!114 &1694938866
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1694938863}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d2c8779b1bdf86c4dbcbe18f17e44e53, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  graphic: {fileID: 1694938865}
+  feature: {fileID: 652095307}
+  texture: {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
 --- !u!1 &2102241332
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/LeapMotionModules/GraphicRenderer/Scenes/Curved Space Examples.unity
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scenes/Curved Space Examples.unity
@@ -108,6 +108,154 @@ NavMeshSettings:
     tileSize: 256
     accuratePlacement: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1 &69772591
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 69772594}
+  - component: {fileID: 69772593}
+  - component: {fileID: 69772592}
+  m_Layer: 0
+  m_Name: Panel (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &69772592
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 69772591}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b051eb69afb505b479d2ea649875e390, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  graphic: {fileID: 69772593}
+  feature: {fileID: 652095307}
+  sprite: {fileID: 21300000, guid: 93f4f81256c947642a93d907d828ee98, type: 3}
+--- !u!114 &69772593
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 69772591}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 57cf8ea40c7f8fc4fa6a3afb12becedb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _anchor: {fileID: 0}
+  _featureData:
+  - {fileID: 69772592}
+  _attachedGroup: {fileID: 652095309}
+  _preferredRendererType:
+    _fullName: Leap.Unity.GraphicalRenderer.LeapBakedRenderer
+  vertexColor: {r: 0.07586192, g: 0, b: 1, a: 1}
+  _sourceData: {fileID: 69772592}
+  _resolutionType: 0
+  _resolution_vert_x: 0
+  _resolution_vert_y: 0
+  _resolution_verts_per_meter: {x: 0, y: 0}
+  _size: {x: 0.019999996, y: 0.020000003}
+  _nineSliced: 0
+--- !u!224 &69772594
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 69772591}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.0015}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 560921529}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: -0.015, y: 0.015000001}
+  m_SizeDelta: {x: 0.019999996, y: 0.020000003}
+  m_Pivot: {x: 1, y: 0}
+--- !u!1 &166039333
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 166039336}
+  - component: {fileID: 166039335}
+  - component: {fileID: 166039334}
+  m_Layer: 0
+  m_Name: Panel (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &166039334
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 166039333}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b051eb69afb505b479d2ea649875e390, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  graphic: {fileID: 166039335}
+  feature: {fileID: 652095307}
+  sprite: {fileID: 21300000, guid: 93f4f81256c947642a93d907d828ee98, type: 3}
+--- !u!114 &166039335
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 166039333}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 57cf8ea40c7f8fc4fa6a3afb12becedb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _anchor: {fileID: 0}
+  _featureData:
+  - {fileID: 166039334}
+  _attachedGroup: {fileID: 652095309}
+  _preferredRendererType:
+    _fullName: Leap.Unity.GraphicalRenderer.LeapBakedRenderer
+  vertexColor: {r: 1, g: 0.64137924, b: 0, a: 1}
+  _sourceData: {fileID: 166039334}
+  _resolutionType: 0
+  _resolution_vert_x: 0
+  _resolution_vert_y: 0
+  _resolution_verts_per_meter: {x: 0, y: 0}
+  _size: {x: 0.02, y: 0.020000003}
+  _nineSliced: 0
+--- !u!224 &166039336
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 166039333}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.0015}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 560921529}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0.015000001, y: 0.015}
+  m_SizeDelta: {x: 0.02, y: 0.020000003}
+  m_Pivot: {x: 0, y: 0}
 --- !u!1 &560921526
 GameObject:
   m_ObjectHideFlags: 0
@@ -115,31 +263,17 @@ GameObject:
   m_PrefabInternal: {fileID: 0}
   serializedVersion: 5
   m_Component:
-  - component: {fileID: 560921527}
   - component: {fileID: 560921529}
-  - component: {fileID: 560921530}
   - component: {fileID: 560921528}
+  - component: {fileID: 560921527}
   m_Layer: 0
-  m_Name: GameObject (1)
+  m_Name: Panel
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &560921527
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 560921526}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 652095311}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &560921528
+--- !u!114 &560921527
 MonoBehaviour:
   m_ObjectHideFlags: 3
   m_PrefabParentObject: {fileID: 0}
@@ -150,10 +284,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b051eb69afb505b479d2ea649875e390, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  graphic: {fileID: 560921530}
+  graphic: {fileID: 560921528}
   feature: {fileID: 652095307}
-  sprite: {fileID: 21300000, guid: 93f4f81256c947642a93d907d828ee98, type: 3}
---- !u!114 &560921529
+  sprite: {fileID: 21300000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
+--- !u!114 &560921528
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
@@ -161,31 +295,45 @@ MonoBehaviour:
   m_GameObject: {fileID: 560921526}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 1b7dca36e8e5c88459b2626007befebc, type: 3}
+  m_Script: {fileID: 11500000, guid: 57cf8ea40c7f8fc4fa6a3afb12becedb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  parent: {fileID: 652095308}
-  space: {fileID: 652095308}
---- !u!114 &560921530
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 560921526}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8fb726b2ea51dd94d8601fa443872ec2, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _anchor: {fileID: 560921529}
+  _anchor: {fileID: 0}
   _featureData:
-  - {fileID: 560921528}
+  - {fileID: 560921527}
   _attachedGroup: {fileID: 652095309}
   _preferredRendererType:
-    _fullName: Leap.Unity.GraphicalRenderer.LeapDynamicRenderer
+    _fullName: Leap.Unity.GraphicalRenderer.LeapBakedRenderer
   vertexColor: {r: 1, g: 1, b: 1, a: 1}
-  _mesh: {fileID: 4300000, guid: 14e47e6e841b85146813b9d552dc3d37, type: 3}
-  _remappableChannels: -1
+  _sourceData: {fileID: 560921527}
+  _resolutionType: 1
+  _resolution_vert_x: 4
+  _resolution_vert_y: 2
+  _resolution_verts_per_meter: {x: 20, y: 20}
+  _size: {x: 0.2, y: 0.1}
+  _nineSliced: 1
+--- !u!224 &560921529
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 560921526}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 793918694}
+  - {fileID: 872725434}
+  - {fileID: 166039336}
+  - {fileID: 69772594}
+  m_Father: {fileID: 652095311}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0.2, y: 0.1}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &652095305
 GameObject:
   m_ObjectHideFlags: 0
@@ -223,7 +371,7 @@ MonoBehaviour:
   _useUv1: 0
   _useUv2: 0
   _useUv3: 0
-  _useColors: 0
+  _useColors: 1
   _bakedTint: {r: 1, g: 1, b: 1, a: 1}
   _useNormals: 0
   _shader: {fileID: 4800000, guid: 692ffa38f03db184d8b27b0661d5bf0d, type: 3}
@@ -235,9 +383,9 @@ MonoBehaviour:
     _format: 5
     _maxAtlasSize: 4096
     _extraTextures: []
-  _material: {fileID: 1423660612}
-  _meshes: {fileID: 11400000, guid: 26c3d624216bdf846a6c4ade059c3af5, type: 2}
-  _packedTextures: {fileID: 11400000, guid: 2d8a22a18fc908945a8712cf133e5f18, type: 2}
+  _material: {fileID: 1236658139}
+  _meshes: {fileID: 11400000, guid: fbd45d69d4e6a78429d0d41d32e61e43, type: 2}
+  _packedTextures: {fileID: 11400000, guid: e7c4999a8002a684180116c650b69886, type: 2}
   _atlasUvs:
     _channel0:
       _keys:
@@ -247,8 +395,8 @@ MonoBehaviour:
       - serializedVersion: 2
         x: 0
         y: 0
-        width: 0.265625
-        height: 0.265625
+        width: 0
+        height: 0
       - serializedVersion: 2
         x: 0
         y: 0
@@ -301,7 +449,11 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   featureData:
-  - {fileID: 560921528}
+  - {fileID: 560921527}
+  - {fileID: 793918692}
+  - {fileID: 872725432}
+  - {fileID: 166039334}
+  - {fileID: 69772592}
   propertyName: _MainTex
   channel: 1
 --- !u!114 &652095308
@@ -310,7 +462,7 @@ MonoBehaviour:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 652095305}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 9261239b711172441b484496a58d001c, type: 3}
   m_Name: 
@@ -334,11 +486,15 @@ MonoBehaviour:
   - {fileID: 652095307}
   _renderer: {fileID: 652095310}
   _graphics:
-  - {fileID: 560921530}
+  - {fileID: 560921528}
+  - {fileID: 793918693}
+  - {fileID: 872725433}
+  - {fileID: 166039335}
+  - {fileID: 69772593}
   _supportInfo:
   - support: 0
     message: 
-  _addRemoveSupported: 1
+  _addRemoveSupported: 0
 --- !u!114 &652095310
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -351,7 +507,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _selectedGroup: 0
-  _space: {fileID: 652095308}
+  _space: {fileID: 0}
   _groups:
   - {fileID: 652095309}
 --- !u!4 &652095311
@@ -364,10 +520,183 @@ Transform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 560921527}
+  - {fileID: 560921529}
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &793918691
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 793918694}
+  - component: {fileID: 793918693}
+  - component: {fileID: 793918692}
+  m_Layer: 0
+  m_Name: Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &793918692
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 793918691}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b051eb69afb505b479d2ea649875e390, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  graphic: {fileID: 793918693}
+  feature: {fileID: 652095307}
+  sprite: {fileID: 21300000, guid: 93f4f81256c947642a93d907d828ee98, type: 3}
+--- !u!114 &793918693
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 793918691}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 57cf8ea40c7f8fc4fa6a3afb12becedb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _anchor: {fileID: 0}
+  _featureData:
+  - {fileID: 793918692}
+  _attachedGroup: {fileID: 652095309}
+  _preferredRendererType:
+    _fullName: Leap.Unity.GraphicalRenderer.LeapBakedRenderer
+  vertexColor: {r: 1, g: 0, b: 0, a: 1}
+  _sourceData: {fileID: 793918692}
+  _resolutionType: 0
+  _resolution_vert_x: 0
+  _resolution_vert_y: 0
+  _resolution_verts_per_meter: {x: 0, y: 0}
+  _size: {x: 0.02, y: 0.02}
+  _nineSliced: 0
+--- !u!224 &793918694
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 793918691}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.0015}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 560921529}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0.015, y: -0.015}
+  m_SizeDelta: {x: 0.02, y: 0.02}
+  m_Pivot: {x: 0, y: 1}
+--- !u!1 &872725431
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 872725434}
+  - component: {fileID: 872725433}
+  - component: {fileID: 872725432}
+  m_Layer: 0
+  m_Name: Panel (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &872725432
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 872725431}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b051eb69afb505b479d2ea649875e390, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  graphic: {fileID: 872725433}
+  feature: {fileID: 652095307}
+  sprite: {fileID: 21300000, guid: 93f4f81256c947642a93d907d828ee98, type: 3}
+--- !u!114 &872725433
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 872725431}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 57cf8ea40c7f8fc4fa6a3afb12becedb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _anchor: {fileID: 0}
+  _featureData:
+  - {fileID: 872725432}
+  _attachedGroup: {fileID: 652095309}
+  _preferredRendererType:
+    _fullName: Leap.Unity.GraphicalRenderer.LeapBakedRenderer
+  vertexColor: {r: 0.0862069, g: 0.7352941, b: 0, a: 1}
+  _sourceData: {fileID: 872725432}
+  _resolutionType: 0
+  _resolution_vert_x: 0
+  _resolution_vert_y: 0
+  _resolution_verts_per_meter: {x: 0, y: 0}
+  _size: {x: 0.019999996, y: 0.02}
+  _nineSliced: 0
+--- !u!224 &872725434
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 872725431}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.0015}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 560921529}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -0.01499999, y: -0.014999993}
+  m_SizeDelta: {x: 0.019999996, y: 0.02}
+  m_Pivot: {x: 1, y: 1}
+--- !u!21 &1236658139
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: Procedural Graphic Material
+  m_Shader: {fileID: 4800000, guid: 692ffa38f03db184d8b27b0661d5bf0d, type: 3}
+  m_ShaderKeywords: GRAPHIC_RENDERER_MOVEMENT_TRANSLATION GRAPHIC_RENDERER_VERTEX_COLORS
+    GRAPHIC_RENDERER_VERTEX_UV_0
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats: []
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
 --- !u!1 &1372800847
 GameObject:
   m_ObjectHideFlags: 0
@@ -433,31 +762,6 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
---- !u!21 &1423660612
-Material:
-  serializedVersion: 6
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_Name: Procedural Graphic Material
-  m_Shader: {fileID: 4800000, guid: 692ffa38f03db184d8b27b0661d5bf0d, type: 3}
-  m_ShaderKeywords: GRAPHIC_RENDERER_CYLINDRICAL GRAPHIC_RENDERER_MOVEMENT_TRANSLATION
-    GRAPHIC_RENDERER_VERTEX_UV_0
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Floats: []
-    m_Colors:
-    - _Color: {r: 1, g: 1, b: 1, a: 1}
 --- !u!1 &2102241332
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/LeapMotionModules/GraphicRenderer/Scenes/Curved Space Examples.unity
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scenes/Curved Space Examples.unity
@@ -116,8 +116,9 @@ GameObject:
   serializedVersion: 5
   m_Component:
   - component: {fileID: 560921527}
-  - component: {fileID: 560921528}
   - component: {fileID: 560921529}
+  - component: {fileID: 560921530}
+  - component: {fileID: 560921528}
   m_Layer: 0
   m_Name: GameObject (1)
   m_TagString: Untagged
@@ -140,16 +141,18 @@ Transform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &560921528
 MonoBehaviour:
-  m_ObjectHideFlags: 0
+  m_ObjectHideFlags: 3
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 560921526}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0df85c45a8c550248bd0a01169f8eeb8, type: 3}
+  m_Script: {fileID: 11500000, guid: b051eb69afb505b479d2ea649875e390, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  prefab: {fileID: 1892722084810738, guid: e63b4091afde9744ab1744624068734c, type: 2}
+  graphic: {fileID: 560921530}
+  feature: {fileID: 652095307}
+  sprite: {fileID: 21300000, guid: 93f4f81256c947642a93d907d828ee98, type: 3}
 --- !u!114 &560921529
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -163,6 +166,26 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   parent: {fileID: 652095308}
   space: {fileID: 652095308}
+--- !u!114 &560921530
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 560921526}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8fb726b2ea51dd94d8601fa443872ec2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _anchor: {fileID: 560921529}
+  _featureData:
+  - {fileID: 560921528}
+  _attachedGroup: {fileID: 652095309}
+  _preferredRendererType:
+    _fullName: Leap.Unity.GraphicalRenderer.LeapDynamicRenderer
+  vertexColor: {r: 1, g: 1, b: 1, a: 1}
+  _mesh: {fileID: 4300000, guid: 14e47e6e841b85146813b9d552dc3d37, type: 3}
+  _remappableChannels: -1
 --- !u!1 &652095305
 GameObject:
   m_ObjectHideFlags: 0
@@ -191,7 +214,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 652095305}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: e4e826f61fa76194f87130a5030b287d, type: 3}
+  m_Script: {fileID: 11500000, guid: 00bb44340bd430d44a098a5e36f4de2d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   renderer: {fileID: 652095310}
@@ -203,7 +226,7 @@ MonoBehaviour:
   _useColors: 0
   _bakedTint: {r: 1, g: 1, b: 1, a: 1}
   _useNormals: 0
-  _shader: {fileID: 4800000, guid: 474347a7dd23a1743b7bdfa349be986b, type: 3}
+  _shader: {fileID: 4800000, guid: 692ffa38f03db184d8b27b0661d5bf0d, type: 3}
   _atlas:
     _border: 0
     _padding: 0
@@ -212,19 +235,25 @@ MonoBehaviour:
     _format: 5
     _maxAtlasSize: 4096
     _extraTextures: []
-  _material: {fileID: 734205479}
-  _meshes: {fileID: 11400000, guid: 4fd6614690fb4e24e8d492c97f79eb16, type: 2}
-  _packedTextures: {fileID: 11400000, guid: 777eae74292749e419af1609ff26f4ef, type: 2}
+  _material: {fileID: 1423660612}
+  _meshes: {fileID: 11400000, guid: 26c3d624216bdf846a6c4ade059c3af5, type: 2}
+  _packedTextures: {fileID: 11400000, guid: 2d8a22a18fc908945a8712cf133e5f18, type: 2}
   _atlasUvs:
     _channel0:
       _keys:
-      - {fileID: 2800000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
+      - {fileID: 21300000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
+      - {fileID: 21300000, guid: 93f4f81256c947642a93d907d828ee98, type: 3}
       _values:
       - serializedVersion: 2
         x: 0
         y: 0
-        width: 0.53125
-        height: 0.53125
+        width: 0.265625
+        height: 0.265625
+      - serializedVersion: 2
+        x: 0
+        y: 0
+        width: 0
+        height: 0
     _channel1:
       _keys: []
       _values: []
@@ -255,6 +284,11 @@ MonoBehaviour:
       y: 0
       width: 0
       height: 0
+  _layer:
+    layerIndex: 0
+  _motionType: 1
+  _createMeshRenderers: 0
+  _renderers: []
 --- !u!114 &652095307
 MonoBehaviour:
   m_ObjectHideFlags: 3
@@ -263,10 +297,11 @@ MonoBehaviour:
   m_GameObject: {fileID: 652095305}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 36ae2dc675d304041af3c95461f228e2, type: 3}
+  m_Script: {fileID: 11500000, guid: eb8619b4d0e4d744183adf2e5fb82581, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  featureData: []
+  featureData:
+  - {fileID: 560921528}
   propertyName: _MainTex
   channel: 1
 --- !u!114 &652095308
@@ -298,7 +333,8 @@ MonoBehaviour:
   _features:
   - {fileID: 652095307}
   _renderer: {fileID: 652095310}
-  _graphics: []
+  _graphics:
+  - {fileID: 560921530}
   _supportInfo:
   - support: 0
     message: 
@@ -331,73 +367,6 @@ Transform:
   - {fileID: 560921527}
   m_Father: {fileID: 0}
   m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!21 &734205479
-Material:
-  serializedVersion: 6
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_Name: Procedural Graphic Material
-  m_Shader: {fileID: 4800000, guid: 474347a7dd23a1743b7bdfa349be986b, type: 3}
-  m_ShaderKeywords: GRAPHIC_RENDERER_CYLINDRICAL GRAPHIC_RENDERER_VERTEX_UV_0
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 28359733727383112, guid: 777eae74292749e419af1609ff26f4ef,
-          type: 2}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Floats: []
-    m_Colors:
-    - _Color: {r: 1, g: 1, b: 1, a: 1}
---- !u!1 &1195100962
-GameObject:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  serializedVersion: 5
-  m_Component:
-  - component: {fileID: 1195100964}
-  - component: {fileID: 1195100963}
-  m_Layer: 0
-  m_Name: GameObject
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &1195100963
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1195100962}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8f17e566afcdd3a4e8e3c311a9117fc0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  value: 4.33
-  sprite: {fileID: 21300000, guid: e87252e5ff761c14e9b56d41ed27f8cb, type: 3}
---- !u!4 &1195100964
-Transform:
-  m_ObjectHideFlags: 0
-  m_PrefabParentObject: {fileID: 0}
-  m_PrefabInternal: {fileID: 0}
-  m_GameObject: {fileID: 1195100962}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: -0.000899176}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1372800847
 GameObject:
@@ -464,6 +433,31 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!21 &1423660612
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: Procedural Graphic Material
+  m_Shader: {fileID: 4800000, guid: 692ffa38f03db184d8b27b0661d5bf0d, type: 3}
+  m_ShaderKeywords: GRAPHIC_RENDERER_CYLINDRICAL GRAPHIC_RENDERER_MOVEMENT_TRANSLATION
+    GRAPHIC_RENDERER_VERTEX_UV_0
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats: []
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
 --- !u!1 &2102241332
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/LeapMotionModules/GraphicRenderer/Scenes/Curved Space Examples.unity
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scenes/Curved Space Examples.unity
@@ -119,7 +119,7 @@ GameObject:
   - component: {fileID: 69772593}
   - component: {fileID: 69772592}
   m_Layer: 0
-  m_Name: Panel (3)
+  m_Name: SubPanel
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -182,6 +182,31 @@ RectTransform:
   m_AnchoredPosition: {x: -0.015, y: 0.015000001}
   m_SizeDelta: {x: 0.019999996, y: 0.020000003}
   m_Pivot: {x: 1, y: 0}
+--- !u!21 &114360703
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: Procedural Graphic Material
+  m_Shader: {fileID: 4800000, guid: 692ffa38f03db184d8b27b0661d5bf0d, type: 3}
+  m_ShaderKeywords: GRAPHIC_RENDERER_MOVEMENT_TRANSLATION GRAPHIC_RENDERER_SPHERICAL
+    GRAPHIC_RENDERER_VERTEX_COLORS GRAPHIC_RENDERER_VERTEX_UV_0
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats: []
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
 --- !u!1 &166039333
 GameObject:
   m_ObjectHideFlags: 0
@@ -193,7 +218,7 @@ GameObject:
   - component: {fileID: 166039335}
   - component: {fileID: 166039334}
   m_Layer: 0
-  m_Name: Panel (2)
+  m_Name: SubPanel
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -256,6 +281,344 @@ RectTransform:
   m_AnchoredPosition: {x: 0.015000001, y: 0.015}
   m_SizeDelta: {x: 0.02, y: 0.020000003}
   m_Pivot: {x: 0, y: 0}
+--- !u!1 &174371918
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 174371921}
+  - component: {fileID: 174371920}
+  - component: {fileID: 174371919}
+  m_Layer: 0
+  m_Name: SubPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &174371919
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 174371918}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b051eb69afb505b479d2ea649875e390, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  graphic: {fileID: 174371920}
+  feature: {fileID: 545613735}
+  sprite: {fileID: 21300000, guid: 93f4f81256c947642a93d907d828ee98, type: 3}
+--- !u!114 &174371920
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 174371918}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 57cf8ea40c7f8fc4fa6a3afb12becedb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _anchor: {fileID: 545613736}
+  _featureData:
+  - {fileID: 174371919}
+  _attachedGroup: {fileID: 545613737}
+  _preferredRendererType:
+    _fullName: Leap.Unity.GraphicalRenderer.LeapBakedRenderer
+  vertexColor: {r: 0.07586192, g: 0, b: 1, a: 1}
+  _sourceData: {fileID: 174371919}
+  _resolutionType: 0
+  _resolution_vert_x: 0
+  _resolution_vert_y: 0
+  _resolution_verts_per_meter: {x: 0, y: 0}
+  _size: {x: 0.019999996, y: 0.020000003}
+  _nineSliced: 0
+--- !u!224 &174371921
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 174371918}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.0015}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1292325070}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: -0.015000001, y: 0.015000001}
+  m_SizeDelta: {x: 0.019999996, y: 0.020000003}
+  m_Pivot: {x: 1, y: 0}
+--- !u!1 &389062205
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 389062206}
+  - component: {fileID: 389062207}
+  - component: {fileID: 389062208}
+  m_Layer: 0
+  m_Name: SubPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &389062206
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 389062205}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.0015}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1957524219}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -0.014999993, y: -0.014999993}
+  m_SizeDelta: {x: 0.019999996, y: 0.02}
+  m_Pivot: {x: 1, y: 1}
+--- !u!114 &389062207
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 389062205}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 57cf8ea40c7f8fc4fa6a3afb12becedb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _anchor: {fileID: 1617273998}
+  _featureData:
+  - {fileID: 389062208}
+  _attachedGroup: {fileID: 1617273999}
+  _preferredRendererType:
+    _fullName: Leap.Unity.GraphicalRenderer.LeapBakedRenderer
+  vertexColor: {r: 0.0862069, g: 0.7352941, b: 0, a: 1}
+  _sourceData: {fileID: 389062208}
+  _resolutionType: 0
+  _resolution_vert_x: 0
+  _resolution_vert_y: 0
+  _resolution_verts_per_meter: {x: 0, y: 0}
+  _size: {x: 0.019999996, y: 0.02}
+  _nineSliced: 0
+--- !u!114 &389062208
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 389062205}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b051eb69afb505b479d2ea649875e390, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  graphic: {fileID: 389062207}
+  feature: {fileID: 1617273997}
+  sprite: {fileID: 21300000, guid: 93f4f81256c947642a93d907d828ee98, type: 3}
+--- !u!1 &545613733
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 545613739}
+  - component: {fileID: 545613738}
+  - component: {fileID: 545613737}
+  - component: {fileID: 545613736}
+  - component: {fileID: 545613735}
+  - component: {fileID: 545613734}
+  m_Layer: 0
+  m_Name: Renderer (2)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &545613734
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 545613733}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 00bb44340bd430d44a098a5e36f4de2d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  renderer: {fileID: 545613738}
+  group: {fileID: 545613737}
+  _useUv0: 1
+  _useUv1: 0
+  _useUv2: 0
+  _useUv3: 0
+  _useColors: 1
+  _bakedTint: {r: 1, g: 1, b: 1, a: 1}
+  _useNormals: 0
+  _shader: {fileID: 4800000, guid: 692ffa38f03db184d8b27b0661d5bf0d, type: 3}
+  _atlas:
+    _border: 0
+    _padding: 0
+    _mipMap: 1
+    _filterMode: 1
+    _format: 5
+    _maxAtlasSize: 4096
+    _extraTextures: []
+  _material: {fileID: 2092193198}
+  _meshes: {fileID: 11400000, guid: c05170bb126c0ba41a319fd6979729ee, type: 2}
+  _packedTextures: {fileID: 11400000, guid: 94a01d4281784ae43aead141b9593fe8, type: 2}
+  _atlasUvs:
+    _channel0:
+      _keys:
+      - {fileID: 21300000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
+      - {fileID: 21300000, guid: 93f4f81256c947642a93d907d828ee98, type: 3}
+      _values:
+      - serializedVersion: 2
+        x: 0
+        y: 0
+        width: 0
+        height: 0
+      - serializedVersion: 2
+        x: 0
+        y: 0
+        width: 0
+        height: 0
+    _channel1:
+      _keys: []
+      _values: []
+    _channel2:
+      _keys: []
+      _values: []
+    _channel3:
+      _keys: []
+      _values: []
+    _nullRects:
+    - serializedVersion: 2
+      x: 0
+      y: 0
+      width: 0
+      height: 0
+    - serializedVersion: 2
+      x: 0
+      y: 0
+      width: 0
+      height: 0
+    - serializedVersion: 2
+      x: 0
+      y: 0
+      width: 0
+      height: 0
+    - serializedVersion: 2
+      x: 0
+      y: 0
+      width: 0
+      height: 0
+  _layer:
+    layerIndex: 0
+  _motionType: 1
+  _createMeshRenderers: 0
+  _renderers: []
+--- !u!114 &545613735
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 545613733}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eb8619b4d0e4d744183adf2e5fb82581, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  featureData:
+  - {fileID: 1292325072}
+  - {fileID: 1659788829}
+  - {fileID: 1810851946}
+  - {fileID: 1625068441}
+  - {fileID: 174371919}
+  propertyName: _MainTex
+  channel: 1
+--- !u!114 &545613736
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 545613733}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9261239b711172441b484496a58d001c, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  parent: {fileID: 545613736}
+  space: {fileID: 545613736}
+  _radius: 0.1
+--- !u!114 &545613737
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 545613733}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b32d8e323bfd9df4d82051c22f44d792, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _renderingMethod: {fileID: 545613734}
+  _features:
+  - {fileID: 545613735}
+  _renderer: {fileID: 545613738}
+  _graphics:
+  - {fileID: 1292325071}
+  - {fileID: 1659788828}
+  - {fileID: 1810851945}
+  - {fileID: 1625068440}
+  - {fileID: 174371920}
+  _supportInfo:
+  - support: 0
+    message: 
+  _addRemoveSupported: 0
+--- !u!114 &545613738
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 545613733}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: adb71699a7372344cb4e7a163c6c6922, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _selectedGroup: 0
+  _space: {fileID: 545613736}
+  _groups:
+  - {fileID: 545613737}
+--- !u!4 &545613739
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 545613733}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.3, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1292325070}
+  m_Father: {fileID: 0}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &560921526
 GameObject:
   m_ObjectHideFlags: 0
@@ -307,9 +670,9 @@ MonoBehaviour:
   vertexColor: {r: 1, g: 1, b: 1, a: 1}
   _sourceData: {fileID: 560921527}
   _resolutionType: 1
-  _resolution_vert_x: 4
-  _resolution_vert_y: 2
-  _resolution_verts_per_meter: {x: 20, y: 20}
+  _resolution_vert_x: 8
+  _resolution_vert_y: 4
+  _resolution_verts_per_meter: {x: 40, y: 40}
   _size: {x: 0.2, y: 0.1}
   _nineSliced: 1
 --- !u!224 &560921529
@@ -334,6 +697,31 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0.2, y: 0.1}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!21 &649955368
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: Procedural Graphic Material
+  m_Shader: {fileID: 4800000, guid: 692ffa38f03db184d8b27b0661d5bf0d, type: 3}
+  m_ShaderKeywords: GRAPHIC_RENDERER_MOVEMENT_TRANSLATION GRAPHIC_RENDERER_VERTEX_COLORS
+    GRAPHIC_RENDERER_VERTEX_UV_0
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats: []
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
 --- !u!1 &652095305
 GameObject:
   m_ObjectHideFlags: 0
@@ -344,9 +732,10 @@ GameObject:
   - component: {fileID: 652095311}
   - component: {fileID: 652095310}
   - component: {fileID: 652095309}
-  - component: {fileID: 652095308}
   - component: {fileID: 652095307}
   - component: {fileID: 652095306}
+  - component: {fileID: 652095312}
+  - component: {fileID: 652095308}
   m_Layer: 0
   m_Name: Renderer (1)
   m_TagString: Untagged
@@ -383,7 +772,7 @@ MonoBehaviour:
     _format: 5
     _maxAtlasSize: 4096
     _extraTextures: []
-  _material: {fileID: 1236658139}
+  _material: {fileID: 649955368}
   _meshes: {fileID: 11400000, guid: fbd45d69d4e6a78429d0d41d32e61e43, type: 2}
   _packedTextures: {fileID: 11400000, guid: e7c4999a8002a684180116c650b69886, type: 2}
   _atlasUvs:
@@ -458,18 +847,24 @@ MonoBehaviour:
   channel: 1
 --- !u!114 &652095308
 MonoBehaviour:
-  m_ObjectHideFlags: 0
+  m_ObjectHideFlags: 3
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 652095305}
-  m_Enabled: 0
+  m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 9261239b711172441b484496a58d001c, type: 3}
+  m_Script: {fileID: 11500000, guid: cdb13d8a1ce808e4787f1af6f2e7fa1b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  parent: {fileID: 652095308}
-  space: {fileID: 652095308}
-  _radius: 1.39
+  renderer: {fileID: 652095310}
+  group: {fileID: 652095312}
+  _font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+  _dynamicPixelsPerUnit: 2
+  _useColor: 1
+  _globalTint: {r: 1, g: 1, b: 1, a: 1}
+  _shader: {fileID: 4800000, guid: 109077dfbfcd5f3469886d8b9ae4b056, type: 3}
+  _meshData: {fileID: 11400000, guid: ddfe1f04069627245b16f6e27241f851, type: 2}
+  scale: 0.005
 --- !u!114 &652095309
 MonoBehaviour:
   m_ObjectHideFlags: 3
@@ -506,10 +901,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: adb71699a7372344cb4e7a163c6c6922, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _selectedGroup: 0
+  _selectedGroup: 1
   _space: {fileID: 0}
   _groups:
   - {fileID: 652095309}
+  - {fileID: 652095312}
 --- !u!4 &652095311
 Transform:
   m_ObjectHideFlags: 0
@@ -521,9 +917,28 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 560921529}
+  - {fileID: 1373190237}
   m_Father: {fileID: 0}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &652095312
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 652095305}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b32d8e323bfd9df4d82051c22f44d792, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _renderingMethod: {fileID: 652095308}
+  _features: []
+  _renderer: {fileID: 652095310}
+  _graphics:
+  - {fileID: 1373190236}
+  _supportInfo: []
+  _addRemoveSupported: 0
 --- !u!1 &793918691
 GameObject:
   m_ObjectHideFlags: 0
@@ -535,7 +950,7 @@ GameObject:
   - component: {fileID: 793918693}
   - component: {fileID: 793918692}
   m_Layer: 0
-  m_Name: Panel
+  m_Name: SubPanel
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -609,7 +1024,7 @@ GameObject:
   - component: {fileID: 872725433}
   - component: {fileID: 872725432}
   m_Layer: 0
-  m_Name: Panel (1)
+  m_Name: SubPanel
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -672,31 +1087,84 @@ RectTransform:
   m_AnchoredPosition: {x: -0.01499999, y: -0.014999993}
   m_SizeDelta: {x: 0.019999996, y: 0.02}
   m_Pivot: {x: 1, y: 1}
---- !u!21 &1236658139
-Material:
-  serializedVersion: 6
+--- !u!1 &1292325069
+GameObject:
   m_ObjectHideFlags: 0
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
-  m_Name: Procedural Graphic Material
-  m_Shader: {fileID: 4800000, guid: 692ffa38f03db184d8b27b0661d5bf0d, type: 3}
-  m_ShaderKeywords: GRAPHIC_RENDERER_MOVEMENT_TRANSLATION GRAPHIC_RENDERER_VERTEX_COLORS
-    GRAPHIC_RENDERER_VERTEX_UV_0
-  m_LightmapFlags: 4
-  m_EnableInstancingVariants: 0
-  m_CustomRenderQueue: -1
-  stringTagMap: {}
-  disabledShaderPasses: []
-  m_SavedProperties:
-    serializedVersion: 3
-    m_TexEnvs:
-    - _MainTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Floats: []
-    m_Colors:
-    - _Color: {r: 1, g: 1, b: 1, a: 1}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1292325070}
+  - component: {fileID: 1292325071}
+  - component: {fileID: 1292325072}
+  m_Layer: 0
+  m_Name: Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1292325070
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1292325069}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1659788827}
+  - {fileID: 1810851944}
+  - {fileID: 1625068439}
+  - {fileID: 174371921}
+  m_Father: {fileID: 545613739}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0.2, y: 0.1}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1292325071
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1292325069}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 57cf8ea40c7f8fc4fa6a3afb12becedb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _anchor: {fileID: 545613736}
+  _featureData:
+  - {fileID: 1292325072}
+  _attachedGroup: {fileID: 545613737}
+  _preferredRendererType:
+    _fullName: Leap.Unity.GraphicalRenderer.LeapBakedRenderer
+  vertexColor: {r: 1, g: 1, b: 1, a: 1}
+  _sourceData: {fileID: 1292325072}
+  _resolutionType: 1
+  _resolution_vert_x: 8
+  _resolution_vert_y: 4
+  _resolution_verts_per_meter: {x: 40, y: 40}
+  _size: {x: 0.2, y: 0.1}
+  _nineSliced: 1
+--- !u!114 &1292325072
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1292325069}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b051eb69afb505b479d2ea649875e390, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  graphic: {fileID: 1292325071}
+  feature: {fileID: 545613735}
+  sprite: {fileID: 21300000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
 --- !u!1 &1372800847
 GameObject:
   m_ObjectHideFlags: 0
@@ -762,6 +1230,801 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 50, y: -30, z: 0}
+--- !u!1 &1373190235
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1373190237}
+  - component: {fileID: 1373190236}
+  m_Layer: 0
+  m_Name: Label
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1373190236
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1373190235}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 05db7042e72e26346af41d89e8da0377, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _anchor: {fileID: 0}
+  _featureData: []
+  _attachedGroup: {fileID: 652095312}
+  _preferredRendererType:
+    _fullName: Leap.Unity.GraphicalRenderer.LeapTextRenderer
+  _text: You can add LeapSpace components to your renderers, and all graphics will
+    become warped by that space!
+  _fontStyle: 0
+  _fontSize: 14
+  _lineSpacing: 1
+  _horizontalAlignment: 1
+  _verticalAlignment: 2
+  _color: {r: 1, g: 1, b: 1, a: 1}
+--- !u!224 &1373190237
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1373190235}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 652095311}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0.294}
+  m_SizeDelta: {x: 0.828, y: 0.412}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1513891853
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1513891854}
+  - component: {fileID: 1513891855}
+  - component: {fileID: 1513891856}
+  m_Layer: 0
+  m_Name: SubPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1513891854
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1513891853}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.0015}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1957524219}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0.015000001, y: 0.015000001}
+  m_SizeDelta: {x: 0.02, y: 0.020000003}
+  m_Pivot: {x: 0, y: 0}
+--- !u!114 &1513891855
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1513891853}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 57cf8ea40c7f8fc4fa6a3afb12becedb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _anchor: {fileID: 1617273998}
+  _featureData:
+  - {fileID: 1513891856}
+  _attachedGroup: {fileID: 1617273999}
+  _preferredRendererType:
+    _fullName: Leap.Unity.GraphicalRenderer.LeapBakedRenderer
+  vertexColor: {r: 1, g: 0.64137924, b: 0, a: 1}
+  _sourceData: {fileID: 1513891856}
+  _resolutionType: 0
+  _resolution_vert_x: 0
+  _resolution_vert_y: 0
+  _resolution_verts_per_meter: {x: 0, y: 0}
+  _size: {x: 0.02, y: 0.020000003}
+  _nineSliced: 0
+--- !u!114 &1513891856
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1513891853}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b051eb69afb505b479d2ea649875e390, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  graphic: {fileID: 1513891855}
+  feature: {fileID: 1617273997}
+  sprite: {fileID: 21300000, guid: 93f4f81256c947642a93d907d828ee98, type: 3}
+--- !u!1 &1521690815
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1521690816}
+  - component: {fileID: 1521690817}
+  - component: {fileID: 1521690818}
+  m_Layer: 0
+  m_Name: SubPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1521690816
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1521690815}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.0015}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1957524219}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0.015000001, y: -0.015000001}
+  m_SizeDelta: {x: 0.02, y: 0.02}
+  m_Pivot: {x: 0, y: 1}
+--- !u!114 &1521690817
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1521690815}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 57cf8ea40c7f8fc4fa6a3afb12becedb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _anchor: {fileID: 1617273998}
+  _featureData:
+  - {fileID: 1521690818}
+  _attachedGroup: {fileID: 1617273999}
+  _preferredRendererType:
+    _fullName: Leap.Unity.GraphicalRenderer.LeapBakedRenderer
+  vertexColor: {r: 1, g: 0, b: 0, a: 1}
+  _sourceData: {fileID: 1521690818}
+  _resolutionType: 0
+  _resolution_vert_x: 0
+  _resolution_vert_y: 0
+  _resolution_verts_per_meter: {x: 0, y: 0}
+  _size: {x: 0.02, y: 0.02}
+  _nineSliced: 0
+--- !u!114 &1521690818
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1521690815}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b051eb69afb505b479d2ea649875e390, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  graphic: {fileID: 1521690817}
+  feature: {fileID: 1617273997}
+  sprite: {fileID: 21300000, guid: 93f4f81256c947642a93d907d828ee98, type: 3}
+--- !u!1 &1617273995
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1617274001}
+  - component: {fileID: 1617274000}
+  - component: {fileID: 1617273999}
+  - component: {fileID: 1617273997}
+  - component: {fileID: 1617273996}
+  - component: {fileID: 1617273998}
+  m_Layer: 0
+  m_Name: Renderer (3)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1617273996
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1617273995}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 00bb44340bd430d44a098a5e36f4de2d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  renderer: {fileID: 1617274000}
+  group: {fileID: 1617273999}
+  _useUv0: 1
+  _useUv1: 0
+  _useUv2: 0
+  _useUv3: 0
+  _useColors: 1
+  _bakedTint: {r: 1, g: 1, b: 1, a: 1}
+  _useNormals: 0
+  _shader: {fileID: 4800000, guid: 692ffa38f03db184d8b27b0661d5bf0d, type: 3}
+  _atlas:
+    _border: 0
+    _padding: 0
+    _mipMap: 1
+    _filterMode: 1
+    _format: 5
+    _maxAtlasSize: 4096
+    _extraTextures: []
+  _material: {fileID: 114360703}
+  _meshes: {fileID: 11400000, guid: 8ece946f0fae1a14baef520d76f930cc, type: 2}
+  _packedTextures: {fileID: 11400000, guid: 68853936f2981954c92be2f059689294, type: 2}
+  _atlasUvs:
+    _channel0:
+      _keys:
+      - {fileID: 21300000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
+      - {fileID: 21300000, guid: 93f4f81256c947642a93d907d828ee98, type: 3}
+      _values:
+      - serializedVersion: 2
+        x: 0
+        y: 0
+        width: 0
+        height: 0
+      - serializedVersion: 2
+        x: 0
+        y: 0
+        width: 0
+        height: 0
+    _channel1:
+      _keys: []
+      _values: []
+    _channel2:
+      _keys: []
+      _values: []
+    _channel3:
+      _keys: []
+      _values: []
+    _nullRects:
+    - serializedVersion: 2
+      x: 0
+      y: 0
+      width: 0
+      height: 0
+    - serializedVersion: 2
+      x: 0
+      y: 0
+      width: 0
+      height: 0
+    - serializedVersion: 2
+      x: 0
+      y: 0
+      width: 0
+      height: 0
+    - serializedVersion: 2
+      x: 0
+      y: 0
+      width: 0
+      height: 0
+  _layer:
+    layerIndex: 0
+  _motionType: 1
+  _createMeshRenderers: 0
+  _renderers: []
+--- !u!114 &1617273997
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1617273995}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: eb8619b4d0e4d744183adf2e5fb82581, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  featureData:
+  - {fileID: 1957524221}
+  - {fileID: 1521690818}
+  - {fileID: 389062208}
+  - {fileID: 1513891856}
+  - {fileID: 1966825827}
+  propertyName: _MainTex
+  channel: 1
+--- !u!114 &1617273998
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1617273995}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6184fcf20cdbf3d40b3f95010efb82ad, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  parent: {fileID: 1617273998}
+  space: {fileID: 1617273998}
+  _radius: 0.1
+--- !u!114 &1617273999
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1617273995}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b32d8e323bfd9df4d82051c22f44d792, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _renderingMethod: {fileID: 1617273996}
+  _features:
+  - {fileID: 1617273997}
+  _renderer: {fileID: 1617274000}
+  _graphics:
+  - {fileID: 1957524220}
+  - {fileID: 1521690817}
+  - {fileID: 389062207}
+  - {fileID: 1513891855}
+  - {fileID: 1966825828}
+  _supportInfo:
+  - support: 0
+    message: 
+  _addRemoveSupported: 0
+--- !u!114 &1617274000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1617273995}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: adb71699a7372344cb4e7a163c6c6922, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _selectedGroup: 0
+  _space: {fileID: 1617273998}
+  _groups:
+  - {fileID: 1617273999}
+--- !u!4 &1617274001
+Transform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1617273995}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.3, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1957524219}
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1625068438
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1625068439}
+  - component: {fileID: 1625068440}
+  - component: {fileID: 1625068441}
+  m_Layer: 0
+  m_Name: SubPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1625068439
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1625068438}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.0015}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1292325070}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0.015000001, y: 0.015000001}
+  m_SizeDelta: {x: 0.02, y: 0.020000003}
+  m_Pivot: {x: 0, y: 0}
+--- !u!114 &1625068440
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1625068438}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 57cf8ea40c7f8fc4fa6a3afb12becedb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _anchor: {fileID: 545613736}
+  _featureData:
+  - {fileID: 1625068441}
+  _attachedGroup: {fileID: 545613737}
+  _preferredRendererType:
+    _fullName: Leap.Unity.GraphicalRenderer.LeapBakedRenderer
+  vertexColor: {r: 1, g: 0.64137924, b: 0, a: 1}
+  _sourceData: {fileID: 1625068441}
+  _resolutionType: 0
+  _resolution_vert_x: 0
+  _resolution_vert_y: 0
+  _resolution_verts_per_meter: {x: 0, y: 0}
+  _size: {x: 0.02, y: 0.020000003}
+  _nineSliced: 0
+--- !u!114 &1625068441
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1625068438}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b051eb69afb505b479d2ea649875e390, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  graphic: {fileID: 1625068440}
+  feature: {fileID: 545613735}
+  sprite: {fileID: 21300000, guid: 93f4f81256c947642a93d907d828ee98, type: 3}
+--- !u!1 &1659788826
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1659788827}
+  - component: {fileID: 1659788828}
+  - component: {fileID: 1659788829}
+  m_Layer: 0
+  m_Name: SubPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1659788827
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1659788826}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.0015}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1292325070}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 0.015000001, y: -0.015000001}
+  m_SizeDelta: {x: 0.02, y: 0.02}
+  m_Pivot: {x: 0, y: 1}
+--- !u!114 &1659788828
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1659788826}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 57cf8ea40c7f8fc4fa6a3afb12becedb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _anchor: {fileID: 545613736}
+  _featureData:
+  - {fileID: 1659788829}
+  _attachedGroup: {fileID: 545613737}
+  _preferredRendererType:
+    _fullName: Leap.Unity.GraphicalRenderer.LeapBakedRenderer
+  vertexColor: {r: 1, g: 0, b: 0, a: 1}
+  _sourceData: {fileID: 1659788829}
+  _resolutionType: 0
+  _resolution_vert_x: 0
+  _resolution_vert_y: 0
+  _resolution_verts_per_meter: {x: 0, y: 0}
+  _size: {x: 0.02, y: 0.02}
+  _nineSliced: 0
+--- !u!114 &1659788829
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1659788826}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b051eb69afb505b479d2ea649875e390, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  graphic: {fileID: 1659788828}
+  feature: {fileID: 545613735}
+  sprite: {fileID: 21300000, guid: 93f4f81256c947642a93d907d828ee98, type: 3}
+--- !u!1 &1810851943
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1810851944}
+  - component: {fileID: 1810851945}
+  - component: {fileID: 1810851946}
+  m_Layer: 0
+  m_Name: SubPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1810851944
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1810851943}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.0015}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1292325070}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 1}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -0.014999993, y: -0.014999993}
+  m_SizeDelta: {x: 0.019999996, y: 0.02}
+  m_Pivot: {x: 1, y: 1}
+--- !u!114 &1810851945
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1810851943}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 57cf8ea40c7f8fc4fa6a3afb12becedb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _anchor: {fileID: 545613736}
+  _featureData:
+  - {fileID: 1810851946}
+  _attachedGroup: {fileID: 545613737}
+  _preferredRendererType:
+    _fullName: Leap.Unity.GraphicalRenderer.LeapBakedRenderer
+  vertexColor: {r: 0.0862069, g: 0.7352941, b: 0, a: 1}
+  _sourceData: {fileID: 1810851946}
+  _resolutionType: 0
+  _resolution_vert_x: 0
+  _resolution_vert_y: 0
+  _resolution_verts_per_meter: {x: 0, y: 0}
+  _size: {x: 0.019999996, y: 0.02}
+  _nineSliced: 0
+--- !u!114 &1810851946
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1810851943}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b051eb69afb505b479d2ea649875e390, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  graphic: {fileID: 1810851945}
+  feature: {fileID: 545613735}
+  sprite: {fileID: 21300000, guid: 93f4f81256c947642a93d907d828ee98, type: 3}
+--- !u!1 &1957524218
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1957524219}
+  - component: {fileID: 1957524220}
+  - component: {fileID: 1957524221}
+  m_Layer: 0
+  m_Name: Panel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1957524219
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1957524218}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1521690816}
+  - {fileID: 389062206}
+  - {fileID: 1513891854}
+  - {fileID: 1966825829}
+  m_Father: {fileID: 1617274001}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0.2, y: 0.1}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1957524220
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1957524218}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 57cf8ea40c7f8fc4fa6a3afb12becedb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _anchor: {fileID: 1617273998}
+  _featureData:
+  - {fileID: 1957524221}
+  _attachedGroup: {fileID: 1617273999}
+  _preferredRendererType:
+    _fullName: Leap.Unity.GraphicalRenderer.LeapBakedRenderer
+  vertexColor: {r: 1, g: 1, b: 1, a: 1}
+  _sourceData: {fileID: 1957524221}
+  _resolutionType: 1
+  _resolution_vert_x: 8
+  _resolution_vert_y: 4
+  _resolution_verts_per_meter: {x: 40, y: 40}
+  _size: {x: 0.2, y: 0.1}
+  _nineSliced: 1
+--- !u!114 &1957524221
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1957524218}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b051eb69afb505b479d2ea649875e390, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  graphic: {fileID: 1957524220}
+  feature: {fileID: 1617273997}
+  sprite: {fileID: 21300000, guid: c0aa9a7cf40cebd4dabb357d3ff4c976, type: 3}
+--- !u!1 &1966825826
+GameObject:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  serializedVersion: 5
+  m_Component:
+  - component: {fileID: 1966825829}
+  - component: {fileID: 1966825828}
+  - component: {fileID: 1966825827}
+  m_Layer: 0
+  m_Name: SubPanel
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1966825827
+MonoBehaviour:
+  m_ObjectHideFlags: 3
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1966825826}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b051eb69afb505b479d2ea649875e390, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  graphic: {fileID: 1966825828}
+  feature: {fileID: 1617273997}
+  sprite: {fileID: 21300000, guid: 93f4f81256c947642a93d907d828ee98, type: 3}
+--- !u!114 &1966825828
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1966825826}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 57cf8ea40c7f8fc4fa6a3afb12becedb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _anchor: {fileID: 1617273998}
+  _featureData:
+  - {fileID: 1966825827}
+  _attachedGroup: {fileID: 1617273999}
+  _preferredRendererType:
+    _fullName: Leap.Unity.GraphicalRenderer.LeapBakedRenderer
+  vertexColor: {r: 0.07586192, g: 0, b: 1, a: 1}
+  _sourceData: {fileID: 1966825827}
+  _resolutionType: 0
+  _resolution_vert_x: 0
+  _resolution_vert_y: 0
+  _resolution_verts_per_meter: {x: 0, y: 0}
+  _size: {x: 0.019999996, y: 0.020000003}
+  _nineSliced: 0
+--- !u!224 &1966825829
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_GameObject: {fileID: 1966825826}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: -0.0015}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1957524219}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: -0.015000001, y: 0.015000001}
+  m_SizeDelta: {x: 0.019999996, y: 0.020000003}
+  m_Pivot: {x: 1, y: 0}
+--- !u!21 &2092193198
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_PrefabParentObject: {fileID: 0}
+  m_PrefabInternal: {fileID: 0}
+  m_Name: Procedural Graphic Material
+  m_Shader: {fileID: 4800000, guid: 692ffa38f03db184d8b27b0661d5bf0d, type: 3}
+  m_ShaderKeywords: GRAPHIC_RENDERER_CYLINDRICAL GRAPHIC_RENDERER_MOVEMENT_TRANSLATION
+    GRAPHIC_RENDERER_VERTEX_COLORS GRAPHIC_RENDERER_VERTEX_UV_0
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats: []
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
 --- !u!1 &2102241332
 GameObject:
   m_ObjectHideFlags: 0
@@ -820,7 +2083,7 @@ Camera:
     height: 1
   near clip plane: 0.3
   far clip plane: 1000
-  field of view: 60
+  field of view: 46.2
   orthographic: 0
   orthographic size: 5
   m_Depth: -1
@@ -845,7 +2108,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 2102241332}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 1, z: -10}
+  m_LocalPosition: {x: 0, y: 0.225, z: -0.839}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}

--- a/Assets/LeapMotionModules/GraphicRenderer/Scenes/Curved Space Examples.unity.meta
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scenes/Curved Space Examples.unity.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c38ca06da8ae90347ad18aca2a2b839b
+timeCreated: 1493325386
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapMotionModules/GraphicRenderer/Scenes/Surface Shader Examples.unity
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scenes/Surface Shader Examples.unity
@@ -1607,12 +1607,12 @@ Material:
     serializedVersion: 3
     m_TexEnvs:
     - _MainTex:
-        m_Texture: {fileID: 28549311730435358, guid: 2d24c2ee4df80934c8b4ea3bcbc6ea2c,
-          type: 2}
+        m_Texture: {fileID: 0}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     m_Floats: []
-    m_Colors: []
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
 --- !u!1 &1819810250
 GameObject:
   m_ObjectHideFlags: 0
@@ -1929,7 +1929,7 @@ MonoBehaviour:
   _useColor: 1
   _globalTint: {r: 1, g: 1, b: 1, a: 1}
   _shader: {fileID: 4800000, guid: 109077dfbfcd5f3469886d8b9ae4b056, type: 3}
-  _meshData: {fileID: 11400000, guid: 84afbb7dee28c1947becff779c4d480e, type: 2}
+  _meshData: {fileID: 11400000, guid: 9d5e7b2ae4a6c1542ac3c4b5b23a2315, type: 2}
   scale: 0.015
 --- !u!114 &1985179170
 MonoBehaviour:
@@ -1983,8 +1983,8 @@ MonoBehaviour:
     _maxAtlasSize: 4096
     _extraTextures: []
   _material: {fileID: 1680639321}
-  _meshes: {fileID: 11400000, guid: 5f64e76ca966f2648aea4f7f53d1b8c6, type: 2}
-  _packedTextures: {fileID: 11400000, guid: 2d24c2ee4df80934c8b4ea3bcbc6ea2c, type: 2}
+  _meshes: {fileID: 11400000, guid: 31a7f34045425ed488a5d4ee019e18a1, type: 2}
+  _packedTextures: {fileID: 11400000, guid: 88c3465d516f70c47a802e47f751d4bd, type: 2}
   _atlasUvs:
     _channel0:
       _keys:
@@ -2156,7 +2156,7 @@ MonoBehaviour:
   - {fileID: 634078603}
   - {fileID: 1819810251}
   - {fileID: 785706452}
-  _channelName: _Glossiness
+  _channelName: _Smoothness
 --- !u!114 &1985179181
 MonoBehaviour:
   m_ObjectHideFlags: 3
@@ -2209,8 +2209,8 @@ MonoBehaviour:
     _maxAtlasSize: 4096
     _extraTextures: []
   _material: {fileID: 1993401699}
-  _meshes: {fileID: 11400000, guid: af825852ce43b9c44ad66571f7329af8, type: 2}
-  _packedTextures: {fileID: 11400000, guid: aefc48970a310934ea6efaa6a2cc0c52, type: 2}
+  _meshes: {fileID: 11400000, guid: 9cda3561f67e3bf4ca6531f4fbbfa352, type: 2}
+  _packedTextures: {fileID: 11400000, guid: 39008675608f9f244be1ef97ac570eb9, type: 2}
   _atlasUvs:
     _channel0:
       _keys:
@@ -2327,7 +2327,7 @@ Material:
     serializedVersion: 3
     m_TexEnvs:
     - _MainTex:
-        m_Texture: {fileID: 28643639833991140, guid: aefc48970a310934ea6efaa6a2cc0c52,
+        m_Texture: {fileID: 28671576554361086, guid: 39008675608f9f244be1ef97ac570eb9,
           type: 2}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
@@ -2336,7 +2336,8 @@ Material:
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
     m_Floats: []
-    m_Colors: []
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
 --- !u!1 &2014846562
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/EditTimeApis/LeapGraphicGroupEditorApi.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/EditTimeApis/LeapGraphicGroupEditorApi.cs
@@ -29,9 +29,6 @@ namespace Leap.Unity.GraphicalRenderer {
           if (_group._renderingMethod != null) {
             _group._addRemoveSupported &= typeof(ISupportsAddRemove).IsAssignableFrom(_group._renderingMethod.GetType());
           }
-          if (_group._renderer.space != null) {
-            _group._addRemoveSupported &= typeof(ISupportsAddRemove).IsAssignableFrom(_group._renderer.space.GetType());
-          }
         }
 
         for (int i = _group._features.Count; i-- != 0;) {

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/EditTimeApis/LeapGraphicGroupEditorApi.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/EditTimeApis/LeapGraphicGroupEditorApi.cs
@@ -114,6 +114,8 @@ namespace Leap.Unity.GraphicalRenderer {
         }
 
         _group._renderingMethod.OnEnableRendererEditor();
+
+        OnValidate();
       }
 
       public LeapGraphicFeatureBase AddFeature(Type featureType) {

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/Editor/LeapGraphicEditor.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/Editor/LeapGraphicEditor.cs
@@ -142,6 +142,10 @@ public abstract class LeapGraphicEditorBase<T> : CustomEditorBase<T> where T : L
         tempArray = new UnityEngine.Object[targets.Length];
       }
 
+      if (mainGraphic.attachedGroup != null) {
+        SpriteAtlasUtil.ShowInvalidSpriteWarning(mainGraphic.attachedGroup.features);
+      }
+
       int maxGraphics = LeapGraphicPreferences.graphicMax;
       if (targets.Query().Any(e => e.attachedGroup != null && e.attachedGroup.graphics.IndexOf(e) >= maxGraphics)) {
         string noun = targets.Length == 1 ? "This graphic" : "Some of these graphics";

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/Editor/LeapGraphicEditor.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/Editor/LeapGraphicEditor.cs
@@ -188,7 +188,7 @@ public abstract class LeapGraphicEditorBase<T> : CustomEditorBase<T> where T : L
                 Select(e => e.featureData.Query().
                                           OfType(mainDataType).
                                           ElementAtOrDefault(typeIndex)).
-                NonNull().
+                ValidUnityObjs().
                 Cast<UnityEngine.Object>().
                 AppendList(tempList);
 
@@ -245,7 +245,7 @@ public abstract class LeapGraphicEditorBase<T> : CustomEditorBase<T> where T : L
   protected Bounds OnGetFrameBounds() {
     return targets.Query().
                    Select(e => e.editor.pickingMesh).
-                   NonNull().
+                   ValidUnityObjs().
                    Select(m => m.bounds).
                    Fold((a, b) => {
                      a.Encapsulate(b);

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/Editor/LeapGraphicGroupEditor.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/Editor/LeapGraphicGroupEditor.cs
@@ -101,18 +101,7 @@ namespace Leap.Unity.GraphicalRenderer {
     private void featureDecorator(SerializedProperty property) {
       int graphicMax = LeapGraphicPreferences.graphicMax;
 
-      var anyRectsInvalid = target.features.Query().
-                                            OfType<LeapSpriteFeature>().
-                                            SelectMany(f => f.featureData.Query().
-                                                                          Select(d => d.sprite).
-                                                                          NonNull()).
-                                            Select(s => SpriteAtlasUtil.GetAtlasedRect(s)).
-                                            Any(r => r.Area() == 0);
-
-      if (anyRectsInvalid) {
-        EditorGUILayout.HelpBox("Due to a Unity bug, packed sprites may be invalid until " +
-                                "PlayMode has been entered at least once.", MessageType.Warning);
-      }
+      SpriteAtlasUtil.ShowInvalidSpriteWarning(target.features);
 
       if (target.graphics.Count > graphicMax) {
         EditorGUILayout.HelpBox("This gui currently has " + target.graphics.Count.ToString() +

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/Editor/LeapGraphicGroupEditor.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/Editor/LeapGraphicGroupEditor.cs
@@ -101,6 +101,19 @@ namespace Leap.Unity.GraphicalRenderer {
     private void featureDecorator(SerializedProperty property) {
       int graphicMax = LeapGraphicPreferences.graphicMax;
 
+      var anyRectsInvalid = target.features.Query().
+                                            OfType<LeapSpriteFeature>().
+                                            SelectMany(f => f.featureData.Query().
+                                                                          Select(d => d.sprite).
+                                                                          NonNull()).
+                                            Select(s => SpriteAtlasUtil.GetAtlasedRect(s)).
+                                            Any(r => r.Area() == 0);
+
+      if (anyRectsInvalid) {
+        EditorGUILayout.HelpBox("Due to a Unity bug, packed sprites may be invalid until " +
+                                "PlayMode has been entered at least once.", MessageType.Warning);
+      }
+
       if (target.graphics.Count > graphicMax) {
         EditorGUILayout.HelpBox("This gui currently has " + target.graphics.Count.ToString() +
                                 " graphics, which is greater than the maximum of " +

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/Editor/LeapGraphicRendererEditor.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/Editor/LeapGraphicRendererEditor.cs
@@ -161,7 +161,7 @@ namespace Leap.Unity.GraphicalRenderer {
       return _renderer.groups.Query().
                          SelectMany(g => g.graphics.Query()).
                          Select(e => e.editor.pickingMesh).
-                         NonNull().
+                         ValidUnityObjs().
                          Select(m => m.bounds).
                          Fold((a, b) => {
                            a.Encapsulate(b);

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/LeapGraphicGroup.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/LeapGraphicGroup.cs
@@ -114,6 +114,7 @@ namespace Leap.Unity.GraphicalRenderer {
       Assert.IsNotNull(graphic);
 
       if (!addRemoveSupportedOrEditTime()) {
+        Debug.LogWarning("Adding graphics at runtime is not supported by this rendering method.");
         return false;
       }
 
@@ -130,6 +131,7 @@ namespace Leap.Unity.GraphicalRenderer {
           //This can easily happen at edit time due to prefab shenanigans 
           graphic.OnDetachedFromGroup();
         } else {
+          Debug.LogWarning("Could not add graphic because it was already a part of this group.");
           return false;
         }
       }
@@ -144,6 +146,12 @@ namespace Leap.Unity.GraphicalRenderer {
       //TODO: this is gonna need to be optimized
       RebuildFeatureData();
       RebuildFeatureSupportInfo();
+
+      //TODO: this is gonna need to be optimized too
+      if (_renderer.space != null) {
+        _renderer.space.RebuildHierarchy();
+        _renderer.space.RecalculateTransformers();
+      }
 
 #if UNITY_EDITOR
       if (!Application.isPlaying) {
@@ -161,11 +169,13 @@ namespace Leap.Unity.GraphicalRenderer {
       Assert.IsNotNull(graphic);
 
       if (!addRemoveSupportedOrEditTime()) {
+        Debug.LogWarning("Removing graphics at runtime is not supported by this rendering method.");
         return false;
       }
 
       int graphicIndex = _graphics.IndexOf(graphic);
       if (graphicIndex < 0) {
+        Debug.LogWarning("Could note remove this graphic because it was not part of the group.");
         return false;
       }
 

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/LeapGraphicGroup.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/LeapGraphicGroup.cs
@@ -114,7 +114,6 @@ namespace Leap.Unity.GraphicalRenderer {
       Assert.IsNotNull(graphic);
 
       if (!addRemoveSupportedOrEditTime()) {
-        Debug.LogWarning("Adding graphics at runtime is not supported by this rendering method.");
         return false;
       }
 
@@ -169,13 +168,11 @@ namespace Leap.Unity.GraphicalRenderer {
       Assert.IsNotNull(graphic);
 
       if (!addRemoveSupportedOrEditTime()) {
-        Debug.LogWarning("Removing graphics at runtime is not supported by this rendering method.");
         return false;
       }
 
       int graphicIndex = _graphics.IndexOf(graphic);
       if (graphicIndex < 0) {
-        Debug.LogWarning("Could note remove this graphic because it was not part of the group.");
         return false;
       }
 

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/LeapRendereringMethod.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/LeapRendereringMethod.cs
@@ -75,7 +75,8 @@ namespace Leap.Unity.GraphicalRenderer {
     /// not called all the time!
     /// </summary>
     public virtual void OnUpdateRendererEditor(bool isHeavyUpdate) {
-      Undo.RecordObject(this, "Updated Renderer");
+      Undo.RecordObject(this, "Updated Renderer " + isHeavyUpdate);
+      Undo.CollapseUndoOperations(Undo.GetCurrentGroup());
       this.isHeavyUpdate = isHeavyUpdate;
     }
 #endif

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/RenderingMethods/LeapMesherBase.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/RenderingMethods/LeapMesherBase.cs
@@ -410,7 +410,7 @@ namespace Leap.Unity.GraphicalRenderer {
     }
 
     protected virtual void prepareMaterial() {
-      if (_material == null) {
+      if (_material == null || isHeavyUpdate) {
         _material = new Material(_shader);
       }
 

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/RenderingMethods/LeapMesherBase.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/RenderingMethods/LeapMesherBase.cs
@@ -190,7 +190,9 @@ namespace Leap.Unity.GraphicalRenderer {
       SupportUtil.OnlySupportFirstFeature(features, info);
 
 #if UNITY_EDITOR
-      Packer.RebuildAtlasCacheIfNeeded(EditorUserBuildSettings.activeBuildTarget);
+      if (!Application.isPlaying) {
+        Packer.RebuildAtlasCacheIfNeeded(EditorUserBuildSettings.activeBuildTarget);
+      }
 
       for (int i = 0; i < features.Count; i++) {
         var feature = features[i];
@@ -430,19 +432,7 @@ namespace Leap.Unity.GraphicalRenderer {
             var sprite = dataObj.sprite;
             if (sprite == null) continue;
 
-            Vector2[] uvs = SpriteAtlasUtil.GetAtlasedUvs(sprite);
-            float minX, minY, maxX, maxY;
-            minX = maxX = uvs[0].x;
-            minY = maxY = uvs[0].y;
-
-            for (int j = 1; j < uvs.Length; j++) {
-              minX = Mathf.Min(minX, uvs[j].x);
-              minY = Mathf.Min(minY, uvs[j].y);
-              maxX = Mathf.Max(maxX, uvs[j].x);
-              maxY = Mathf.Max(maxY, uvs[j].y);
-            }
-
-            Rect rect = Rect.MinMaxRect(minX, minY, maxX, maxY);
+            Rect rect = SpriteAtlasUtil.GetAtlasedRect(sprite);
             _atlasUvs.SetRect(spriteFeature.channel.Index(), sprite, rect);
           }
         }

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/Utility/AttachedObjectHandler.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/Utility/AttachedObjectHandler.cs
@@ -72,14 +72,14 @@ namespace Leap.Unity.GraphicalRenderer {
     }
 
     public static void Validate<T, K>(T t, List<K> ks) where T : Component where K : Component {
-      K mainK = ks.Query().NonNull().FirstOrDefault();
+      K mainK = ks.Query().ValidUnityObjs().FirstOrDefault();
 
       if (mainK == null) {
         return;
       }
 
       GameObject mainKObj = mainK.gameObject;
-      if (ks.Query().NonNull().Any(k => k.gameObject != mainKObj)) {
+      if (ks.Query().ValidUnityObjs().Any(k => k.gameObject != mainKObj)) {
         Debug.LogError("Could not validate attached objects because they were on different gameObjects");
         return;
       }

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/Utility/SpriteUtil.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/Utility/SpriteUtil.cs
@@ -7,6 +7,23 @@ namespace Leap.Unity.GraphicalRenderer {
 
   public static class SpriteAtlasUtil {
 
+    public static Rect GetAtlasedRect(Sprite sprite) {
+      Vector2[] uvs = GetAtlasedUvs(sprite);
+
+      float minX, minY, maxX, maxY;
+      minX = maxX = uvs[0].x;
+      minY = maxY = uvs[0].y;
+
+      for (int j = 1; j < uvs.Length; j++) {
+        minX = Mathf.Min(minX, uvs[j].x);
+        minY = Mathf.Min(minY, uvs[j].y);
+        maxX = Mathf.Max(maxX, uvs[j].x);
+        maxY = Mathf.Max(maxY, uvs[j].y);
+      }
+
+      return Rect.MinMaxRect(minX, minY, maxX, maxY);
+    }
+
     public static Vector2[] GetAtlasedUvs(Sprite sprite) {
 #if UNITY_EDITOR
       if (!Application.isPlaying)

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/Utility/SpriteUtil.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/Utility/SpriteUtil.cs
@@ -1,11 +1,31 @@
 ﻿using UnityEngine;
 #if UNITY_EDITOR
+using UnityEditor;
 using UnityEditor.Sprites;
 #endif
+using System.Collections.Generic;
+using Leap.Unity.Query;
 
 namespace Leap.Unity.GraphicalRenderer {
 
   public static class SpriteAtlasUtil {
+
+#if UNITY_EDITOR
+    public static void ShowInvalidSpriteWarning(List<LeapGraphicFeatureBase> features) {
+      var anyRectsInvalid = features.Query().
+                                     OfType<LeapSpriteFeature>().
+                                     SelectMany(f => f.featureData.Query().
+                                                                   Select(d => d.sprite).
+                                                                   NonNull()).
+                                     Select(s => SpriteAtlasUtil.GetAtlasedRect(s)).
+                                     Any(r => r.Area() == 0);
+
+      if (anyRectsInvalid) {
+        EditorGUILayout.HelpBox("Due to a Unity bug, packed sprites may be invalid until " +
+                                "PlayMode has been entered at least once.", MessageType.Warning);
+      }
+    }
+#endif
 
     public static Rect GetAtlasedRect(Sprite sprite) {
       Vector2[] uvs = GetAtlasedUvs(sprite);

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/Utility/SpriteUtil.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/Utility/SpriteUtil.cs
@@ -15,9 +15,9 @@ namespace Leap.Unity.GraphicalRenderer {
       var anyRectsInvalid = features.Query().
                                      OfType<LeapSpriteFeature>().
                                      SelectMany(f => f.featureData.Query().
-                                                                   Select(d => d.sprite).
-                                                                   NonNull()).
-                                     Select(s => SpriteAtlasUtil.GetAtlasedRect(s)).
+                                                                   Select(d => d.sprite)).
+                                     ValidUnityObjs().
+                                     Select(s => GetAtlasedRect(s)).
                                      Any(r => r.Area() == 0);
 
       if (anyRectsInvalid) {

--- a/Assets/LeapMotionModules/GraphicRenderer/Shaders/Example Shaders/Baked_SurfaceExample1.shader
+++ b/Assets/LeapMotionModules/GraphicRenderer/Shaders/Example Shaders/Baked_SurfaceExample1.shader
@@ -23,12 +23,11 @@
     struct Input {
       SURF_INPUT_GRAPHICAL
       float2 uv_MainTex;
-      float2 metalAndGloss;
+      float2 smoothness;
       float4 specularColor;
     };
 
-    DEFINE_FLOAT_CHANNEL(_Metallic);
-    DEFINE_FLOAT_CHANNEL(_Glossiness);
+    DEFINE_FLOAT_CHANNEL(_Smoothness);
     DEFINE_FLOAT4_CHANNEL(_SpecularColor);
     sampler2D _MainTex;
 
@@ -38,8 +37,7 @@
 
       APPLY_BAKED_GRAPHICS_STANDARD(v, o);   
 
-      o.metalAndGloss.x = getChannel(_Metallic);
-      o.metalAndGloss.y = getChannel(_Glossiness);
+      o.smoothness = getChannel(_Smoothness);
       o.specularColor = getChannel(_SpecularColor);
     }
 
@@ -52,7 +50,7 @@
     void surf (Input IN, inout SurfaceOutputStandardSpecular o) {
       o.Albedo = tex2D(_MainTex, IN.uv_MainTex).rgb;
       o.Specular = IN.specularColor;
-      o.Smoothness = IN.metalAndGloss.y;
+      o.Smoothness = IN.smoothness;
     }
     ENDCG
   }

--- a/Assets/LeapMotionModules/GraphicRenderer/Shaders/Example Shaders/Baked_Surface_Basic.shader
+++ b/Assets/LeapMotionModules/GraphicRenderer/Shaders/Example Shaders/Baked_Surface_Basic.shader
@@ -1,0 +1,41 @@
+﻿Shader "Leap Motion/Graphic Renderer/Examples/Bake 1" {
+  Properties {
+    _Color("Color", Color) = (1,1,1,1)
+    _MainTex ("Albedo (RGB)", 2D) = "white" {}
+  }
+  SubShader {
+    Tags { "RenderType"="Opaque" }
+    LOD 200
+    
+    CGPROGRAM
+    #pragma surface surf Standard fullforwardshadows vertex:vert addshadow 
+    #pragma target 3.0
+
+    #define GRAPHIC_RENDERER_VERTEX_UV_0
+    #define GRAPHIC_RENDERER_VERTEX_NORMALS
+    #define GRAPHIC_RENDERER_MOVEMENT_TRANSLATION
+
+    #pragma shader_feature _ GRAPHIC_RENDERER_CYLINDRICAL GRAPHIC_RENDERER_SPHERICAL
+    #include "Assets/LeapMotionModules/GraphicRenderer/Resources/BakedRenderer.cginc"
+    #include "UnityCG.cginc"
+
+    struct Input {
+      SURF_INPUT_GRAPHICAL
+      float2 uv_MainTex;
+    };
+
+    sampler2D _MainTex;
+
+    void vert(inout appdata_graphic_baked v, out Input o) {
+      UNITY_INITIALIZE_OUTPUT(Input, o);
+      BEGIN_V2F(v);
+      APPLY_BAKED_GRAPHICS_STANDARD(v, o);   
+    }
+
+    void surf (Input IN, inout SurfaceOutputStandard o) {
+      o.Albedo = tex2D(_MainTex, IN.uv_MainTex).rgb;
+    }
+    ENDCG
+  }
+  FallBack "Diffuse"
+}

--- a/Assets/LeapMotionModules/GraphicRenderer/Shaders/Example Shaders/Baked_Surface_Basic.shader.meta
+++ b/Assets/LeapMotionModules/GraphicRenderer/Shaders/Example Shaders/Baked_Surface_Basic.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: ef0749350c0ebba4a93dd89982ea75a9
+timeCreated: 1492803908
+licenseType: Free
+ShaderImporter:
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapMotionModules/GraphicRenderer/Shaders/Example Shaders/Dynamic_Surface_Basic.shader
+++ b/Assets/LeapMotionModules/GraphicRenderer/Shaders/Example Shaders/Dynamic_Surface_Basic.shader
@@ -1,0 +1,47 @@
+﻿Shader "Leap Motion/Graphic Renderer/Dynamic/Basic" {
+  Properties {
+    _Color("Color", Color) = (1,1,1,1)
+    _MainTex ("Albedo (RGB)", 2D) = "white" {}
+  }
+  SubShader {
+    Tags { "Queue"="Transparent" "RenderType"="Transparent" }
+    LOD 200
+    
+    ZWrite Off
+    ZTest On
+
+    CGPROGRAM
+    #pragma surface surf Standard alpha:blend fullforwardshadows vertex:vert addshadow 
+    #pragma target 3.0
+
+    //Our graphics always has the following features
+    #define GRAPHIC_RENDERER_VERTEX_UV_0
+    #define GRAPHIC_RENDERER_VERTEX_COLORS
+    #define GRAPHIC_RENDERER_VERTEX_NORMALS
+
+    #pragma shader_feature _ GRAPHIC_RENDERER_CYLINDRICAL GRAPHIC_RENDERER_SPHERICAL
+    #include "Assets/LeapMotionModules/GraphicRenderer/Resources/DynamicRenderer.cginc"
+    #include "UnityCG.cginc"
+
+    struct Input {
+      SURF_INPUT_GRAPHICAL
+      float2 uv_MainTex;
+    };
+
+    sampler2D _MainTex;
+
+    void vert(inout appdata_graphic_dynamic v, out Input o) {
+      UNITY_INITIALIZE_OUTPUT(Input, o);
+      BEGIN_V2F(v);
+      APPLY_DYNAMIC_GRAPHICS_STANDARD(v, o);
+    }
+
+    void surf(Input IN, inout SurfaceOutputStandard o) {
+      fixed4 color = tex2D(_MainTex, IN.uv_MainTex) * IN.color;
+      o.Albedo = color.rgb;
+      o.Alpha = color.a;
+    }
+    ENDCG
+  }
+  FallBack "Diffuse"
+}

--- a/Assets/LeapMotionModules/GraphicRenderer/Shaders/Example Shaders/Dynamic_Surface_Basic.shader.meta
+++ b/Assets/LeapMotionModules/GraphicRenderer/Shaders/Example Shaders/Dynamic_Surface_Basic.shader.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: f8e996b2e23d82847b27d2e0fcfa6a65
+timeCreated: 1492803908
+licenseType: Free
+ShaderImporter:
+  defaultTextures: []
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/EditorSettings.asset
+++ b/ProjectSettings/EditorSettings.asset
@@ -7,7 +7,7 @@ EditorSettings:
   m_ExternalVersionControlSupport: Visible Meta Files
   m_SerializationMode: 2
   m_DefaultBehaviorMode: 0
-  m_SpritePackerMode: 0
+  m_SpritePackerMode: 2
   m_SpritePackerPaddingPower: 1
   m_ProjectGenerationIncludedExtensions: txt;xml;fnt;cd
   m_ProjectGenerationRootNamespace: 

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -76,6 +76,7 @@ PlayerSettings:
   forceSingleInstance: 0
   resizableWindow: 0
   useMacAppStoreValidation: 0
+  macAppStoreCategory: public.app-category.games
   gpuSkinning: 0
   graphicsJobs: 0
   xboxPIXTextureCapture: 0
@@ -204,6 +205,7 @@ PlayerSettings:
   iOSMetalForceHardShadows: 0
   metalEditorSupport: 1
   metalAPIValidation: 1
+  iOSRenderExtraFrameOnPause: 1
   appleDeveloperTeamID: 
   iOSManualSigningProvisioningProfileID: 
   tvOSManualSigningProvisioningProfileID: 
@@ -230,6 +232,9 @@ PlayerSettings:
     m_Enabled: 1
     m_Devices:
     - Oculus
+  - m_BuildTarget: Android
+    m_Enabled: 0
+    m_Devices: []
   openGLRequireES31: 0
   openGLRequireES31AEP: 0
   webPlayerTemplate: APPLICATION:Default
@@ -252,6 +257,7 @@ PlayerSettings:
   wiiUGamePadStartupScreen: {fileID: 0}
   wiiUDrcBufferDisabled: 0
   wiiUProfilerLibPath: 
+  playModeTestRunnerEnabled: 0
   actionOnDotNetUnhandledException: 1
   enableInternalProfiler: 0
   logObjCUncaughtExceptions: 1

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 5.6.0f3
+m_EditorVersion: 5.6.0p3


### PR DESCRIPTION
 - Recalculate add/remove ability more accurately
 - Remember to rebuild space data if we are using a space whenever we add a graphic
 - Add minimum frame delay to DelayAction, can result in 2x speedup when editing large meshes!
 - Reconstruct the material during a heavy update to help with duplication
 - Added basic shaders for baked and dynamic surface shaders
 - Added warning to try to help users understand that sprites are broken (thanks Unity)
 - Tweaked project settings to prevent vertex lit being the default rendering mode
 - Added curved space atomic example scene