### PR TITLE
Fix bug where rebuild of atlas was not handled

### DIFF
--- a/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/RenderingMethods/LeapTextRenderer.cs
+++ b/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/RenderingMethods/LeapTextRenderer.cs
@@ -79,7 +79,10 @@ namespace Leap.Unity.GraphicalRenderer {
     public override void OnUpdateRenderer() {
       for (int i = 0; i < group.graphics.Count; i++) {
         var graphic = group.graphics[i] as LeapTextGraphic;
-        prepareFontWithGraphic(graphic);
+
+        if (graphic.isRepresentationDirtyOrEditTime) {
+          prepareFontWithGraphic(graphic);
+        }
       }
 
       for (int i = 0; i < group.graphics.Count; i++) {


### PR DESCRIPTION
Fixed #760

Now, whenever a rebuild of a font happens due to a change in a text graphic, it will mark _all_ graphics as dirty and rebuild them all.  This prevents the weird corruption that can happen as you change text at runtime.

To test:
 - [ ] Make sure that text still works
 - [ ] Verify that adding a whole bunch of new text at runtime doesn't break existing text.  Helps to have a lot of different sizes to trigger a rebuild.