### PR TITLE
Fix Hand Bone Mass Calculation

### DIFF
--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/Internal/ContactBone.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/Internal/ContactBone.cs
@@ -130,7 +130,7 @@ namespace Leap.Unity.Interaction {
         if (interactionObj is InteractionBehaviour) {
           switch ((interactionObj as InteractionBehaviour).contactForceMode) {
             case ContactForceMode.UI:
-              _lastObjectTouchedAdjustedMass *= 1F;
+              _lastObjectTouchedAdjustedMass *= 2F;
               break;
             case ContactForceMode.Object: default:
               if (interactionHand != null) {

--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/UI/InteractionButton.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/UI/InteractionButton.cs
@@ -152,7 +152,7 @@ namespace Leap.Unity.Interaction {
           localPhysicsVelocity = Vector3.back * 0.05f;
           localPhysicsPosition = getDepressedConstrainedLocalPosition(curLocalDepressorPos - origLocalDepressorPos);
         } else {
-          localPhysicsVelocity += _springForce * Vector3.forward * (initialLocalPosition.z - Mathf.Lerp(minMaxHeight.x, minMaxHeight.y, restingHeight) - localPhysicsPosition.z) / Time.fixedDeltaTime;
+          localPhysicsVelocity += Mathf.Clamp(_springForce * (initialLocalPosition.z - Mathf.Lerp(minMaxHeight.x, minMaxHeight.y, restingHeight) - localPhysicsPosition.z) / Time.fixedDeltaTime, -1f, 1f) * Vector3.forward;
           localPhysicsVelocity *= Mathf.Pow(0.0000000001f, Time.fixedDeltaTime);
         }
 

--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/UI/InteractionButton.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/UI/InteractionButton.cs
@@ -152,7 +152,7 @@ namespace Leap.Unity.Interaction {
           localPhysicsVelocity = Vector3.back * 0.05f;
           localPhysicsPosition = getDepressedConstrainedLocalPosition(curLocalDepressorPos - origLocalDepressorPos);
         } else {
-          localPhysicsVelocity += Mathf.Clamp(_springForce * (initialLocalPosition.z - Mathf.Lerp(minMaxHeight.x, minMaxHeight.y, restingHeight) - localPhysicsPosition.z) / Time.fixedDeltaTime, -1f, 1f) * Vector3.forward;
+          localPhysicsVelocity += (Mathf.Clamp(_springForce * (initialLocalPosition.z - Mathf.Lerp(minMaxHeight.x, minMaxHeight.y, restingHeight) - localPhysicsPosition.z), -0.01f, 0.01f) / Time.fixedDeltaTime) * Vector3.forward;
           localPhysicsVelocity *= Mathf.Pow(0.0000000001f, Time.fixedDeltaTime);
         }
 


### PR DESCRIPTION
Change the way the Hand's mass is calculated relative to the objects its touching (so that that entire hand is affected simultaneously when a new object is touched).

This reduces the mass ratio necessary to to fully manipulate UI elements (as now the entire hand's mass is contributing to the interaction rather than just the contacting bone).