### PR TITLE
Removed unnecessary Debug.Log statements

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/Hands/SkeletalFinger.cs
+++ b/Assets/LeapMotion/Core/Scripts/Hands/SkeletalFinger.cs
@@ -25,9 +25,7 @@ namespace Leap.Unity{
     }
   
     /** Updates the finger bones and joints by setting their positions and rotations. */
-    public override void UpdateFinger() {
-      Debug.Log("SkeletalFinger.SetPositions()");
-  
+    public override void UpdateFinger() {  
       SetPositions();
     }
   

--- a/Assets/LeapMotion/Core/Scripts/Hands/SkeletalHand.cs
+++ b/Assets/LeapMotion/Core/Scripts/Hands/SkeletalHand.cs
@@ -47,8 +47,6 @@ namespace Leap.Unity{
     }
   
     protected void SetPositions() {
-      Debug.Log("SkeletalHand.SetPositions()");
-  
       for (int f = 0; f < fingers.Length; ++f) {
         if (fingers[f] != null) {
           fingers[f].UpdateFinger();


### PR DESCRIPTION
Just removed some Debug.Log() statements from SkeletalFinger and SkeletalHand. They were unnecessarily logging each frame, which was bad for performance.