### PR TITLE
Unify all leap motion preferences

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/LeapPreferences.cs
+++ b/Assets/LeapMotion/Core/Scripts/LeapPreferences.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using System.Collections.Generic;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+namespace Leap.Unity {
+
+  /// <summary>
+  /// This attribute is used to add items to the Leap Motion preferences window.
+  /// This allows each module to define their own preferences and still have them
+  /// all show up under the same window.  
+  /// 
+  /// The usage is very similar to the built-in PreferenceItem attribute.  You
+  /// add the attribute onto a static method that should be run whenever the 
+  /// preference window is visited.  This method is a gui method and should use
+  /// GuiLayout and EditorGuiLayout in order to draw the preferences.  You can
+  /// specify the name of the preferences as well as an order value to specify
+  /// how the preferences are ordered relative to other preferences.
+  /// </summary>
+  [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+  public class LeapPreferences : Attribute {
+    public readonly string header;
+    public readonly int order;
+
+    public LeapPreferences(string header, int order) {
+      this.header = header;
+      this.order = order;
+    }
+
+    private static List<LeapPreferenceItem> _leapPreferenceItems = null;
+
+    private struct LeapPreferenceItem {
+      public Action drawPreferenceGui;
+      public LeapPreferences attribute;
+    }
+
+    private static void ensurePreferenceItemsLoaded() {
+      if (_leapPreferenceItems != null) {
+        return;
+      }
+
+      _leapPreferenceItems = new List<LeapPreferenceItem>();
+
+      var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+      foreach (var type in assemblies.SelectMany(a => a.GetTypes())) {
+        foreach (var method in type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static)) {
+          var attributes = method.GetCustomAttributes(typeof(LeapPreferences), inherit: true);
+          if (attributes.Length == 0) {
+            continue;
+          }
+
+          var attribute = attributes[0] as LeapPreferences;
+          _leapPreferenceItems.Add(new LeapPreferenceItem() {
+            drawPreferenceGui = () => {
+              EditorGUILayout.LabelField(attribute.header, EditorStyles.whiteLargeLabel);
+              method.Invoke(null, null);
+              EditorGUILayout.Space();
+              EditorGUILayout.Space();
+              EditorGUILayout.Space();
+            },
+            attribute = attribute
+          });
+        }
+      }
+
+      _leapPreferenceItems.Sort((a, b) => a.attribute.order.CompareTo(b.attribute.order));
+    }
+
+    [PreferenceItem("Leap Motion")]
+    private static void preferenceMenu() {
+      ensurePreferenceItemsLoaded();
+
+      foreach (var item in _leapPreferenceItems) {
+        item.drawPreferenceGui();
+      }
+    }
+  }
+}

--- a/Assets/LeapMotion/Core/Scripts/LeapPreferences.cs
+++ b/Assets/LeapMotion/Core/Scripts/LeapPreferences.cs
@@ -30,6 +30,7 @@ namespace Leap.Unity {
       this.order = order;
     }
 
+#if UNITY_EDITOR
     private static List<LeapPreferenceItem> _leapPreferenceItems = null;
 
     private struct LeapPreferenceItem {
@@ -77,5 +78,6 @@ namespace Leap.Unity {
         item.drawPreferenceGui();
       }
     }
+#endif
   }
 }

--- a/Assets/LeapMotion/Core/Scripts/LeapPreferences.cs.meta
+++ b/Assets/LeapMotion/Core/Scripts/LeapPreferences.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: cd43137876cee8047a74a63a15fce7e9
+timeCreated: 1498008374
+licenseType: Pro
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/Editor/LeapGraphicPreferences.cs
+++ b/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/Editor/LeapGraphicPreferences.cs
@@ -63,7 +63,7 @@ namespace Leap.Unity.GraphicalRenderer {
         EditorPrefs.SetBool(PROMP_WHEN_ADD_CUSTOM_CHANNEL_LEY, value);
       }
     }
-    
+
     [LeapPreferences("Graphic Renderer", 20)]
     private static void preferencesGUI() {
       drawGraphicMaxField();

--- a/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/Editor/LeapGraphicPreferences.cs
+++ b/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/Editor/LeapGraphicPreferences.cs
@@ -63,8 +63,8 @@ namespace Leap.Unity.GraphicalRenderer {
         EditorPrefs.SetBool(PROMP_WHEN_ADD_CUSTOM_CHANNEL_LEY, value);
       }
     }
-
-    [PreferenceItem("Leap Graphics")]
+    
+    [LeapPreferences("Graphic Renderer", 20)]
     private static void preferencesGUI() {
       drawGraphicMaxField();
 

--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/Internal/InteractionPreferences.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/Internal/InteractionPreferences.cs
@@ -44,7 +44,7 @@ namespace Leap.Unity.Interaction.Internal {
       }
     }
 
-    [PreferenceItem("Leap Interaction")]
+    [LeapPreferences("Interaction Engine", 10)]
     private static void preferencesGUI() {
       bool newGravityValue = EditorGUILayout.Toggle(_gravityPrompContent, shouldPrompForGravity);
       if (newGravityValue != shouldPrompForGravity) {


### PR DESCRIPTION
Currently the interaction engine and the graphic renderer both have project settings underneath their own tab when you visit the Preferences window.  This PR unifies all preferences underneath the same Leap Motion preferences tab to reduce clutter and to allow us to give better names.  

This new menu automatically scans the project for qualifying methods and adds them to the preferences window automatically, this ensures that the single preferences tab grows to accommodate installed modules.  The existing preferences have been updated to use this new system.

To test:
 - [ ] Verify that the new tab still shows all the same preferences and that they all work properly.
 - [ ] Verify it is possible to create new preference areas using the attribute.