### PR TITLE
Improve panels and rect transform default

### DIFF
--- a/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/Graphics/ProceduralMeshGraphics/LeapPanelGraphic.cs
+++ b/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/Graphics/ProceduralMeshGraphics/LeapPanelGraphic.cs
@@ -156,7 +156,9 @@ namespace Leap.Unity.GraphicalRenderer {
       }
     }
 
-    private void Reset() {
+    protected override void Reset() {
+      base.Reset();
+
       assignDefaultSourceValue();
       setSourceFeatureDirty();
     }
@@ -186,11 +188,6 @@ namespace Leap.Unity.GraphicalRenderer {
     public override void RefreshMeshData() {
       if (sourceData == null) {
         assignDefaultSourceValue();
-      }
-
-      //No valid source was found :(
-      if (_sourceDataIndex == -1) {
-        return;
       }
 
       Vector4 borderSize = Vector4.zero;

--- a/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/LeapGraphic.cs
+++ b/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/LeapGraphic.cs
@@ -303,6 +303,15 @@ namespace Leap.Unity.GraphicalRenderer {
     #endregion
 
     #region UNITY CALLBACKS
+    protected virtual void Reset() {
+      var rectTransform = GetComponent<RectTransform>();
+      if (rectTransform != null &&
+          Mathf.Abs(rectTransform.sizeDelta.x - 100) < Mathf.Epsilon &&
+          Mathf.Abs(rectTransform.sizeDelta.y - 100) < Mathf.Epsilon) {
+        rectTransform.sizeDelta = Vector3.one * 0.1f;
+      }
+    }
+
     protected virtual void OnValidate() {
 #if UNITY_EDITOR
       editor.OnValidate();


### PR DESCRIPTION
Now whenever a graphic is added to a rect transform, and that rect transform has the default size, it is changed to instead have a size of 0.1, 0.1, which is a much more reasonable size for things that the graphic renderer is used for.

Also, the panel graphic was refusing to generate mesh data whenever there was not a texture source, but that actually had no reasoning behind it, it is perfectly capable of generating a mesh without a texture source, so that restriction has been removed.