### PR TITLE
Deprecate auto-find

### DIFF
--- a/Assets/LeapMotion/Scripts/Attributes/AutoFindAttribute.cs
+++ b/Assets/LeapMotion/Scripts/Attributes/AutoFindAttribute.cs
@@ -8,16 +8,10 @@
  ******************************************************************************/
 
 using System;
-using System.Reflection;
-using System.Collections.Generic;
-#if UNITY_EDITOR
-using UnityEditor;
-using UnityEditor.Callbacks;
-#endif
-using UnityEngine;
 
 namespace Leap.Unity.Attributes {
 
+  [Obsolete]
   public enum AutoFindLocations {
     Object = 0x01,
     Children = 0x02,
@@ -26,99 +20,12 @@ namespace Leap.Unity.Attributes {
     All = 0xFFFF
   }
 
-  public class AutoFindAttribute : CombinablePropertyAttribute, IPropertyConstrainer {
+  [Obsolete]
+  public class AutoFindAttribute : Attribute {
     public readonly AutoFindLocations searchLocations;
 
     public AutoFindAttribute(AutoFindLocations searchLocations = AutoFindLocations.All) {
       this.searchLocations = searchLocations;
     }
-
-#if UNITY_EDITOR
-    public void ConstrainValue(SerializedProperty property) {
-      if (property.objectReferenceValue != null) return;
-
-      //Only support auto-find for single selection
-      if (targets.Length != 1) {
-        return;
-      }
-
-      //Only support auto-find for components
-      Component component = targets[0] as Component;
-      if (component == null) {
-        return;
-      }
-
-      if (search(property, AutoFindLocations.Object, component.GetComponent)) return;
-      if (search(property, AutoFindLocations.Parents, component.GetComponentInParent)) return;
-      if (search(property, AutoFindLocations.Children, component.GetComponentInChildren)) return;
-      if (search(property, AutoFindLocations.Scene, UnityEngine.Object.FindObjectOfType)) return;
-    }
-
-    private bool search(SerializedProperty property, AutoFindLocations location, Func<Type, UnityEngine.Object> searchDelegate) {
-      if ((searchLocations & location) != 0) {
-        var value = searchDelegate(fieldInfo.FieldType);
-        if (value != null) {
-          property.objectReferenceValue = value;
-          return true;
-        }
-      }
-      return false;
-    }
-
-    [PostProcessScene]
-    private static void OnPostProcessScene() {
-      MonoBehaviour[] scripts = UnityEngine.Object.FindObjectsOfType<MonoBehaviour>();
-
-      Dictionary<KeyValuePair<Type, string>, KeyValuePair<AutoFindAttribute, FieldInfo>> cache = new Dictionary<KeyValuePair<Type, string>, KeyValuePair<AutoFindAttribute, FieldInfo>>();
-
-      for (int j = 0; j < scripts.Length; j++) {
-        MonoBehaviour script = scripts[j];
-
-        SerializedObject sObj = new SerializedObject(script);
-        SerializedProperty it = sObj.GetIterator();
-
-        Type scriptType = script.GetType();
-        bool wasConstrained = false;
-
-        it.NextVisible(true);
-        while (it.NextVisible(false)) {
-          KeyValuePair<Type, string> key = new KeyValuePair<Type, string>(scriptType, it.name);
-
-          KeyValuePair<AutoFindAttribute, FieldInfo> info;
-          if (!cache.TryGetValue(key, out info)) {
-            FieldInfo field = scriptType.GetField(it.name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy);
-            if (field == null) continue;
-
-            object[] attributes = field.GetCustomAttributes(typeof(AutoFindAttribute), true);
-
-            if (attributes.Length == 0) {
-              cache[key] = new KeyValuePair<AutoFindAttribute, FieldInfo>(null, null);
-            } else {
-              cache[key] = info = new KeyValuePair<AutoFindAttribute, FieldInfo>(attributes[0] as AutoFindAttribute, field);
-            }
-          }
-
-          AutoFindAttribute attribute = info.Key;
-
-          if (attribute != null) {
-            wasConstrained = true;
-            attribute.targets = new UnityEngine.Object[] { script };
-            attribute.fieldInfo = info.Value;
-            attribute.ConstrainValue(it);
-          }
-        }
-
-        if (wasConstrained) {
-          sObj.ApplyModifiedProperties();
-        }
-      }
-    }
-
-    public override IEnumerable<SerializedPropertyType> SupportedTypes {
-      get {
-        yield return SerializedPropertyType.ObjectReference;
-      }
-    }
-#endif
   }
 }

--- a/Assets/LeapMotion/Scripts/DetectionUtilities/AbstractHoldDetector.cs
+++ b/Assets/LeapMotion/Scripts/DetectionUtilities/AbstractHoldDetector.cs
@@ -22,8 +22,7 @@ namespace Leap.Unity {
 
     /** Implementations must implement this method. */
     protected abstract void ensureUpToDate();
-
-    [AutoFind(AutoFindLocations.Parents)]
+    
     [SerializeField]
     protected IHandModel _handModel;
     public IHandModel HandModel { get { return _handModel; } set { _handModel = value; } }

--- a/Assets/LeapMotion/Scripts/DetectionUtilities/ExtendedFingerDetector.cs
+++ b/Assets/LeapMotion/Scripts/DetectionUtilities/ExtendedFingerDetector.cs
@@ -42,7 +42,6 @@ namespace Leap.Unity {
      * Set automatically if not explicitly set in the editor.
      * @since 4.1.2
      */
-    [AutoFind(AutoFindLocations.Parents)]
     [Tooltip("The hand model to watch. Set automatically if detector is on a hand.")]
     public IHandModel HandModel = null;
   

--- a/Assets/LeapMotion/Scripts/DetectionUtilities/FingerDirectionDetector.cs
+++ b/Assets/LeapMotion/Scripts/DetectionUtilities/FingerDirectionDetector.cs
@@ -43,7 +43,6 @@ namespace Leap.Unity {
      * Set automatically if not explicitly set in the editor.
      * @since 4.1.2
      */
-    [AutoFind(AutoFindLocations.Parents)]
     [Tooltip("The hand model to watch. Set automatically if detector is on a hand.")]
     public IHandModel HandModel = null;  
 

--- a/Assets/LeapMotion/Scripts/DetectionUtilities/PalmDirectionDetector.cs
+++ b/Assets/LeapMotion/Scripts/DetectionUtilities/PalmDirectionDetector.cs
@@ -45,7 +45,6 @@ namespace Leap.Unity {
      * Set automatically if not explicitly set in the editor.
      * @since 4.1.2
      */
-    [AutoFind(AutoFindLocations.Parents)]
     [Tooltip("The hand model to watch. Set automatically if detector is on a hand.")]
     public IHandModel HandModel = null;
 

--- a/Assets/LeapMotion/Scripts/LeapImageRetriever.cs
+++ b/Assets/LeapMotion/Scripts/LeapImageRetriever.cs
@@ -27,8 +27,7 @@ namespace Leap.Unity {
     public const int LEFT_IMAGE_INDEX = 0;
     public const int RIGHT_IMAGE_INDEX = 1;
     public const float IMAGE_SETTING_POLL_RATE = 2.0f;
-
-    [AutoFind]
+    
     [SerializeField]
     LeapServiceProvider _provider;
 

--- a/Assets/LeapMotion/Scripts/LeapServiceProvider.cs
+++ b/Assets/LeapMotion/Scripts/LeapServiceProvider.cs
@@ -35,8 +35,7 @@ namespace Leap.Unity {
     [Tooltip("Set true if the Leap Motion hardware is mounted on an HMD; otherwise, leave false.")]
     [SerializeField]
     protected bool _isHeadMounted = false;
-
-    [AutoFind]
+    
     [SerializeField]
     protected LeapVRTemporalWarping _temporalWarping;
 

--- a/Assets/LeapMotion/Scripts/Utils/ConnectionMonitor.cs
+++ b/Assets/LeapMotion/Scripts/Utils/ConnectionMonitor.cs
@@ -21,7 +21,6 @@ namespace Leap.Unity {
   [RequireComponent(typeof(SpriteRenderer))]
   public class ConnectionMonitor : MonoBehaviour {
     /** The LeapServiceProvider in the scene. */
-    [AutoFind]
     [Tooltip("The scene LeapServiceProvider.")]
     public LeapServiceProvider provider;
     /** The speed to fade the sprite alpha from 0 to 1. */

--- a/Assets/LeapMotion/Scripts/VR/LeapVRTemporalWarping.cs
+++ b/Assets/LeapMotion/Scripts/VR/LeapVRTemporalWarping.cs
@@ -54,8 +54,7 @@ namespace Leap.Unity {
         };
       }
     }
-
-    [AutoFind]
+    
     [SerializeField]
     private LeapServiceProvider provider;
 

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/InteractionGraspDetector.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionBehaviours/InteractionGraspDetector.cs
@@ -38,7 +38,6 @@ namespace Leap.Unity.Interaction {
     * targets must be managed by this manager.
     * @since 4.1.5
     */
-    [AutoFind(AutoFindLocations.Scene)]
     [Tooltip("The Interaction Manager.")]
     public InteractionManager interactionManager = null;
 
@@ -47,7 +46,6 @@ namespace Leap.Unity.Interaction {
      * Set automatically if not explicitly set in the editor.
      * @since 4.1.5
      */
-    [AutoFind(AutoFindLocations.Parents)]
     [Tooltip("The hand model to watch. Set automatically if detector is on a hand.")]
     public IHandModel HandModel = null;
 

--- a/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
+++ b/Assets/LeapMotionModules/InteractionEngine/Scripts/InteractionManager.cs
@@ -40,11 +40,9 @@ namespace Leap.Unity.Interaction {
   /// </remarks>
   public partial class InteractionManager : MonoBehaviour {
     #region SERIALIZED FIELDS
-    [AutoFind]
     [SerializeField]
     protected LeapProvider _leapProvider;
-
-    [AutoFind]
+    
     [SerializeField]
     protected HandPool _handPool;
 


### PR DESCRIPTION
Deprecating AutoFind.  It is misleading because it cannot and does not auto find in all situations, leading developers to need to manually assign the references themselves, or write extra code to do safety checks anyway. 

To test:
 - [ ] Make sure everything still compiles
 - [ ] Make sure trying to use an AutoFind attribute correctly notifies you it is deprecated