### PR TITLE
Overhaul add remove and optimize mesh usage

### DIFF
--- a/Assets/LeapMotion/Scripts/Query/ListAndArrayExtensions.cs
+++ b/Assets/LeapMotion/Scripts/Query/ListAndArrayExtensions.cs
@@ -101,7 +101,11 @@ namespace Leap.Unity.Query {
     }
 
     public static void RemoveAtUnordered<T>(this List<T> list, int index) {
-      list[index] = list.RemoveLast();
+      if (list.Count - 1 == index) {
+        list.RemoveLast();
+      } else {
+        list[index] = list.RemoveLast();
+      }
     }
 
     public static void InsertUnordered<T>(this List<T> list, int index, T element) {

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/ISupportsAddRemove.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/ISupportsAddRemove.cs
@@ -1,16 +1,8 @@
-﻿
+﻿using System.Collections.Generic;
+
 namespace Leap.Unity.GraphicalRenderer {
 
   public interface ISupportsAddRemove {
-    /// <summary>
-    /// The graphic to add.  It is always added to the end of
-    /// a list.
-    /// </summary>
-    void OnAddGraphic(LeapGraphic graphic, int index);
-
-    /// <summary>
-    /// The graphic to remove, in addition to it's previous index.
-    /// </summary>
-    void OnRemoveGraphic(LeapGraphic graphic, int index);
+    void OnAddRemoveGraphics(List<int> dirtyIndexes);
   }
 }

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/RenderingMethods/AssetData/RendererMeshData.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/RenderingMethods/AssetData/RendererMeshData.cs
@@ -10,6 +10,9 @@ namespace Leap.Unity.GraphicalRenderer {
     [SerializeField]
     private List<Mesh> meshes = new List<Mesh>();
 
+    [System.NonSerialized]
+    private Queue<Mesh> _tempMeshPool = new Queue<Mesh>();
+
 #if UNITY_EDITOR
     protected override void OnAssetSaved() {
       base.OnAssetSaved();
@@ -31,9 +34,24 @@ namespace Leap.Unity.GraphicalRenderer {
 
     public void Clear() {
       foreach (var mesh in meshes) {
-        DestroyImmediate(mesh, allowDestroyingAssets: true);
+        mesh.Clear();
+        _tempMeshPool.Enqueue(mesh);
       }
       meshes.Clear();
+    }
+
+    public Mesh GetMeshFromPoolOrNew() {
+      if (_tempMeshPool.Count > 0) {
+        return _tempMeshPool.Dequeue();
+      } else {
+        return new Mesh();
+      }
+    }
+
+    public void ClearPool() {
+      while (_tempMeshPool.Count > 0) {
+        DestroyImmediate(_tempMeshPool.Dequeue(), allowDestroyingAssets: true);
+      }
     }
 
     public void AddMesh(Mesh mesh) {
@@ -41,7 +59,7 @@ namespace Leap.Unity.GraphicalRenderer {
 
       meshes.Add(mesh);
 #if UNITY_EDITOR
-      if (isSavedAsset) {
+      if (isSavedAsset && string.IsNullOrEmpty(AssetDatabase.GetAssetPath(mesh))) {
         AssetDatabase.AddObjectToAsset(mesh, this);
       }
 #endif

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/RenderingMethods/LeapBakedRenderer.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/RenderingMethods/LeapBakedRenderer.cs
@@ -169,7 +169,7 @@ namespace Leap.Unity.GraphicalRenderer {
       //If the next graphic is going to put us over the limit, finish the current mesh
       //and start a new one.
       if (_generation.verts.Count + _generation.graphic.mesh.vertexCount > MeshUtil.MAX_VERT_COUNT) {
-        finishMesh();
+        finishAndAddMesh();
         beginMesh();
       }
 

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/RenderingMethods/LeapDynamicRenderer.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/RenderingMethods/LeapDynamicRenderer.cs
@@ -124,6 +124,21 @@ namespace Leap.Unity.GraphicalRenderer {
       }
     }
 
+    protected override void updateTinting() {
+      foreach (var tintFeature in _tintFeatures) {
+        var graphicList = group.graphics;
+        for (int i = 0; i < graphicList.Count; i++) {
+          int index = _graphicToId[graphicList[i]];
+          if (_tintColors.Count <= index) {
+            _tintColors.Append(index - _tintColors.Count + 1, Vector4.zero);
+          }
+          _tintColors[index] = tintFeature.featureData[i].color;
+        }
+      }
+
+      _material.SetVectorArraySafe(TINTS_PROPERTY, _tintColors);
+    }
+
     protected override void setupForBuilding() {
       if (_shader == null) {
         _shader = Shader.Find("Leap Motion/Graphic Renderer/Unlit/Dynamic");

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/RenderingMethods/LeapDynamicRenderer.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/RenderingMethods/LeapDynamicRenderer.cs
@@ -24,15 +24,6 @@ namespace Leap.Unity.GraphicalRenderer {
         _meshes.RemoveMesh(_meshes.Count - 1);
       }
 
-      foreach (var dirtyIndex in dirtyIndexes) {
-        beginMesh(_meshes[dirtyIndex]);
-        _generation.graphic = group.graphics[dirtyIndex] as LeapMeshGraphicBase;
-        _generation.graphicIndex = dirtyIndex;
-        _generation.graphicId = dirtyIndex;
-        buildGraphic();
-        finishMesh();
-      }
-
       while (_meshes.Count < group.graphics.Count) {
         beginMesh();
         _generation.graphic = group.graphics[_meshes.Count] as LeapMeshGraphicBase;
@@ -40,6 +31,16 @@ namespace Leap.Unity.GraphicalRenderer {
         _generation.graphicId = _meshes.Count;
         buildGraphic();
         finishAndAddMesh();
+      }
+
+      foreach (var dirtyIndex in dirtyIndexes) {
+        beginMesh(_meshes[dirtyIndex]);
+        _generation.graphic = group.graphics[dirtyIndex] as LeapMeshGraphicBase;
+        _generation.graphicIndex = dirtyIndex;
+        _generation.graphicId = dirtyIndex;
+        buildGraphic();
+        finishMesh();
+        _generation.mesh = null;
       }
     }
 

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/RenderingMethods/LeapDynamicRenderer.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/RenderingMethods/LeapDynamicRenderer.cs
@@ -12,9 +12,6 @@ namespace Leap.Unity.GraphicalRenderer {
 
     #region PRIVATE VARIABLES
 
-    private Dictionary<LeapGraphic, int> _graphicToId = new Dictionary<LeapGraphic, int>();
-    private Stack<int> _freeIds = new Stack<int>();
-
     //Curved space
     private const string CURVED_PARAMETERS = LeapGraphicRenderer.PROPERTY_PREFIX + "Curved_GraphicParameters";
     private List<Matrix4x4> _curved_worldToAnchor = new List<Matrix4x4>();
@@ -22,31 +19,28 @@ namespace Leap.Unity.GraphicalRenderer {
     private List<Vector4> _curved_graphicParameters = new List<Vector4>();
     #endregion
 
-    public void OnAddGraphic(LeapGraphic graphic, int newIndex) {
-      int id;
-      if (_freeIds.Count > 0) {
-        id = _freeIds.Pop();
-      } else {
-        id = newIndex;
+    public void OnAddRemoveGraphics(List<int> dirtyIndexes) {
+      while (_meshes.Count > group.graphics.Count) {
+        _meshes.RemoveMesh(_meshes.Count - 1);
       }
 
-      beginMesh();
-      _generation.graphic = graphic as LeapMeshGraphicBase;
-      _generation.graphicIndex = newIndex;
-      _generation.graphicId = id;
-      buildGraphic();
-      finishMesh();
+      foreach (var dirtyIndex in dirtyIndexes) {
+        beginMesh(_meshes[dirtyIndex]);
+        _generation.graphic = group.graphics[dirtyIndex] as LeapMeshGraphicBase;
+        _generation.graphicIndex = dirtyIndex;
+        _generation.graphicId = dirtyIndex;
+        buildGraphic();
+        finishMesh();
+      }
 
-      _graphicToId[graphic] = id;
-    }
-
-    public void OnRemoveGraphic(LeapGraphic graphic, int graphicIndex) {
-      int id = _graphicToId[graphic];
-      _freeIds.Push(id);
-
-      _graphicToId.Remove(graphic);
-
-      _meshes.RemoveMesh(graphicIndex);
+      while (_meshes.Count < group.graphics.Count) {
+        beginMesh();
+        _generation.graphic = group.graphics[_meshes.Count] as LeapMeshGraphicBase;
+        _generation.graphicIndex = _meshes.Count;
+        _generation.graphicId = _meshes.Count;
+        buildGraphic();
+        finishAndAddMesh();
+      }
     }
 
     public override SupportInfo GetSpaceSupportInfo(LeapSpace space) {
@@ -58,24 +52,6 @@ namespace Leap.Unity.GraphicalRenderer {
         return SupportInfo.Error("Dynamic Renderer does not support " + space.GetType().Name);
       }
     }
-
-    public override void OnEnableRenderer() {
-      for (int i = 0; i < group.graphics.Count; i++) {
-        _graphicToId[group.graphics[i]] = i;
-      }
-
-      base.OnEnableRenderer();
-    }
-
-#if UNITY_EDITOR
-    public override void OnUpdateRendererEditor(bool isHeavyUpdate) {
-      for (int i = 0; i < group.graphics.Count; i++) {
-        _graphicToId[group.graphics[i]] = i;
-      }
-
-      base.OnUpdateRendererEditor(isHeavyUpdate);
-    }
-#endif
 
     public override void OnUpdateRenderer() {
       base.OnUpdateRenderer();
@@ -124,21 +100,6 @@ namespace Leap.Unity.GraphicalRenderer {
       }
     }
 
-    protected override void updateTinting() {
-      foreach (var tintFeature in _tintFeatures) {
-        var graphicList = group.graphics;
-        for (int i = 0; i < graphicList.Count; i++) {
-          int index = _graphicToId[graphicList[i]];
-          if (_tintColors.Count <= index) {
-            _tintColors.Append(index - _tintColors.Count + 1, Vector4.zero);
-          }
-          _tintColors[index] = tintFeature.featureData[i].color;
-        }
-      }
-
-      _material.SetVectorArraySafe(TINTS_PROPERTY, _tintColors);
-    }
-
     protected override void setupForBuilding() {
       if (_shader == null) {
         _shader = Shader.Find("Leap Motion/Graphic Renderer/Unlit/Dynamic");
@@ -157,7 +118,7 @@ namespace Leap.Unity.GraphicalRenderer {
 
     protected override void buildGraphic() {
       //Always start a new mesh for each graphic
-      finishMesh();
+      finishAndAddMesh();
       beginMesh();
 
       base.buildGraphic();

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/RenderingMethods/LeapMesherBase.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/RenderingMethods/LeapMesherBase.cs
@@ -496,6 +496,8 @@ namespace Leap.Unity.GraphicalRenderer {
         }
         finishAndAddMesh();
       }
+
+      _meshes.ClearPool();
     }
 
     protected virtual void buildGraphic() {
@@ -638,7 +640,7 @@ namespace Leap.Unity.GraphicalRenderer {
       _generation.Reset();
 
       if (mesh == null) {
-        mesh = new Mesh();
+        mesh = _meshes.GetMeshFromPoolOrNew();
       }
 
       mesh.name = "Procedural Graphic Mesh";
@@ -652,7 +654,7 @@ namespace Leap.Unity.GraphicalRenderer {
         //If there is no data, don't actually do anything
         if (_generation.verts.Count == 0) {
           if (!Application.isPlaying) {
-            DestroyImmediate(_generation.mesh);
+            DestroyImmediate(_generation.mesh, allowDestroyingAssets: true);
           }
           _generation.mesh = null;
           return;

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/RenderingMethods/LeapMesherBase.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/RenderingMethods/LeapMesherBase.cs
@@ -651,7 +651,9 @@ namespace Leap.Unity.GraphicalRenderer {
       using (new ProfilerSample("Finish Mesh")) {
         //If there is no data, don't actually do anything
         if (_generation.verts.Count == 0) {
-          DestroyImmediate(_generation.mesh);
+          if (!Application.isPlaying) {
+            DestroyImmediate(_generation.mesh);
+          }
           _generation.mesh = null;
           return;
         }

--- a/Assets/LeapMotionModules/GraphicRenderer/Scripts/RenderingMethods/LeapMesherBase.cs
+++ b/Assets/LeapMotionModules/GraphicRenderer/Scripts/RenderingMethods/LeapMesherBase.cs
@@ -494,7 +494,7 @@ namespace Leap.Unity.GraphicalRenderer {
           _generation.graphic = group.graphics[_generation.graphicIndex] as LeapMeshGraphicBase;
           buildGraphic();
         }
-        finishMesh();
+        finishAndAddMesh();
       }
     }
 
@@ -632,14 +632,19 @@ namespace Leap.Unity.GraphicalRenderer {
       return graphicVertToMeshVert(shapeVert) - originalVert;
     }
 
-    protected virtual void beginMesh() {
+    protected virtual void beginMesh(Mesh mesh = null) {
       Assert.IsNull(_generation.mesh, "Cannot begin a new mesh without finishing the current mesh.");
 
       _generation.Reset();
 
-      _generation.mesh = new Mesh();
-      _generation.mesh.name = "Procedural Graphic Mesh";
-      _generation.mesh.hideFlags = HideFlags.None;
+      if (mesh == null) {
+        mesh = new Mesh();
+      }
+
+      mesh.name = "Procedural Graphic Mesh";
+      mesh.hideFlags = HideFlags.None;
+
+      _generation.mesh = mesh;
     }
 
     protected virtual void finishMesh() {
@@ -671,7 +676,13 @@ namespace Leap.Unity.GraphicalRenderer {
         }
 
         postProcessMesh();
+      }
+    }
 
+    protected virtual void finishAndAddMesh() {
+      finishMesh();
+
+      if (_generation.mesh != null) {
         _meshes.AddMesh(_generation.mesh);
         _generation.mesh = null;
       }

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 5.6.0f3
+m_EditorVersion: 5.6.0p3


### PR DESCRIPTION
- Add/Remove functionality drastically changed for better runtime performance 
- Overhaul also fixes bugs with dynamic renderer when referencing per-graphic data
- Optimize mesh generation at edit time to re-use meshes instead of recreate them every frame

To test:
 - [ ] Make sure edit time still works as expected for baked / dynamic renderers
 - [ ] Make sure at runtime you can enable/disable objects in a dynamic renderer all day long without error