### PR TITLE
Adding with previous and small fixes

### DIFF
--- a/Assets/LeapMotion/Scripts/Query/DirectQueryOps.cs
+++ b/Assets/LeapMotion/Scripts/Query/DirectQueryOps.cs
@@ -125,6 +125,30 @@ namespace Leap.Unity.Query {
       return -1;
     }
 
+    public bool AllEqual() {
+      QueryType a;
+      if (!_op.TryGetNext(out a)) {
+        return true;
+      }
+
+      QueryType b;
+      while (_op.TryGetNext(out b)) {
+        if ((a == null) != (b == null)) {
+          return false;
+        }
+
+        if (a == null && b == null) {
+          continue;
+        }
+
+        if (!a.Equals(b)) {
+          return false;
+        }
+      }
+
+      return true;
+    }
+
     private static List<QueryType> _utilityList = new List<QueryType>();
     public QueryType[] ToArray() {
       try {

--- a/Assets/LeapMotion/Scripts/Query/Editor/QueryTests.cs
+++ b/Assets/LeapMotion/Scripts/Query/Editor/QueryTests.cs
@@ -94,6 +94,30 @@ namespace Leap.Unity.Query.Test {
     }
 
     [Test]
+    public void WithPreviousTest() {
+      Assert.That(LIST_0.Query().WithPrevious().Count(p => p.hasPrev), Is.EqualTo(LIST_0.Length - 1));
+      Assert.That(LIST_0.Query().WithPrevious(includeStart: true).Count(p => !p.hasPrev), Is.EqualTo(1));
+      Assert.That(LIST_0.Query().WithPrevious(includeStart: true).Count(p => p.hasPrev), Is.EqualTo(LIST_0.Length - 1));
+
+      foreach (var pair in LIST_0.Query().WithPrevious()) {
+        Assert.That(pair.value, Is.EqualTo(pair.prev + 1));
+      }
+    }
+
+    [Test]
+    public void WithPreviousOffsetTest() {
+      Assert.That(LIST_0.Query().WithPrevious(offset: 4).Count(), Is.EqualTo(1));
+      Assert.That(LIST_0.Query().WithPrevious(offset: 5).Count(), Is.EqualTo(0));
+      Assert.That(LIST_0.Query().WithPrevious(offset: int.MaxValue).Count(), Is.EqualTo(0));
+
+      var item = LIST_0.Query().WithPrevious(offset: 4).First();
+      Assert.That(item.value, Is.EqualTo(5));
+      Assert.That(item.prev, Is.EqualTo(1));
+
+      Assert.That(LIST_0.Query().WithPrevious(offset: 2).All(i => i.value - i.prev == 2));
+    }
+
+    [Test]
     public void WhereTest() {
       Assert.That(LIST_0.Where(i => i % 2 == 0).SequenceEqual(
                   LIST_0.Query().Where(i => i % 2 == 0).ToList()));

--- a/Assets/LeapMotion/Scripts/Query/ListAndArrayExtensions.cs
+++ b/Assets/LeapMotion/Scripts/Query/ListAndArrayExtensions.cs
@@ -110,7 +110,11 @@ namespace Leap.Unity.Query {
     }
 
     public static void RemoveAtUnordered<T>(this List<T> list, int index) {
-      list[index] = list.RemoveLast();
+      if (list.Count - 1 == index) {
+        list.RemoveLast();
+      } else {
+        list[index] = list.RemoveLast();
+      }
     }
 
     public static void InsertUnordered<T>(this List<T> list, int index, T element) {

--- a/Assets/LeapMotion/Scripts/Query/Where.cs
+++ b/Assets/LeapMotion/Scripts/Query/Where.cs
@@ -45,5 +45,9 @@ namespace Leap.Unity.Query {
     public QueryWrapper<QueryType, WhereOp<QueryType, QueryOp>> NonNull() {
       return Where(obj => obj != null);
     }
+
+    public QueryWrapper<QueryType, WhereOp<QueryType, QueryOp>> ValidUnityObjs() {
+      return Where(obj => (obj as UnityEngine.Object) != null);
+    }
   }
 }

--- a/Assets/LeapMotion/Scripts/Query/WithPrevious.cs
+++ b/Assets/LeapMotion/Scripts/Query/WithPrevious.cs
@@ -1,0 +1,87 @@
+﻿
+using System;
+
+namespace Leap.Unity.Query {
+
+  public struct WithPreviousOp<SourceType, SourceOp> : IQueryOp<PrevPair<SourceType>>
+    where SourceOp : IQueryOp<SourceType> {
+    private SourceOp _mainOp;
+    private SourceOp _delayedOp;
+
+    private bool _includeStart;
+    private int _offsetLeft;
+    private int _offset;
+
+    public WithPreviousOp(SourceOp op, int offset, bool includeStart) {
+      if (offset <= 0) {
+        throw new ArgumentException("Offset must be larger than zero.");
+      }
+
+      _mainOp = op;
+      _delayedOp = op;
+
+      _includeStart = includeStart;
+      _offsetLeft = offset;
+      _offset = offset;
+    }
+
+    public bool TryGetNext(out PrevPair<SourceType> t) {
+      top:
+
+      SourceType value;
+      if (_mainOp.TryGetNext(out value)) {
+        if (_offsetLeft > 0) {
+          _offsetLeft--;
+          if (!_includeStart) {
+            goto top;
+          }
+
+          t = new PrevPair<SourceType>() {
+            value = value,
+            prev = default(SourceType),
+            hasPrev = false
+          };
+        } else {
+          SourceType prev;
+          _delayedOp.TryGetNext(out prev);
+          t = new PrevPair<SourceType>() {
+            value = value,
+            prev = prev,
+            hasPrev = true
+          };
+        }
+        return true;
+      } else {
+        t = default(PrevPair<SourceType>);
+        return false;
+      }
+    }
+
+    public void Reset() {
+      _mainOp.Reset();
+      _delayedOp.Reset();
+      _offsetLeft = _offset;
+    }
+  }
+
+  public partial struct QueryWrapper<QueryType, QueryOp> where QueryOp : IQueryOp<QueryType> {
+
+    public QueryWrapper<PrevPair<QueryType>, WithPreviousOp<QueryType, QueryOp>> WithPrevious(int offset = 1) {
+      return new QueryWrapper<PrevPair<QueryType>, WithPreviousOp<QueryType, QueryOp>>(new WithPreviousOp<QueryType, QueryOp>(_op, offset, includeStart: false));
+    }
+
+    public QueryWrapper<PrevPair<QueryType>, WithPreviousOp<QueryType, QueryOp>> WithPrevious(bool includeStart) {
+      return new QueryWrapper<PrevPair<QueryType>, WithPreviousOp<QueryType, QueryOp>>(new WithPreviousOp<QueryType, QueryOp>(_op, 1, includeStart));
+    }
+
+    public QueryWrapper<PrevPair<QueryType>, WithPreviousOp<QueryType, QueryOp>> WithPrevious(int offset, bool includeStart) {
+      return new QueryWrapper<PrevPair<QueryType>, WithPreviousOp<QueryType, QueryOp>>(new WithPreviousOp<QueryType, QueryOp>(_op, offset, includeStart));
+    }
+  }
+
+  public struct PrevPair<T> {
+    public T value;
+    public T prev;
+    public bool hasPrev;
+  }
+}

--- a/Assets/LeapMotion/Scripts/Query/WithPrevious.cs.meta
+++ b/Assets/LeapMotion/Scripts/Query/WithPrevious.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: a7e4394d6de21074e8dcee8649cca2b7
+timeCreated: 1494357808
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Adding 
 - The withPrevious query operator to allow you to operate on elements of a query along with a previous element chosen at a specific constant offset.
 - The allEqual method, which only returns true of all elements in the sequence are all equal to each other.
 - Fixes the RemoveAtUnordered method throwing an exception if you removed the last element.
 - Added ValidUnityObjs as an alternative to NonNull to catch weird/stupid unity operator overloading.

To test:
 - [ ] Make sure unit tests pass
 - [ ] Make sure code/logic looks good