### PR TITLE
Create world-space unwarping extension method, use for hand unwarping

### DIFF
--- a/Assets/LeapMotion/Scripts/Space/ITransformer.cs
+++ b/Assets/LeapMotion/Scripts/Space/ITransformer.cs
@@ -102,14 +102,16 @@ namespace Leap.Unity.Space {
                                         Vector3 worldWarpedPosition, Quaternion worldWarpedRotation,
                                         out Vector3 worldRectilinearPosition, out Quaternion worldRectilinearRotation) {
 
-      Vector3 anchorLocalWarpedPosition = transformer.anchor.space.transform.InverseTransformPoint(worldWarpedPosition);
-      Quaternion anchorLocalWarpedRotation = transformer.anchor.space.transform.InverseTransformRotation(worldWarpedRotation);
+      Transform spaceTransform = transformer.anchor.space.transform;
+
+      Vector3 anchorLocalWarpedPosition = spaceTransform.InverseTransformPoint(worldWarpedPosition);
+      Quaternion anchorLocalWarpedRotation = spaceTransform.InverseTransformRotation(worldWarpedRotation);
 
       Vector3 anchorLocalRectPosition = transformer.InverseTransformPoint(anchorLocalWarpedPosition);
-      worldRectilinearPosition = transformer.anchor.space.transform.TransformPoint(anchorLocalRectPosition);
+      worldRectilinearPosition = spaceTransform.TransformPoint(anchorLocalRectPosition);
 
       Quaternion anchorLocalRectRotation = transformer.InverseTransformRotation(anchorLocalWarpedPosition, anchorLocalWarpedRotation);
-      worldRectilinearRotation = transformer.anchor.space.transform.TransformRotation(anchorLocalRectRotation);
+      worldRectilinearRotation = spaceTransform.TransformRotation(anchorLocalRectRotation);
     }
 
   }

--- a/Assets/LeapMotion/Scripts/Space/ITransformer.cs
+++ b/Assets/LeapMotion/Scripts/Space/ITransformer.cs
@@ -89,4 +89,28 @@ namespace Leap.Unity.Space {
       return Matrix4x4.TRS(localRectPos, Quaternion.identity, Vector3.one);
     }
   }
+
+  public static class ITransformerExtensions {
+
+    /// <summary>
+    /// Given a transformer and a world-space position and rotation, this method interprets that position
+    /// and rotation as being within the transformers "warped" space (e.g. cylindrical space for LeapCylindricalSpace)
+    /// and outputs the world-space position and rotation that would result if the space was no longer warped,
+    /// i.e., standard Unity rectilinear space.
+    /// </summary>
+    public static void WorldSpaceUnwarp(this ITransformer transformer,
+                                        Vector3 worldWarpedPosition, Quaternion worldWarpedRotation,
+                                        out Vector3 worldRectilinearPosition, out Quaternion worldRectilinearRotation) {
+
+      Vector3 anchorLocalWarpedPosition = transformer.anchor.space.transform.InverseTransformPoint(worldWarpedPosition);
+      Quaternion anchorLocalWarpedRotation = transformer.anchor.space.transform.InverseTransformRotation(worldWarpedRotation);
+
+      Vector3 anchorLocalRectPosition = transformer.InverseTransformPoint(anchorLocalWarpedPosition);
+      worldRectilinearPosition = transformer.anchor.space.transform.TransformPoint(anchorLocalRectPosition);
+
+      Quaternion anchorLocalRectRotation = transformer.InverseTransformRotation(anchorLocalWarpedPosition, anchorLocalWarpedRotation);
+      worldRectilinearRotation = transformer.anchor.space.transform.TransformRotation(anchorLocalRectRotation);
+    }
+
+  }
 }

--- a/Assets/LeapMotionModules/Interaction/Scripts/InteractionBehaviour.cs
+++ b/Assets/LeapMotionModules/Interaction/Scripts/InteractionBehaviour.cs
@@ -640,7 +640,7 @@ namespace Leap.Unity.Interaction {
         manager.RegisterInteractionBehaviour(this);
       }
 
-      space = GetComponent<ISpaceComponent>();
+      space = GetComponentInChildren<ISpaceComponent>();
     }
 
     protected virtual void OnDisable() {


### PR DESCRIPTION
Change to make the inverse transform operation we do to support curved spaces a little more readable. 
I'll be using this to make supporting controllers less of a hassle.

To test:
- [ ] Make sure it produces functionally identical results to the previous method