### PR TITLE
Added a checkbox to manually force custom updates

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/VR/Editor/LeapTemporalWarpingEditor.cs
+++ b/Assets/LeapMotion/Core/Scripts/VR/Editor/LeapTemporalWarpingEditor.cs
@@ -28,7 +28,7 @@ namespace Leap.Unity {
 
     private void warningDecorator(SerializedProperty prop) {
       if (!PlayerSettings.virtualRealitySupported) {
-        EditorGUILayout.HelpBox("Unity VR Disabled.  ManualyUpdateTemporalWarping must be called right after " +
+        EditorGUILayout.HelpBox("Unity VR Disabled.  ManuallyUpdateTemporalWarping must be called right after " +
                                 "the Head transform has been updated.", MessageType.Warning);
       }
     }

--- a/Assets/LeapMotion/Core/Scripts/VR/LeapVRTemporalWarping.cs
+++ b/Assets/LeapMotion/Core/Scripts/VR/LeapVRTemporalWarping.cs
@@ -54,7 +54,7 @@ namespace Leap.Unity {
         };
       }
     }
-    
+
     [SerializeField]
     private LeapServiceProvider provider;
 
@@ -89,6 +89,12 @@ namespace Leap.Unity {
     [Tooltip("Controls when this script synchronizes the time warp of images.  Use LowLatency for VR, and SyncWithImages for AR.")]
     [SerializeField]
     private SyncMode syncMode = SyncMode.LOW_LATENCY;
+
+    [Header("Advanced")]
+    [Tooltip("Forces an update of the temporal warping to happen in Late Update using the existing head transform.  Should not be enabled if you " +
+             "are using the default Unity VR integration!")]
+    [SerializeField]
+    private bool forceCustomUpdate = false;
 
     // Manual Time Alignment
     [Tooltip("Allow manual adjustment of the rewind time.")]
@@ -165,7 +171,7 @@ namespace Leap.Unity {
         return false;
       }
 
-      TransformData past = transformAtTime((leapTime - warpingAdjustment * 1000) + (syncMode == SyncMode.SYNC_WITH_IMAGES?20000:0));
+      TransformData past = transformAtTime((leapTime - warpingAdjustment * 1000) + (syncMode == SyncMode.SYNC_WITH_IMAGES ? 20000 : 0));
 
       // Rewind position and rotation
       if (_trackingAnchor == null) {
@@ -207,7 +213,7 @@ namespace Leap.Unity {
     /// Use this method when not using Unity default VR integration.  This method should be called directly after
     /// the head transform has been updated using your input tracking solution.
     /// </summary>
-    public void ManualyUpdateTemporalWarping() {
+    public void ManuallyUpdateTemporalWarping() {
       if (_trackingAnchor == null) {
         updateHistory(_headTransform.position, _headTransform.rotation);
         updateTemporalWarping(_headTransform.position, _headTransform.rotation);
@@ -315,7 +321,9 @@ namespace Leap.Unity {
     }
 
     protected void LateUpdate() {
-      if (VRSettings.enabled) {
+      if (forceCustomUpdate) {
+        ManuallyUpdateTemporalWarping();
+      } else if (VRSettings.enabled) {
         updateTemporalWarping(InputTracking.GetLocalPosition(VRNode.CenterEye),
                               InputTracking.GetLocalRotation(VRNode.CenterEye));
       }

--- a/Assets/LeapMotion/Core/Scripts/VR/LeapVRTemporalWarping.cs.meta
+++ b/Assets/LeapMotion/Core/Scripts/VR/LeapVRTemporalWarping.cs.meta
@@ -1,11 +1,11 @@
 fileFormatVersion: 2
 guid: e21f7214440054f59a5d2da168b3e2dd
-timeCreated: 1431469572
-licenseType: Pro
+timeCreated: 1498147994
+licenseType: Free
 MonoImporter:
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: 1000
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 


### PR DESCRIPTION
Adds a checkbox that manually forces the temporal warping script to trigger manual updates in Late Update.  This is to try to handle the general case when someone is using a vr tracking solution that is not the integrated unity VR solution.  They should be able to check the checkbox, and as long as they update the transform of the head before late update, everything should be good.