### PR TITLE
Allow buttons and sliders to function with no travel

### DIFF
--- a/Assets/LeapMotionModules/Interaction/Scripts/UI/Editor/InteractionSliderEditor.cs
+++ b/Assets/LeapMotionModules/Interaction/Scripts/UI/Editor/InteractionSliderEditor.cs
@@ -1,0 +1,18 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace Leap.Unity.Interaction {
+
+  [CanEditMultipleObjects]
+  [CustomEditor(typeof(InteractionSlider), editorForChildClasses: true)]
+  public class InteractionSliderEditor : InteractionButtonEditor {
+    public override void OnInspectorGUI() {
+      bool noRectTransformParent = !(target.transform.parent != null && target.transform.parent.GetComponent<RectTransform>() != null);
+      specifyConditionalDrawing(() => noRectTransformParent, "horizontalSlideLimits", "verticalSlideLimits");
+      if (!noRectTransformParent) {
+        EditorGUILayout.HelpBox("This slider's limits are being controlled by the rect transform in its parent.", MessageType.Info);
+      }
+      base.OnInspectorGUI();
+    }
+  }
+}

--- a/Assets/LeapMotionModules/Interaction/Scripts/UI/Editor/InteractionSliderEditor.cs.meta
+++ b/Assets/LeapMotionModules/Interaction/Scripts/UI/Editor/InteractionSliderEditor.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: fe7130992cfc6be4c965f280abba45c6
+timeCreated: 1495067354
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapMotionModules/Interaction/Scripts/UI/InteractionButton.cs
+++ b/Assets/LeapMotionModules/Interaction/Scripts/UI/InteractionButton.cs
@@ -165,10 +165,10 @@ namespace Leap.Unity.Interaction {
         // If the button is depressed past its limit...
         if (localPhysicsPosition.z > initialLocalPosition.z - minMaxHeight.x) {
           transform.localPosition = new Vector3(localPhysicsPosition.x, localPhysicsPosition.y, initialLocalPosition.z - minMaxHeight.x);
-          if (isPrimaryHovered || isGrasped) {
+          if ((isPrimaryHovered && _lastDepressor!=null) || isGrasped) {
             isDepressed = true;
           } else {
-            _physicsPosition = transform.parent.TransformPoint(new Vector3(localPhysicsPosition.x, localPhysicsPosition.y, initialLocalPosition.z));
+            _physicsPosition = transform.parent.TransformPoint(new Vector3(localPhysicsPosition.x, localPhysicsPosition.y, initialLocalPosition.z - minMaxHeight.x));
             _physicsVelocity = _physicsVelocity * 0.1f;
             isDepressed = false;
             _lastDepressor = null;
@@ -199,6 +199,7 @@ namespace Leap.Unity.Interaction {
         } else if (!isDepressed && oldDepressed) {
           unDepressedThisFrame = true;
           OnUnpress.Invoke();
+          _lastDepressor = null;
           manager.GetInteractionHand(_handIsLeft).SetInteractionHoverOverride(false);
         }
       }
@@ -227,7 +228,7 @@ namespace Leap.Unity.Interaction {
 
     // Try grabbing the offset between the fingertip and this object...
     private void trySetDepressor(Collision collision) {
-      if (collision.rigidbody != null && _lastDepressor == null && isDepressed
+      if (collision.rigidbody != null && _lastDepressor == null && (localPhysicsPosition.z > initialLocalPosition.z - minMaxHeight.x)
         && (manager.contactBoneBodies.ContainsKey(collision.collider.attachedRigidbody)
             && !this.ShouldIgnoreHover(manager.contactBoneBodies[collision.collider.attachedRigidbody].interactionHand))) {
         _lastDepressor = collision.rigidbody;

--- a/Assets/LeapMotionModules/Interaction/Scripts/UI/InteractionSlider.cs
+++ b/Assets/LeapMotionModules/Interaction/Scripts/UI/InteractionSlider.cs
@@ -100,8 +100,13 @@ namespace Leap.Unity.Interaction {
       if (transform.parent != null) {
         parent = transform.parent.GetComponent<RectTransform>();
         if (parent != null) {
-          horizontalSlideLimits = new Vector2(parent.rect.xMin - transform.localPosition.x, parent.rect.xMax - transform.localPosition.x);
-          verticalSlideLimits = new Vector2(parent.rect.yMin - transform.localPosition.y, parent.rect.yMax - transform.localPosition.y);
+          if (parent.rect.width < 0f || parent.rect.height < 0f) {
+            Debug.LogError("Parent Rectangle dimensions negative; can't set slider boundaries!", parent.gameObject);
+            enabled = false;
+          } else {
+            horizontalSlideLimits = new Vector2(parent.rect.xMin - transform.localPosition.x, parent.rect.xMax - transform.localPosition.x);
+            verticalSlideLimits = new Vector2(parent.rect.yMin - transform.localPosition.y, parent.rect.yMax - transform.localPosition.y);
+          }
         }
       }
 

--- a/Assets/LeapMotionModules/Interaction/Scripts/UI/InteractionSlider.cs
+++ b/Assets/LeapMotionModules/Interaction/Scripts/UI/InteractionSlider.cs
@@ -97,10 +97,12 @@ namespace Leap.Unity.Interaction {
 
       _started = true;
 
-      parent = transform.parent.GetComponent<RectTransform>();
-      if(parent != null) {
-        horizontalSlideLimits = new Vector2(parent.rect.xMin - transform.localPosition.x, parent.rect.xMax - transform.localPosition.x);
-        verticalSlideLimits = new Vector2(parent.rect.yMin - transform.localPosition.y, parent.rect.yMax - transform.localPosition.y);
+      if (transform.parent != null) {
+        parent = transform.parent.GetComponent<RectTransform>();
+        if (parent != null) {
+          horizontalSlideLimits = new Vector2(parent.rect.xMin - transform.localPosition.x, parent.rect.xMax - transform.localPosition.x);
+          verticalSlideLimits = new Vector2(parent.rect.yMin - transform.localPosition.y, parent.rect.yMax - transform.localPosition.y);
+        }
       }
 
       base.Start();


### PR DESCRIPTION
Tweak of some of the button math that allows them to function with 0 min/max heights, and/or at 0 resting height.  Should sidestep some of the issues that newcomers find when they get started with the UI.

Also, allow slider limits to be configurable by a parent rect transform.