### PR TITLE
Feature: Edit-time Poses

### DIFF
--- a/Assets/LeapMotion/Core/Examples/Attachment Hands/Attachment Hands Example.unity
+++ b/Assets/LeapMotion/Core/Examples/Attachment Hands/Attachment Hands Example.unity
@@ -700,8 +700,8 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 54453159}
-  m_LocalRotation: {x: 0.7071067, y: 0.00000014611093, z: 0.00000014611093, w: -0.7071068}
-  m_LocalPosition: {x: 0.079999976, y: -0.000000028610232, z: 0.12000001}
+  m_LocalRotation: {x: 0.12940939, y: 0.48296285, z: 0.86273, w: -0.07547903}
+  m_LocalPosition: {x: 0.21999994, y: -0.13000005, z: 0.27}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 557313549}
@@ -730,8 +730,8 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 74475611}
-  m_LocalRotation: {x: 0.6680724, y: 0.027450718, z: 0.22323182, w: -0.70929074}
-  m_LocalPosition: {x: 0.115337424, y: 0.009728684, z: 0.12000003}
+  m_LocalRotation: {x: -0.08120685, y: 0.5080129, z: 0.857468, w: 0.008782302}
+  m_LocalPosition: {x: 0.18771176, y: -0.12188777, z: 0.28533128}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1716909846}
@@ -954,7 +954,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 111871131}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -9.313226e-10, y: 1.7347185e-17, z: 0.017299937}
+  m_LocalPosition: {x: -0.0000000110272325, y: 0.000000002694122, z: 0.017299945}
   m_LocalScale: {x: 1, y: 1.000002, z: 1.0000017}
   m_Children:
   - {fileID: 720171620}
@@ -2191,7 +2191,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 266856075}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.000000006879556, y: 0.000000007450565, z: 0.021669963}
+  m_LocalPosition: {x: -0.0000000044237747, y: -0.0000000017878381, z: 0.02166996}
   m_LocalScale: {x: 1.0000019, y: 1.0000021, z: 1.0000019}
   m_Children:
   - {fileID: 817774161}
@@ -2575,8 +2575,8 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 326403806}
-  m_LocalRotation: {x: 0.64989656, y: -0.058857407, z: -0.045786943, w: -0.75635564}
-  m_LocalPosition: {x: -0.07721127, y: 0.023252076, z: 0.11599997}
+  m_LocalRotation: {x: 0.09523599, y: -0.55546176, z: -0.8259058, w: -0.016494665}
+  m_LocalPosition: {x: -0.2271814, y: -0.11224286, z: 0.2840551}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1827925084}
@@ -2772,8 +2772,8 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 362540213}
-  m_LocalRotation: {x: -0, y: -0, z: -0.0000000037252903, w: 1}
-  m_LocalPosition: {x: -0.000000005122274, y: 0, z: 0.03977999}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.000000013969839, y: -0.000000026077032, z: 0.039779983}
   m_LocalScale: {x: 1, y: 1.0000006, z: 0.9999995}
   m_Children:
   - {fileID: 1989840660}
@@ -2830,7 +2830,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 372778011}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.000000005820766, y: -0.000000014901161, z: 0.017399969}
+  m_LocalPosition: {x: -0.000000001862645, y: 0.000000012822866, z: 0.017399983}
   m_LocalScale: {x: 1, y: 1, z: 1.000001}
   m_Children:
   - {fileID: 2110001594}
@@ -2860,7 +2860,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 376851378}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 4.6566126e-10, y: 0.0000000010573854, z: 0.022380013}
+  m_LocalPosition: {x: 0.0000000055879354, y: 0.0000000023913367, z: 0.02238001}
   m_LocalScale: {x: 1, y: 1.0000008, z: 0.9999992}
   m_Children:
   - {fileID: 712894081}
@@ -3236,7 +3236,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 435512177}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.000000003259629, y: 0.0000000090199705, z: 0.026330002}
+  m_LocalPosition: {x: -0.000000011175871, y: -0.000000009026101, z: 0.02632999}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1431802146}
@@ -3323,8 +3323,8 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 457174335}
-  m_LocalRotation: {x: 0.6498965, y: 0.058857724, z: 0.045787208, w: -0.75635564}
-  m_LocalPosition: {x: 0.077211194, y: 0.023252076, z: 0.11600001}
+  m_LocalRotation: {x: 0.095235705, y: 0.55546176, z: 0.8259058, w: -0.016494483}
+  m_LocalPosition: {x: 0.22718123, y: -0.11224286, z: 0.28405523}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1263177449}
@@ -3482,7 +3482,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 477727594}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -9.3132246e-10, y: -0.000000013061743, z: 0.015820028}
+  m_LocalPosition: {x: 0.000000018626451, y: -9.429447e-10, z: 0.015820032}
   m_LocalScale: {x: 1, y: 1.0000006, z: 0.9999994}
   m_Children:
   - {fileID: 718909996}
@@ -3654,7 +3654,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 522600404}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -9.3132246e-10, y: 0.0000000111758505, z: 0.018109981}
+  m_LocalPosition: {x: 0.000000010710209, y: -0.0000000055879252, z: 0.018109974}
   m_LocalScale: {x: 1, y: 1.0000019, z: 1.0000011}
   m_Children:
   - {fileID: 1618038258}
@@ -4043,12 +4043,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 025cc0fa7b46aa541aba29d28d35ac09, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  editTimePose: 1
   _isHeadMounted: 1
   _temporalWarping: {fileID: 1571381170}
-  _frameOptimization: 1
-  _overrideDeviceType: 1
+  _frameOptimization: 0
+  _overrideDeviceType: 0
   _overrideDeviceTypeWith: 1
