### PR TITLE
Adding comment component

### DIFF
--- a/Assets/LeapMotion/Scripts/Utils/Comment.cs
+++ b/Assets/LeapMotion/Scripts/Utils/Comment.cs
@@ -1,0 +1,26 @@
+﻿using UnityEngine;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+namespace Leap.Unity {
+
+  public class Comment : MonoBehaviour {
+
+    [TextArea]
+    [SerializeField]
+    private string _comment;
+
+    [SerializeField, HideInInspector]
+    private bool _isEditing = true;
+
+#if UNITY_EDITOR
+    [ContextMenu("Edit")]
+    private void beginEditing() {
+      Undo.RecordObject(this, "Enabled editing");
+      EditorUtility.SetDirty(this);
+      _isEditing = true;
+    }
+#endif
+  }
+}

--- a/Assets/LeapMotion/Scripts/Utils/Comment.cs.meta
+++ b/Assets/LeapMotion/Scripts/Utils/Comment.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: e933f13d48c681d48b14750922ac906d
+timeCreated: 1494266598
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapMotion/Scripts/Utils/Editor/CommentEditor.cs
+++ b/Assets/LeapMotion/Scripts/Utils/Editor/CommentEditor.cs
@@ -1,0 +1,55 @@
+﻿using UnityEngine;
+using UnityEditor;
+
+namespace Leap.Unity {
+
+  [CustomEditor(typeof(Comment))]
+  public class CommentEditor : CustomEditorBase<Comment> {
+
+    private SerializedProperty _isEditing;
+    private GUIStyle _editStyle;
+    private GUIStyle _displayStyle;
+
+    protected override void OnEnable() {
+      base.OnEnable();
+
+      _isEditing = serializedObject.FindProperty("_isEditing");
+
+      dontShowScriptField();
+
+      specifyCustomDrawer("_comment", drawComment);
+    }
+
+    private void drawComment(SerializedProperty commentProp) {
+      string text = commentProp.stringValue;
+
+      if (_editStyle == null) {
+        _editStyle = new GUIStyle(EditorStyles.textArea);
+        _editStyle.wordWrap = true;
+      }
+
+      if (_displayStyle == null) {
+        _displayStyle = new GUIStyle(EditorStyles.label);
+        _displayStyle.wordWrap = true;
+        _displayStyle.richText = true;
+      }
+
+      if (string.IsNullOrEmpty(text)) {
+        _isEditing.boolValue = true;
+      }
+
+      if (_isEditing.boolValue) {
+        if (GUILayout.Button("Finish")) {
+          _isEditing.boolValue = false;
+        }
+
+        commentProp.stringValue = EditorGUILayout.TextArea(text, _editStyle);
+      } else {
+        EditorGUILayout.Space();
+        var rect = GUILayoutUtility.GetRect(new GUIContent(text), _displayStyle);
+        EditorGUI.SelectableLabel(rect, text, _displayStyle);
+      }
+    }
+
+  }
+}

--- a/Assets/LeapMotion/Scripts/Utils/Editor/CommentEditor.cs.meta
+++ b/Assets/LeapMotion/Scripts/Utils/Editor/CommentEditor.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 39c8666ec0ebe1d4c89b4b85bc7f07c9
+timeCreated: 1494266655
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Simple component that will allow us to put comments directly in the hierarchy on relevant gameObjects.  Starts out in edit mode, can press the button to exit edit mode and finish editing.  If you need to edit again, right click the component and select Edit from the dropdown.  Also supports [Rich Text!](https://docs.unity3d.com/Manual/StyledText.html)