### PR TITLE
Adding a string overload of SetRuntimeTint

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/Utils/Utils.cs
+++ b/Assets/LeapMotion/Core/Scripts/Utils/Utils.cs
@@ -495,8 +495,7 @@ namespace Leap.Unity {
             colliders.Add(collider);
           }
         }
-      }
-      finally {
+      } finally {
         toVisit.Clear();
         Pool<Stack<Transform>>.Recycle(toVisit);
 
@@ -511,6 +510,24 @@ namespace Leap.Unity {
 
     public static Color WithAlpha(this Color color, float alpha) {
       return new Color(color.r, color.g, color.b, alpha);
+    }
+
+    /// <summary>
+    /// Just like ColorUtility.TryParseHtmlString but throws a useful
+    /// error message if it fails.
+    /// </summary>
+    public static Color ParseHtmlColorString(string htmlString) {
+      Color color;
+      if (!ColorUtility.TryParseHtmlString(htmlString, out color)) {
+        throw new ArgumentException("The string [" + htmlString + "] is not a valid color code.  Valid color codes include:\n" +
+                                    "#RGB\n" +
+                                    "#RGBA\n" +
+                                    "#RRGGBB\n" +
+                                    "#RRGGBBAA\n" +
+                                    "For more information, see the documentation for ColorUtility.TryParseHtmlString.");
+      }
+
+      return color;
     }
 
     #endregion

--- a/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/Features/Tint/LeapRuntimeTintData.cs
+++ b/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/Features/Tint/LeapRuntimeTintData.cs
@@ -25,6 +25,16 @@ namespace Leap.Unity.GraphicalRenderer {
     }
 
     /// <summary>
+    /// Overload of SetRuntimeTint that takes in a Html style string
+    /// code that represents a color.  Any string that can be parsed
+    /// by ColorUtility.TryParseHtmlString can be used as an argument
+    /// to this method.
+    /// </summary>
+    public void SetRuntimeTint(string htmlString) {
+      SetRuntimeTint(Utils.ParseHtmlColorString(htmlString));
+    }
+
+    /// <summary>
     /// Helper method to get the runtime tint color for a runtime 
     /// tint data object attached to this graphic.  This method will
     /// throw an exception if there is no tint data obj attached to 


### PR DESCRIPTION
UnityEvents are unable to use color as an argument in any way, which really sucks.  This is a workaround that allows you to specify the hex code of the color as a string instead.  You can also use strings like 'blue', or 'white', or anything supported by [ColorUtility](https://docs.unity3d.com/ScriptReference/ColorUtility.TryParseHtmlString.html)

To test:
 - [ ] Verify it works, but throws a useful error message if you provide an invalid code.