-  _updateHandInPrecull: 0
+  _updateHandInPrecull: 1
 --- !u!114 &575511663
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4179,8 +4180,8 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 593673683}
-  m_LocalRotation: {x: 0.7071067, y: 0.00000014611093, z: 0.00000014611093, w: -0.7071068}
-  m_LocalPosition: {x: -0.084363915, y: -0.03101116, z: 0.11349996}
+  m_LocalRotation: {x: 0.12940967, y: -0.48296285, z: -0.86272997, w: -0.075479195}
+  m_LocalPosition: {x: -0.21282761, y: -0.15986496, z: 0.26107657}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 780624578}
@@ -4305,8 +4306,8 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 602482288}
-  m_LocalRotation: {x: 0.5269208, y: 0.12559153, z: 0.63125104, w: -0.5550707}
-  m_LocalPosition: {x: -0.036358662, y: -0.018803203, z: 0.14509633}
+  m_LocalRotation: {x: 0.66444683, y: -0.3444115, z: -0.5637821, w: -0.34934366}
+  m_LocalPosition: {x: -0.25244933, y: -0.13270538, z: 0.22724845}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1409227694}
@@ -4764,8 +4765,8 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 689183289}
-  m_LocalRotation: {x: 0.6520475, y: 0.025763933, z: 0.12257417, w: -0.7477606}
-  m_LocalPosition: {x: 0.09744714, y: 0.017279115, z: 0.11600002}
+  m_LocalRotation: {x: 0.01326618, y: 0.54483914, z: 0.8380313, w: -0.026037497}
+  m_LocalPosition: {x: 0.20695539, y: -0.11744297, z: 0.28706264}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 840185102}
@@ -5265,7 +5266,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 760587167}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -9.313226e-10, y: 0.000000013869975, z: 0.017299954}
+  m_LocalPosition: {x: 0.0000000064288264, y: 0.000000002694124, z: 0.017299969}
   m_LocalScale: {x: 1, y: 1.0000011, z: 1.0000015}
   m_Children:
   - {fileID: 194472992}
@@ -5295,7 +5296,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 780421941}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.0000000037252903, y: -0.000000011175871, z: 0.01596}
+  m_LocalPosition: {x: 0.0000000023283064, y: 0.000000022351742, z: 0.01596}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 182057572}
@@ -5382,7 +5383,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 801710431}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.0000000018626451, y: -0.000000003725285, z: 0.015820013}
+  m_LocalPosition: {x: -0.000000020489097, y: -0.000000003725285, z: 0.015820032}
   m_LocalScale: {x: 1, y: 1.0000007, z: 0.9999997}
   m_Children:
   - {fileID: 2052513601}
@@ -6002,8 +6003,8 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 895799941}
-  m_LocalRotation: {x: -0.000000029802322, y: -0, z: -0.0000000055879354, w: 1}
-  m_LocalPosition: {x: 0.000000013969839, y: 0, z: 0.04137001}
+  m_LocalRotation: {x: -0.000000029802322, y: 9.313226e-10, z: -0, w: 1}
+  m_LocalPosition: {x: 0.0000000050640665, y: -0.000000007450581, z: 0.04136999}
   m_LocalScale: {x: 1, y: 1.000001, z: 1.0000012}
   m_Children:
   - {fileID: 1438451178}
@@ -6640,8 +6641,8 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1032835622}
-  m_LocalRotation: {x: 0.5269211, y: -0.12559128, z: -0.6312508, w: -0.55507076}
-  m_LocalPosition: {x: 0.036358558, y: -0.018803203, z: 0.14509636}
+  m_LocalRotation: {x: 0.66444665, y: 0.34441158, z: 0.56378233, w: -0.34934354}
+  m_LocalPosition: {x: 0.2524492, y: -0.13270538, z: 0.22724862}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 460569612}
@@ -7594,8 +7595,8 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1141904582}
-  m_LocalRotation: {x: -0, y: -0, z: -0.0000000018626451, w: 1}
-  m_LocalPosition: {x: 9.313226e-10, y: -0.000000007450581, z: 0.03274}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.000000017229468, y: -0.000000013038516, z: 0.03273999}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1206546617}
@@ -7900,8 +7901,8 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1196606713}
-  m_LocalRotation: {x: 0.7071067, y: 0.00000014611093, z: 0.00000014611093, w: -0.7071068}
-  m_LocalPosition: {x: 0.08436384, y: -0.03101116, z: 0.11350002}
+  m_LocalRotation: {x: 0.12940939, y: 0.48296285, z: 0.86273, w: -0.07547903}
+  m_LocalPosition: {x: 0.21282743, y: -0.15986496, z: 0.2610767}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1393873880}
@@ -9473,7 +9474,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1383826728}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.000000011175871, y: 0.000000026077032, z: 0.018110003}
+  m_LocalPosition: {x: -0.000000015832484, y: -0.0000000055879354, z: 0.01811}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1130950439}
@@ -9530,7 +9531,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1390747672}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.000000011175871, y: 0.0000000010371206, z: 0.017399997}
+  m_LocalPosition: {x: -9.313226e-10, y: 0.000000013859989, z: 0.017400004}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 298056260}
@@ -9559,8 +9560,8 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1391263028}
-  m_LocalRotation: {x: -0.000000059604645, y: -0, z: -0.0000000037252903, w: 1}
-  m_LocalPosition: {x: 0.0000000023283064, y: 0, z: 0.039779995}
+  m_LocalRotation: {x: -0.000000029802322, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.0000000055879354, y: -0.000000026077032, z: 0.039779987}
   m_LocalScale: {x: 1, y: 1.0000008, z: 0.9999995}
   m_Children:
   - {fileID: 704594351}
