### PR TITLE
Fixed multi-edit for single layer editor

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/Utils/Editor/SingleLayerEditor.cs
+++ b/Assets/LeapMotion/Core/Scripts/Utils/Editor/SingleLayerEditor.cs
@@ -50,8 +50,18 @@ namespace Leap.Unity {
         label.tooltip = tooltipAttribute.tooltip;
       }
 
+      bool originalMixedValue = EditorGUI.showMixedValue;
+      if (layerProperty.hasMultipleDifferentValues) {
+        EditorGUI.showMixedValue = true;
+      }
+
+      EditorGUI.BeginChangeCheck();
       index = EditorGUI.Popup(position, label, index, _layerNames);
-      layerProperty.intValue = _layerValues[index];
+      if (EditorGUI.EndChangeCheck()) {
+        layerProperty.intValue = _layerValues[index];
+      }
+
+      EditorGUI.showMixedValue = originalMixedValue;
     }
 
     private void ensureLayersInitialized() {


### PR DESCRIPTION
Make sure to support the case where the serialized property has more than one value.  Before this update selecting multiple components of the same type would result in all single layer properties collapsing into a single value.

To test:
 - [ ] Make sure the layer exhibits proper behavior in multi-edit situations