### PR TITLE
Updating and fixing multi-select for attributes

### DIFF
--- a/Assets/LeapMotion/Scripts/Attributes/AutoFindAttribute.cs
+++ b/Assets/LeapMotion/Scripts/Attributes/AutoFindAttribute.cs
@@ -36,7 +36,17 @@ namespace Leap.Unity.Attributes {
 #if UNITY_EDITOR
     public void ConstrainValue(SerializedProperty property) {
       if (property.objectReferenceValue != null) return;
-      if (component == null) return;
+
+      //Only support auto-find for single selection
+      if (targets.Length != 1) {
+        return;
+      }
+
+      //Only support auto-find for components
+      Component component = targets[0] as Component;
+      if (component == null) {
+        return;
+      }
 
       if (search(property, AutoFindLocations.Object, component.GetComponent)) return;
       if (search(property, AutoFindLocations.Parents, component.GetComponentInParent)) return;
@@ -92,7 +102,7 @@ namespace Leap.Unity.Attributes {
 
           if (attribute != null) {
             wasConstrained = true;
-            attribute.component = script;
+            attribute.targets = new UnityEngine.Object[] { script };
             attribute.fieldInfo = info.Value;
             attribute.ConstrainValue(it);
           }

--- a/Assets/LeapMotion/Scripts/Attributes/CombinablePropertyAttribute.cs
+++ b/Assets/LeapMotion/Scripts/Attributes/CombinablePropertyAttribute.cs
@@ -49,7 +49,7 @@ namespace Leap.Unity.Attributes {
 
   public abstract class CombinablePropertyAttribute : PropertyAttribute {
     public FieldInfo fieldInfo;
-    public Component component;
+    public UnityEngine.Object[] targets;
 
 #if UNITY_EDITOR
     public virtual IEnumerable<SerializedPropertyType> SupportedTypes {

--- a/Assets/LeapMotion/Scripts/Attributes/Editor/CombinablePropertyDrawer.cs
+++ b/Assets/LeapMotion/Scripts/Attributes/Editor/CombinablePropertyDrawer.cs
@@ -44,17 +44,12 @@ namespace Leap.Unity.Attributes {
       bool canUseDefaultDrawer = true;
       bool shouldDisable = false;
 
-      Component attachedComponent = null;
-      if (!property.serializedObject.isEditingMultipleObjects) {
-        attachedComponent = property.serializedObject.targetObject as Component;
-      }
-
       RangeAttribute rangeAttribute = fieldInfo.GetCustomAttributes(typeof(RangeAttribute), true).FirstOrDefault() as RangeAttribute;
 
       IFullPropertyDrawer fullPropertyDrawer = null;
       foreach (var a in attributes) {
         a.fieldInfo = fieldInfo;
-        a.component = attachedComponent;
+        a.targets = property.serializedObject.targetObjects;
 
         if (a is IBeforeLabelAdditiveDrawer) {
           EditorGUIUtility.labelWidth -= (a as IBeforeLabelAdditiveDrawer).GetWidth();


### PR DESCRIPTION
Component references were simply ignored for multi-select situations.  Now the default and only way is to reference an array of all selected objects.  This prevents accidental creation of attributes that only support single selection in the future.  

OnEditorChange has been updated to properly dispatch callbacks to *all* selected objects instead of just throwing tantrum.  AutoFind also had to be changed, since it also used the component reference, but AutoFind was left to be a component that only works when single-selecting.  

To test:
 - [ ] Make sure both OnEditorChange and AutoFind still work properly!
 - [ ] Make sure OnEditorChange correctly dispatches callbacks to multiple selected objects