### PR TITLE
Make buttons less molasses at low fixed timesteps

### DIFF
--- a/Assets/LeapMotion/Modules/InteractionEngine/Examples/2. Basic UI/Basic UI.unity
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Examples/2. Basic UI/Basic UI.unity
@@ -191,7 +191,7 @@ Rigidbody:
   m_GameObject: {fileID: 112263976}
   serializedVersion: 2
   m_Mass: 1
-  m_Drag: 40
+  m_Drag: 0
   m_AngularDrag: 0.05
   m_UseGravity: 0
   m_IsKinematic: 0
@@ -3982,7 +3982,7 @@ Rigidbody:
   m_GameObject: {fileID: 1758933908}
   serializedVersion: 2
   m_Mass: 1
-  m_Drag: 40
+  m_Drag: 0
   m_AngularDrag: 0.05
   m_UseGravity: 0
   m_IsKinematic: 0

--- a/Assets/LeapMotion/Modules/InteractionEngine/Examples/Common Example Assets/Prefabs/Cube UI Button.prefab
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Examples/Common Example Assets/Prefabs/Cube UI Button.prefab
@@ -192,7 +192,7 @@ Rigidbody:
   m_GameObject: {fileID: 1329088948137194}
   serializedVersion: 2
   m_Mass: 1
-  m_Drag: 40
+  m_Drag: 0
   m_AngularDrag: 0.05
   m_UseGravity: 0
   m_IsKinematic: 0
@@ -236,6 +236,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   _manager: {fileID: 0}
   _ignoreHoverMode: 0
+  _isIgnoringAllHoverState: 0
+  _ignorePrimaryHover: 0
   _ignoreContact: 0
   _ignoreGrasping: 1
   _contactForceMode: 1
@@ -271,3 +273,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   useHover: 0
   usePrimaryHover: 1
+  defaultColor: {r: 0.1, g: 0.1, b: 0.1, a: 1}
+  suspendedColor: {r: 1, g: 0, b: 0, a: 1}
+  hoverColor: {r: 0.7, g: 0.7, b: 0.7, a: 1}
+  primaryHoverColor: {r: 0.8, g: 0.8, b: 0.8, a: 1}
+  pressedColor: {r: 1, g: 1, b: 1, a: 1}

--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/UI/InteractionButton.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/UI/InteractionButton.cs
@@ -158,7 +158,7 @@ namespace Leap.Unity.Interaction {
           Vector3 originalLocalVelocity = localPhysicsVelocity;
 
           // Spring force
-          localPhysicsVelocity += (Mathf.Clamp(_springForce * (initialLocalPosition.z - Mathf.Lerp(minMaxHeight.x, minMaxHeight.y, restingHeight) - localPhysicsPosition.z), -0.01f, 0.01f) / Time.fixedDeltaTime) * Vector3.forward;
+          localPhysicsVelocity += (Mathf.Clamp(_springForce*10000f * (initialLocalPosition.z - Mathf.Lerp(minMaxHeight.x, minMaxHeight.y, restingHeight) - localPhysicsPosition.z), -100f, 100f) * Time.fixedDeltaTime) * Vector3.forward;
 
           // Friction & Drag
           float velMag = originalLocalVelocity.magnitude;

--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/UI/InteractionButton.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/UI/InteractionButton.cs
@@ -170,7 +170,7 @@ namespace Leap.Unity.Interaction {
             localPhysicsVelocity = localPhysicsVelocity + (frictionForce /* assume unit mass */ * Time.fixedDeltaTime);
 
             // Drag force
-            float velSqrMag = localPhysicsVelocity.sqrMagnitude;
+            float velSqrMag = velMag * velMag;
             Vector3 dragForce = resistanceDir * velSqrMag * DRAG_COEFFICIENT;
             localPhysicsVelocity = localPhysicsVelocity + (dragForce /* assume unit mass */ * Time.fixedDeltaTime);
           }

--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/UI/InteractionButton.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/UI/InteractionButton.cs
@@ -119,6 +119,9 @@ namespace Leap.Unity.Interaction {
       }
     }
 
+    private const float FRICTION_COEFFICIENT = 30F;
+    private const float DRAG_COEFFICIENT = 50F;
+
     protected virtual void Update() {
       //Reset our convenience state variables...
       depressedThisFrame = false;
@@ -152,8 +155,25 @@ namespace Leap.Unity.Interaction {
           localPhysicsVelocity = Vector3.back * 0.05f;
           localPhysicsPosition = getDepressedConstrainedLocalPosition(curLocalDepressorPos - origLocalDepressorPos);
         } else {
+          Vector3 originalLocalVelocity = localPhysicsVelocity;
+
+          // Spring force
           localPhysicsVelocity += (Mathf.Clamp(_springForce * (initialLocalPosition.z - Mathf.Lerp(minMaxHeight.x, minMaxHeight.y, restingHeight) - localPhysicsPosition.z), -0.01f, 0.01f) / Time.fixedDeltaTime) * Vector3.forward;
-          localPhysicsVelocity *= Mathf.Pow(0.0000000001f, Time.fixedDeltaTime);
+
+          // Friction & Drag
+          float velMag = originalLocalVelocity.magnitude;
+          if (velMag > 0F) {
+            Vector3 resistanceDir = -originalLocalVelocity / velMag;
+
+            // Friction force
+            Vector3 frictionForce = resistanceDir * velMag * FRICTION_COEFFICIENT;
+            localPhysicsVelocity = localPhysicsVelocity + (frictionForce /* assume unit mass */ * Time.fixedDeltaTime);
+
+            // Drag force
+            float velSqrMag = localPhysicsVelocity.sqrMagnitude;
+            Vector3 dragForce = resistanceDir * velSqrMag * DRAG_COEFFICIENT;
+            localPhysicsVelocity = localPhysicsVelocity + (dragForce /* assume unit mass */ * Time.fixedDeltaTime);
+          }
         }
 
         // Transform the local physics back into world space

--- a/ProjectSettings/TimeManager.asset
+++ b/ProjectSettings/TimeManager.asset
@@ -3,7 +3,7 @@
 --- !u!5 &1
 TimeManager:
   m_ObjectHideFlags: 0
-  Fixed Timestep: 0.0111111
-  Maximum Allowed Timestep: 0.33333334
+  Fixed Timestep: 0.011111111
+  Maximum Allowed Timestep: 1
   m_TimeScale: 1
-  Maximum Particle Timestep: 0.03
+  Maximum Particle Timestep: 1


### PR DESCRIPTION
Swapped the exponential decay in InteractionButton for a friction-and-drag model, and tuned the coefficients to produce reasonable results at physics timesteps of 1/30, 1/45, 1/60, and 1/90 (seconds). 

Note that at a timestep of 1/30 (and to a lesser extent 1/45), buttons are still noticeably slower than their 1/60 & 1/90 counterparts. (Making the button motion truly timestep-independent is nontrivial and honestly unnecessary). If it's important to be able to make the buttons faster in lower-frequency-timestep situations, we should expose button friction & drag in the inspector for user tuning. This could be done in this hotfix but should probably be done as a v1.1 release feature.

Qs for John:
- [ ] Does the model make sense?
- [ ] Should we expose friction and drag coefficients in the inspector?

Qs for QA:
- [ ] Do buttons behave acceptably on Android now given the 1/60 timestep?
- [ ] Do buttons and sliders still behave acceptably on all UI example scenes?