### PR TITLE
Fixed stupid unity null weirdness

### DIFF
--- a/Assets/LeapMotion/Scripts/DataStructures/SerializableHashSet.cs
+++ b/Assets/LeapMotion/Scripts/DataStructures/SerializableHashSet.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using UnityEngine;
+using Leap.Unity.Query;
 
 namespace Leap.Unity {
 
@@ -91,8 +92,14 @@ namespace Leap.Unity {
 
       //Add any values not accounted for
       foreach (var value in this) {
-        if (!_values.Contains(value)) {
-          _values.Add(value);
+        if (isNull(value)) {
+          if (!_values.Query().Any(obj => isNull(obj))) {
+            _values.Add(value);
+          }
+        } else {
+          if (!_values.Contains(value)) {
+            _values.Add(value);
+          }
         }
       }
 #else
@@ -100,6 +107,18 @@ namespace Leap.Unity {
       _values.Clear();
       _values.AddRange(this);
 #endif
+    }
+
+    private bool isNull(object obj) {
+      if (obj == null) {
+        return true;
+      }
+
+      if (obj is Object) {
+        return (obj as Object) == null;
+      }
+
+      return false;
     }
   }
 }


### PR DESCRIPTION
Since Unity objects can become null but not really be null, it can cause multiple values to be added to the hash set because actual null is considered differently than unity null.  Very annoying.

To test:
 - [ ] Create hash set of gameObjects.  Add a few gameObjects to the set.  Save scene.  Delete gameobjects.  Save scene.  Reload scene.  Visit hash set component, and verify that the number of empty elements is equal to the number of elements that were added in the first place!