@@ -9647,8 +9648,8 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1408244859}
-  m_LocalRotation: {x: 0.6502362, y: 0.05497836, z: -0.06383985, w: -0.7550462}
-  m_LocalPosition: {x: 0.056818686, y: 0.023149315, z: 0.11800001}
+  m_LocalRotation: {x: 0.1985087, y: 0.5493819, z: 0.81014276, w: -0.049422033}
+  m_LocalPosition: {x: 0.24613243, y: -0.11117952, z: 0.2763361}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1581863436}
@@ -10384,7 +10385,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1531519021}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 9.313226e-10, y: -0.000000007450581, z: 0.032740004}
+  m_LocalPosition: {x: 0.0000000018626451, y: -0.000000013038516, z: 0.032739997}
   m_LocalScale: {x: 1.0000001, y: 1.0000019, z: 1.0000011}
   m_Children:
   - {fileID: 272528850}
@@ -10428,7 +10429,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1547423078}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.0000000027939677, y: 5.204165e-17, z: 0.025649957}
+  m_LocalPosition: {x: -0.000000008857995, y: -0.000000012704717, z: 0.025649961}
   m_LocalScale: {x: 1, y: 1.0000018, z: 1.0000017}
   m_Children:
   - {fileID: 1641153144}
@@ -10588,8 +10589,8 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1596634625}
-  m_LocalRotation: {x: 0.66807246, y: -0.027450424, z: -0.22323154, w: -0.70929074}
-  m_LocalPosition: {x: -0.1153375, y: 0.009728684, z: 0.11999995}
+  m_LocalRotation: {x: -0.081206575, y: -0.5080129, z: -0.857468, w: 0.008782136}
+  m_LocalPosition: {x: -0.18771194, y: -0.12188777, z: 0.28533116}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1042039111}
@@ -10913,7 +10914,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1634442780}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.0000000018626449, y: -0.00000001117583, z: 0.015959969}
+  m_LocalPosition: {x: -0.0000000060535963, y: 0.00000002235166, z: 0.015959976}
   m_LocalScale: {x: 1, y: 1.0000019, z: 1.0000011}
   m_Children:
   - {fileID: 136060737}
@@ -10955,8 +10956,8 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1635190765}
-  m_LocalRotation: {x: 0.000000029802322, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.0000000016298145, y: -0.000000007450581, z: 0.04463}
+  m_LocalRotation: {x: -0.000000029918738, y: -0, z: 0.0000000037252903, w: 1}
+  m_LocalPosition: {x: 0.000000013969839, y: -0.000000022351742, z: 0.044629995}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1586920352}
@@ -11196,8 +11197,8 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1671515517}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.000000007450581, y: 0, z: 0.04463}
+  m_LocalRotation: {x: -0.00000005972106, y: -0, z: 0.0000000037252903, w: 1}
+  m_LocalPosition: {x: 0.000000013969839, y: 0.000000029802322, z: 0.044630006}
   m_LocalScale: {x: 1, y: 1, z: 1.000001}
   m_Children:
   - {fileID: 514141368}
@@ -11254,7 +11255,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1690107033}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.0000000046565978, y: 0.000000003725276, z: 0.02166993}
+  m_LocalPosition: {x: -0.0000000023282989, y: 6.4581374e-10, z: 0.02166993}
   m_LocalScale: {x: 1.0000031, y: 1.000004, z: 1.0000037}
   m_Children:
   - {fileID: 880980077}
@@ -11909,7 +11910,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1769762659}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.0000000013969839, y: 0.0000000037252883, z: 0.022380017}
+  m_LocalPosition: {x: -0.000000010244548, y: 0.0000000074505766, z: 0.022380006}
   m_LocalScale: {x: 1, y: 1.000001, z: 0.9999997}
   m_Children:
   - {fileID: 189197935}
@@ -12119,7 +12120,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1811656209}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.0000000121071935, y: 0, z: 0.026329977}
+  m_LocalPosition: {x: 0.0000000027939677, y: -0.0000000031449103, z: 0.02632997}
   m_LocalScale: {x: 1, y: 1, z: 1.000001}
   m_Children:
   - {fileID: 1412381221}
@@ -12443,7 +12444,7 @@ Transform:
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1870428528}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.0000000055879354, y: -0.000000016430006, z: 0.025649961}
+  m_LocalPosition: {x: 0.0000000021641142, y: -0.000000012704718, z: 0.025649965}
   m_LocalScale: {x: 1, y: 1.0000011, z: 1.0000013}
   m_Children:
   - {fileID: 289886812}
@@ -12486,8 +12487,8 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1883586274}
-  m_LocalRotation: {x: -0, y: -0.000000029802322, z: -0, w: 1}
-  m_LocalPosition: {x: 0.0000000037252903, y: 0, z: 0.03157}
+  m_LocalRotation: {x: 0.000000044703484, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.000000026077032, y: -0.000000026077032, z: 0.031570006}
   m_LocalScale: {x: 1.0000018, y: 1.0000021, z: 1.0000017}
   m_Children:
   - {fileID: 223881312}
@@ -13269,8 +13270,8 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 1998410773}
-  m_LocalRotation: {x: 0.7071067, y: 0.00000014611093, z: 0.00000014611093, w: -0.7071068}
-  m_LocalPosition: {x: -0.08000005, y: -0.000000028610229, z: 0.11999997}
+  m_LocalRotation: {x: 0.12940967, y: -0.48296285, z: -0.86272997, w: -0.075479195}
+  m_LocalPosition: {x: -0.22000012, y: -0.13000005, z: 0.2699999}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 542896046}
@@ -13299,8 +13300,8 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 2008156287}
-  m_LocalRotation: {x: -0, y: -0, z: 0.000000009313226, w: 1}
-  m_LocalPosition: {x: -0.000000011175871, y: -0.000000007450581, z: 0.04137}
+  m_LocalRotation: {x: -0.000000029802322, y: -9.313226e-10, z: -0, w: 1}
+  m_LocalPosition: {x: 0.0000000136788, y: -0.000000007450581, z: 0.04136999}
   m_LocalScale: {x: 1, y: 1.0000011, z: 1.0000017}
   m_Children:
   - {fileID: 1755547430}
@@ -13439,8 +13440,8 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 2018920667}
-  m_LocalRotation: {x: 0.6502361, y: -0.054978054, z: 0.06384012, w: -0.75504625}
-  m_LocalPosition: {x: -0.05681876, y: 0.023149315, z: 0.11799998}
+  m_LocalRotation: {x: 0.19850898, y: -0.5493819, z: -0.81014276, w: -0.049422216}
+  m_LocalPosition: {x: -0.24613261, y: -0.11117952, z: 0.27633592}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1391263029}
@@ -13566,8 +13567,8 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 2048082923}
-  m_LocalRotation: {x: 0.6520476, y: -0.025763627, z: -0.122573905, w: -0.7477606}
-  m_LocalPosition: {x: -0.09744722, y: 0.017279115, z: 0.11599996}
+  m_LocalRotation: {x: 0.013266453, y: -0.54483914, z: -0.8380313, w: -0.026037674}
+  m_LocalPosition: {x: -0.20695557, y: -0.11744297, z: 0.28706253}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1138166029}
@@ -13794,8 +13795,8 @@ Transform:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 0}
   m_GameObject: {fileID: 2079288360}
-  m_LocalRotation: {x: -0, y: -0, z: -0.000000014901159, w: 1}
-  m_LocalPosition: {x: 0.000000008381903, y: -0.0000000037252903, z: 0.031570006}
+  m_LocalRotation: {x: 0.000000014901161, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.0000000146683306, y: -0.000000022351742, z: 0.03157001}
   m_LocalScale: {x: 1.0000033, y: 1.0000038, z: 1.0000031}
   m_Children:
   - {fileID: 1994716657}

--- a/Assets/LeapMotion/Core/Scripts/Attachments/AttachmentHand.cs
+++ b/Assets/LeapMotion/Core/Scripts/Attachments/AttachmentHand.cs
@@ -7,6 +7,7 @@
  * between Leap Motion and you, your company or other organization.           *
  ******************************************************************************/
 
+using Leap.Unity.Attributes;
 using Leap.Unity.Query;
 using System;
 using System.Collections;
@@ -101,7 +102,7 @@ namespace Leap.Unity.Attachments {
     /// Used by AttachmentHands as a hint to help prevent mixing up hand chiralities
     /// when refreshing its AttachmentHand references.
     /// </summary>
-    [SerializeField, HideInInspector]
+    [SerializeField, Disable]
     private Chirality _chirality;
 
     /// <summary>

--- a/Assets/LeapMotion/Core/Scripts/Attachments/AttachmentHands.cs
+++ b/Assets/LeapMotion/Core/Scripts/Attachments/AttachmentHands.cs
@@ -124,7 +124,7 @@ namespace Leap.Unity.Attachments {
           #if UNITY_EDITOR
           if (Hands.Provider != null) {
             if (leapHand == null && !Application.isPlaying) {
-              leapHand = TestHandFactory.MakeTestHand(0, i, i == 0).TransformedCopy(UnityMatrixExtension.GetLeapMatrix(Hands.Provider.transform));
+              leapHand = Hands.Provider.MakeTestHand(attachmentHand.chirality == Chirality.Left);
             }
           }
           #endif

--- a/Assets/LeapMotion/Core/Scripts/Hands/IHandModel.cs
+++ b/Assets/LeapMotion/Core/Scripts/Hands/IHandModel.cs
@@ -63,13 +63,17 @@ namespace Leap.Unity {
       if (!EditorApplication.isPlaying && SupportsEditorPersistence()) {
         Transform editorPoseSpace;
         LeapServiceProvider leapServiceProvider = FindObjectOfType<LeapServiceProvider>();
-        if (leapServiceProvider) {
+        LeapTransform poseTransform = LeapTransform.Identity;
+        if (leapServiceProvider != null) {
           editorPoseSpace = leapServiceProvider.transform;
+          poseTransform = TestHandFactory.GetTestPoseLeftHandTransform(leapServiceProvider.editTimePose);
         } else {
           editorPoseSpace = transform;
         }
 
-        Hand hand = TestHandFactory.MakeTestHand(0, 0, Handedness == Chirality.Left).TransformedCopy(UnityMatrixExtension.GetLeapMatrix(editorPoseSpace));
+        Hand hand = TestHandFactory.MakeTestHand(Handedness == Chirality.Left, poseTransform).TransformedCopy(UnityMatrixExtension.GetLeapMatrix(editorPoseSpace));
+        //Hand hand = TestHandFactory.MakeTestHand(0, 0, Handedness == Chirality.Left).TransformedCopy(UnityMatrixExtension.GetLeapMatrix(editorPoseSpace));
+
         if (GetLeapHand() == null) {
           SetLeapHand(hand);
           InitHand();

--- a/Assets/LeapMotion/Core/Scripts/Hands/TestHandFactory.cs
+++ b/Assets/LeapMotion/Core/Scripts/Hands/TestHandFactory.cs
@@ -9,189 +9,226 @@
 
 namespace Leap {
 
-using System;
-using System.Runtime.InteropServices;
+  using System;
   using System.Collections.Generic;
   using Leap.Unity;
   using UnityEngine;
 
+  public class TestHandFactory {
 
-    public class TestHandFactory {
+    public static Frame MakeTestFrame(int frameId, bool leftHandIncluded, bool rightHandIncluded) {
+      Frame testFrame = new Frame(frameId, 0, 120.0f, new InteractionBox(), new List<Hand>());
+      if (leftHandIncluded)
+        testFrame.Hands.Add(MakeTestHand(frameId, 10, true));
+      if (rightHandIncluded)
+        testFrame.Hands.Add(MakeTestHand(frameId, 20, false));
+      return testFrame;
+    }
 
-        public static Frame MakeTestFrame(int frameId, bool leftHandIncluded, bool rightHandIncluded){
-            Frame testFrame = new Frame(frameId, 0, 120.0f, new InteractionBox(), new List<Hand>());
-            if(leftHandIncluded)
-                testFrame.Hands.Add(MakeTestHand(frameId, 10, true));
-            if(rightHandIncluded)
-              testFrame.Hands.Add(MakeTestHand(frameId, 20, false));
-            return testFrame;
-        }
+    public static Hand MakeTestHand(bool isLeft, int frameId = 0, int handId = 0) {
+      return MakeTestHand(frameId, handId, isLeft);
+    }
 
-        public static Hand MakeTestHand(int frameId, int handId, bool isLeft){
-            List<Finger> fingers = new List<Finger>(5);
-            fingers.Add(MakeThumb (frameId, handId, isLeft));
-            fingers.Add(MakeIndexFinger (frameId, handId, isLeft));
-            fingers.Add(MakeMiddleFinger (frameId, handId, isLeft));
-            fingers.Add(MakeRingFinger (frameId, handId, isLeft));
-            fingers.Add( MakePinky (frameId, handId, isLeft));
+    /// <summary>
+    /// Returns a test Leap Hand object transformed by the leftHandTransform argument. If the Leap hand is
+    /// a right hand, the position and rotation of the Hand will be mirrored along the X axis (so you can provide
+    /// LeapTransform to construct both left and right hands.
+    /// </summary>
+    public static Hand MakeTestHand(bool isLeft, LeapTransform leftHandTransform, int frameId = 0, int handId = 0) {
+      if (!isLeft) {
+        leftHandTransform.translation = new Vector(-leftHandTransform.translation.x, leftHandTransform.translation.y, leftHandTransform.translation.z);
 
-            Vector armWrist = new Vector(-7.05809944059f, 4.0f, 50.0f);
-            Vector elbow = armWrist + 250f * Vector.Backward;
+        leftHandTransform.rotation = new LeapQuaternion(-leftHandTransform.rotation.x,
+                                                         leftHandTransform.rotation.y,
+                                                         leftHandTransform.rotation.z,
+                                                        -leftHandTransform.rotation.w);
 
-            // Adrian: The previous "armBasis" used "elbow" as a translation component.
-            Arm arm = new Arm(elbow, armWrist,(elbow + armWrist)/2, Vector.Forward, 250f, 41f, LeapQuaternion.Identity);
-            Hand testHand = new Hand(frameId,
-            handId,
-            1.0f,
-            0.0f,
-            0.0f,
-            0.0f,
-            0.0f,
-            85f,
-            isLeft,
-            0.0f,
-            arm,
-                fingers,
-                new Vector (0,0,0),
-                new Vector(0,0,0),
-                new Vector(0,0,0),
-                Vector.Down,
-                LeapQuaternion.Identity,
-                Vector.Forward,
-                new Vector(-4.36385750984f, 6.5f, 31.0111342526f)
-            );
-            LeapTransform restPosition = LeapTransform.Identity;
-            //restPosition.rotation = RotationFromTo(Vector.Up, Vector.Left).Multiply(RotationFromTo(Vector.Up, Vector.Left));
-            restPosition.rotation = AngleAxis(180 * Constants.DEG_TO_RAD, Vector.Forward);
-            if(isLeft){
-                restPosition.translation = new Vector(80f, 120f, 0f);
+        leftHandTransform.MirrorX();
+      }
+      return MakeTestHand(frameId, handId, isLeft).Transform(leftHandTransform);
+    }
 
-            } else {
-                restPosition.translation = new Vector(-80f, 120f, 0f);
-                restPosition.MirrorX();
-            }
-            return testHand.TransformedCopy(restPosition);
-        }
+    /// <summary>
+    /// Returns a test Leap Hand object in the argument pose position and rotation from the hand controller.
+    /// </summary>
+    public static Hand MakeTestHand(bool isLeft, TestHandPose pose, int frameId = 0, int handId = 0) {
+      return MakeTestHand(isLeft, GetTestPoseLeftHandTransform(pose), frameId, handId);
+    }
 
-         static LeapQuaternion AngleAxis(float angle, Vector axis){
-           if(!axis.MagnitudeSquared.NearlyEquals(1.0f)){
-             throw new ArgumentException("Axis must be a unit vector.");
-           }
-           float sineHalfAngle = Mathf.Sin(angle/2.0f);
-           LeapQuaternion q = new LeapQuaternion(sineHalfAngle * axis.x,
-                                                 sineHalfAngle * axis.y,
-                                                 sineHalfAngle * axis.z,
-                                                 Mathf.Cos(angle/2.0f));
-           return q.Normalized;
-         }
+    public enum TestHandPose {
+      PoseA,
+      PoseB
+    }
 
-    static LeapQuaternion RotationBetween(Vector fromDirection, Vector toDirection)
-    {
+    public static LeapTransform GetTestPoseLeftHandTransform(TestHandPose pose) {
+      LeapTransform transform = LeapTransform.Identity;
+      switch (pose) {
+        case TestHandPose.PoseA:
+          transform.rotation = AngleAxis(180 * Constants.DEG_TO_RAD, Vector.Forward);
+          transform.translation = new Vector(80f, 120f, 0f);
+          break;
+        case TestHandPose.PoseB:
+          transform.rotation = Quaternion.Euler(30F, -10F, -20F).ToLeapQuaternion();
+          transform.translation = new Vector(220f, 270f, 130f);
+          break;
+      }
+      return transform;
+    }
+
+    public static Hand MakeTestHand(int frameId, int handId, bool isLeft) {
+      List<Finger> fingers = new List<Finger>(5);
+      fingers.Add(MakeThumb(frameId, handId, isLeft));
+      fingers.Add(MakeIndexFinger(frameId, handId, isLeft));
+      fingers.Add(MakeMiddleFinger(frameId, handId, isLeft));
+      fingers.Add(MakeRingFinger(frameId, handId, isLeft));
+      fingers.Add(MakePinky(frameId, handId, isLeft));
+
+      Vector armWrist = new Vector(-7.05809944059f, 4.0f, 50.0f);
+      Vector elbow = armWrist + 250f * Vector.Backward;
+
+      // Adrian: The previous "armBasis" used "elbow" as a translation component.
+      Arm arm = new Arm(elbow, armWrist,(elbow + armWrist)/2, Vector.Forward, 250f, 41f, LeapQuaternion.Identity);
+      Hand testHand = new Hand(frameId,
+                               handId,
+                               1.0f,
+                               0.0f,
+                               0.0f,
+                               0.0f,
+                               0.0f,
+                               85f,
+                               isLeft,
+                               0.0f,
+                               arm,
+                               fingers,
+                               new Vector (0,0,0),
+                               new Vector(0,0,0),
+                               new Vector(0,0,0),
+                               Vector.Down,
+                               LeapQuaternion.Identity,
+                               Vector.Forward,
+                               new Vector(-4.36385750984f, 6.5f, 31.0111342526f));
+
+      return testHand;
+    }
+
+    static LeapQuaternion AngleAxis(float angle, Vector axis) {
+      if (!axis.MagnitudeSquared.NearlyEquals(1.0f)) {
+        throw new ArgumentException("Axis must be a unit vector.");
+      }
+      float sineHalfAngle = Mathf.Sin(angle/2.0f);
+      LeapQuaternion q = new LeapQuaternion(sineHalfAngle * axis.x,
+                                                sineHalfAngle * axis.y,
+                                                sineHalfAngle * axis.z,
+                                                Mathf.Cos(angle/2.0f));
+      return q.Normalized;
+    }
+
+    static LeapQuaternion RotationBetween(Vector fromDirection, Vector toDirection) {
       float m = Mathf.Sqrt(2.0f + 2.0f * fromDirection.Dot(toDirection));
       Vector w = (1.0f / m) * fromDirection.Cross(toDirection);
       return new LeapQuaternion(w.x, w.y, w.z, 0.5f * m);
     }
 
-         static Finger MakeThumb(int frameId, int handId, bool isLeft){
-            //Thumb
-            Vector position = new Vector(19.3382610281f, -6.0f, 53.168484654f);
-            Vector forward = new Vector(0.636329113772f, -0.5f, -0.899787143982f);
-            Vector up = new Vector(0.804793943718f, 0.447213915513f, 0.390264553767f);
-            float[] jointLengths = {0.0f, 46.22f, 31.57f, 21.67f};
-            return MakeFinger (Finger.FingerType.TYPE_THUMB, position, forward, up, jointLengths, frameId, handId, handId + 0, isLeft);
-        }
-
-         static Finger MakeIndexFinger(int frameId, int handId, bool isLeft){
-            //Index Finger
-            Vector position = new Vector(23.1812851873f, 2.0f, -23.1493459317f);
-            Vector forward = new Vector(0.166044313785f, -0.14834045293f, -0.974897120667f);
-            Vector up = new Vector(0.0249066470677f, 0.988936352868f, -0.1462345681f);
-            float[]  jointLengths = {68.12f, 39.78f, 22.38f, 15.82f};
-            return MakeFinger (Finger.FingerType.TYPE_INDEX, position, forward, up, jointLengths, frameId, handId, handId + 1, isLeft);
-        }
-
-         static Finger MakeMiddleFinger(int frameId, int handId, bool isLeft){
-            //Middle Finger
-            Vector position = new Vector(2.78877821918f, 4.0f, -23.252105626f);
-            Vector forward = new Vector(0.0295207858556f, -0.148340452932f, -0.988495641481f);
-            Vector up = new Vector(-0.145765270107f, 0.977715980076f, -0.151075968756f);
-            float[]  jointLengths = {64.60f, 44.63f, 26.33f, 17.40f};
-            return MakeFinger (Finger.FingerType.TYPE_MIDDLE, position, forward, up, jointLengths, frameId, handId, handId + 2, isLeft);
-        }
-
-         static Finger MakeRingFinger(int frameId, int handId, bool isLeft){
-            //Ring Finger
-            Vector position = new Vector(-17.447168266f, 4.0f, -17.2791440615f);
-            Vector forward = new Vector(-0.121317937368f, -0.148340347175f, -0.981466810174f);
-            Vector up = new Vector(-0.216910468316f, 0.968834928679f, -0.119619102602f);
-            float[]  jointLengths = {58.00f, 41.37f, 25.65f, 17.30f};
-            return MakeFinger (Finger.FingerType.TYPE_RING, position, forward, up, jointLengths, frameId, handId, handId + 3, isLeft);
-        }
-
-         static Finger MakePinky(int frameId, int handId, bool isLeft){
-            //Pinky Finger
-            Vector position = new Vector(-35.3374394559f, 0.0f, -9.72871382551f);
-            Vector forward = new Vector(-0.259328923438f, -0.105851224797f, -0.959970847306f);
-            Vector up = new Vector(-0.353350220937f, 0.935459475557f, -0.00769356576168f);
-            float[]  jointLengths = {53.69f, 32.74f, 18.11f, 15.96f};
-            return MakeFinger (Finger.FingerType.TYPE_PINKY, position, forward, up, jointLengths, frameId, handId, handId + 4, isLeft);
-        }
-
-
-         static Finger MakeFinger(Finger.FingerType name, Vector position, Vector forward, Vector up, float[] jointLengths,
-            int frameId, int handId, int fingerId, bool isLeft){
-
-            forward = forward.Normalized;
-            up = up.Normalized;
-
-            Bone[] bones = new Bone[5];
-            float proximalDistance = -jointLengths[0];
-            Bone metacarpal = MakeBone (Bone.BoneType.TYPE_METACARPAL, position + forward * proximalDistance, jointLengths[0], 8f, forward, up, isLeft);
-            proximalDistance += jointLengths[0];
-            bones[0] = metacarpal;
-
-            Bone proximal = MakeBone (Bone.BoneType.TYPE_PROXIMAL,  position + forward * proximalDistance, jointLengths[1], 8f, forward, up, isLeft);
-            proximalDistance += jointLengths[1];
-            bones[1] = proximal;
-
-            Bone intermediate = MakeBone (Bone.BoneType.TYPE_INTERMEDIATE,  position + forward * proximalDistance, jointLengths[2], 8f, forward, up, isLeft);
-            proximalDistance += jointLengths[2];
-            bones[2] = intermediate;
-
-            Bone distal = MakeBone (Bone.BoneType.TYPE_DISTAL,  position + forward * proximalDistance, jointLengths[3], 8f, forward, up, isLeft);
-            bones[3] = distal;
-
-            return new Finger(frameId,
-            handId,
-            fingerId,
-            0.0f,
-            position,
-            new Vector(0,0,0),
-            forward,
-            position,
-            8f,
-            jointLengths[1] + jointLengths[2] +jointLengths[3],
-            true,
-            name,
-            bones[0],
-            bones[1],
-            bones[2],
-            bones[3]);
-        }
-
-         static Bone MakeBone(Bone.BoneType name, Vector proximalPosition, float length, float width, Vector direction, Vector up, bool isLeft){
-
-           LeapQuaternion rotation = UnityEngine.Quaternion.LookRotation(-direction.ToVector3(), up.ToVector3()).ToLeapQuaternion();
-
-           return new Bone(
-                proximalPosition,
-                proximalPosition + direction * length,
-                Vector.Lerp(proximalPosition, proximalPosition + direction * length, .5f),
-                direction,
-                length,
-                width,
-                name,
-                rotation);
-        }
+    static Finger MakeThumb(int frameId, int handId, bool isLeft) {
+      //Thumb
+      Vector position = new Vector(19.3382610281f, -6.0f, 53.168484654f);
+      Vector forward = new Vector(0.636329113772f, -0.5f, -0.899787143982f);
+      Vector up = new Vector(0.804793943718f, 0.447213915513f, 0.390264553767f);
+      float[] jointLengths = {0.0f, 46.22f, 31.57f, 21.67f};
+      return MakeFinger(Finger.FingerType.TYPE_THUMB, position, forward, up, jointLengths, frameId, handId, handId + 0, isLeft);
     }
+
+    static Finger MakeIndexFinger(int frameId, int handId, bool isLeft) {
+      //Index Finger
+      Vector position = new Vector(23.1812851873f, 2.0f, -23.1493459317f);
+      Vector forward = new Vector(0.166044313785f, -0.14834045293f, -0.974897120667f);
+      Vector up = new Vector(0.0249066470677f, 0.988936352868f, -0.1462345681f);
+      float[]  jointLengths = {68.12f, 39.78f, 22.38f, 15.82f};
+      return MakeFinger(Finger.FingerType.TYPE_INDEX, position, forward, up, jointLengths, frameId, handId, handId + 1, isLeft);
+    }
+
+    static Finger MakeMiddleFinger(int frameId, int handId, bool isLeft) {
+      //Middle Finger
+      Vector position = new Vector(2.78877821918f, 4.0f, -23.252105626f);
+      Vector forward = new Vector(0.0295207858556f, -0.148340452932f, -0.988495641481f);
+      Vector up = new Vector(-0.145765270107f, 0.977715980076f, -0.151075968756f);
+      float[]  jointLengths = {64.60f, 44.63f, 26.33f, 17.40f};
+      return MakeFinger(Finger.FingerType.TYPE_MIDDLE, position, forward, up, jointLengths, frameId, handId, handId + 2, isLeft);
+    }
+
+    static Finger MakeRingFinger(int frameId, int handId, bool isLeft) {
+      //Ring Finger
+      Vector position = new Vector(-17.447168266f, 4.0f, -17.2791440615f);
+      Vector forward = new Vector(-0.121317937368f, -0.148340347175f, -0.981466810174f);
+      Vector up = new Vector(-0.216910468316f, 0.968834928679f, -0.119619102602f);
+      float[]  jointLengths = {58.00f, 41.37f, 25.65f, 17.30f};
+      return MakeFinger(Finger.FingerType.TYPE_RING, position, forward, up, jointLengths, frameId, handId, handId + 3, isLeft);
+    }
+
+    static Finger MakePinky(int frameId, int handId, bool isLeft) {
+      //Pinky Finger
+      Vector position = new Vector(-35.3374394559f, 0.0f, -9.72871382551f);
+      Vector forward = new Vector(-0.259328923438f, -0.105851224797f, -0.959970847306f);
+      Vector up = new Vector(-0.353350220937f, 0.935459475557f, -0.00769356576168f);
+      float[]  jointLengths = {53.69f, 32.74f, 18.11f, 15.96f};
+      return MakeFinger(Finger.FingerType.TYPE_PINKY, position, forward, up, jointLengths, frameId, handId, handId + 4, isLeft);
+    }
+
+
+    static Finger MakeFinger(Finger.FingerType name, Vector position, Vector forward, Vector up, float[] jointLengths,
+       int frameId, int handId, int fingerId, bool isLeft) {
+
+      forward = forward.Normalized;
+      up = up.Normalized;
+
+      Bone[] bones = new Bone[5];
+      float proximalDistance = -jointLengths[0];
+      Bone metacarpal = MakeBone (Bone.BoneType.TYPE_METACARPAL, position + forward * proximalDistance, jointLengths[0], 8f, forward, up, isLeft);
+      proximalDistance += jointLengths[0];
+      bones[0] = metacarpal;
+
+      Bone proximal = MakeBone (Bone.BoneType.TYPE_PROXIMAL,  position + forward * proximalDistance, jointLengths[1], 8f, forward, up, isLeft);
+      proximalDistance += jointLengths[1];
+      bones[1] = proximal;
+
+      Bone intermediate = MakeBone (Bone.BoneType.TYPE_INTERMEDIATE,  position + forward * proximalDistance, jointLengths[2], 8f, forward, up, isLeft);
+      proximalDistance += jointLengths[2];
+      bones[2] = intermediate;
+
+      Bone distal = MakeBone (Bone.BoneType.TYPE_DISTAL,  position + forward * proximalDistance, jointLengths[3], 8f, forward, up, isLeft);
+      bones[3] = distal;
+
+      return new Finger(frameId,
+      handId,
+      fingerId,
+      0.0f,
+      position,
+      new Vector(0, 0, 0),
+      forward,
+      position,
+      8f,
+      jointLengths[1] + jointLengths[2] + jointLengths[3],
+      true,
+      name,
+      bones[0],
+      bones[1],
+      bones[2],
+      bones[3]);
+    }
+
+    static Bone MakeBone(Bone.BoneType name, Vector proximalPosition, float length, float width, Vector direction, Vector up, bool isLeft) {
+
+      LeapQuaternion rotation = UnityEngine.Quaternion.LookRotation(-direction.ToVector3(), up.ToVector3()).ToLeapQuaternion();
+
+      return new Bone(
+           proximalPosition,
+           proximalPosition + direction * length,
+           Vector.Lerp(proximalPosition, proximalPosition + direction * length, .5f),
+           direction,
+           length,
+           width,
+           name,
+           rotation);
+    }
+  }
 }

--- a/Assets/LeapMotion/Core/Scripts/LeapProvider.cs
+++ b/Assets/LeapMotion/Core/Scripts/LeapProvider.cs
@@ -12,8 +12,16 @@ using System;
 using System.Collections;
 
 namespace Leap.Unity {
-  /**LeapProvider's supply images and Leap Hands */
+
+  /// <summary>
+  /// Provides Frame object data to the Unity application by firing events as soon
+  /// as Frame data is available. Frames contain all currently tracked Hands in view
+  /// of the Leap Motion Controller.
+  /// </summary>
   public abstract class LeapProvider : MonoBehaviour {
+
+    public TestHandFactory.TestHandPose editTimePose = TestHandFactory.TestHandPose.PoseA;
+
     public event Action<Frame> OnUpdateFrame;
     public event Action<Frame> OnFixedFrame;
 

--- a/Assets/LeapMotion/Core/Scripts/LeapProvider.cs
+++ b/Assets/LeapMotion/Core/Scripts/LeapProvider.cs
@@ -56,5 +56,15 @@ namespace Leap.Unity {
         OnFixedFrame(frame);
       }
     }
+
+  }
+
+  public static class LeapProviderExtensions {
+
+    public static Leap.Hand MakeTestHand(this LeapProvider provider, bool isLeft) {
+      return TestHandFactory.MakeTestHand(isLeft, Hands.Provider.editTimePose)
+                            .Transform(UnityMatrixExtension.GetLeapMatrix(Hands.Provider.transform));
+    }
+
   }
 }


### PR DESCRIPTION
This feature addition:

- Restructures TestHandFactory to take arbitrary LeapTransforms to apply to hands after constructing them
- Provides two alternative default poses specifyable by the enum value, `TestHandPose`, PoseA (the original pose), and PoseB (a palms-in, further-out pose more suitable for building hand UIs)
- Adds an editTimePose public field to the inspector for all LeapProviders
- Modifies IHandModel to use the LeapServiceProvider's editTimePose to construct its edit-time pose

To test:
- [x] Open any Leap-enabled scene and change the editTimePose field of the LeapServiceProvider.
- [x] Verify nothing is borked!