### PR TITLE
changed expected deviceString in Oculus Interaction Controller prefabs

### DIFF
--- a/Assets/LeapMotion/Modules/InteractionEngine/Prefabs/Interaction Controllers/VR Oculus-style Controller (Left).prefab
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Prefabs/Interaction Controllers/VR Oculus-style Controller (Left).prefab
@@ -443,7 +443,7 @@ MonoBehaviour:
   _contactEnabled: 1
   _graspingEnabled: 1
   _trackingProviderType: Leap.Unity.Interaction.DefaultVRNodeTrackingProvider
-  _deviceString: oculus touch left
+  _deviceString: oculus touch controller - left
   _chirality: 0
   _hoverPoint: {fileID: 4560782703005532}
   primaryHoverPoints:

--- a/Assets/LeapMotion/Modules/InteractionEngine/Prefabs/Interaction Controllers/VR Oculus-style Controller (Right).prefab
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Prefabs/Interaction Controllers/VR Oculus-style Controller (Right).prefab
@@ -447,6 +447,7 @@ MonoBehaviour:
   _contactEnabled: 1
   _graspingEnabled: 1
   _trackingProviderType: Leap.Unity.Interaction.DefaultVRNodeTrackingProvider
+  _deviceString: oculus touch controller - right
   _chirality: 1
   _hoverPoint: {fileID: 4806976238791452}
   primaryHoverPoints:

--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionVRController.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionVRController.cs
@@ -39,7 +39,7 @@ namespace Leap.Unity.Interaction {
     [Tooltip("If this string is non-empty, but does not match a controller in Input.GetJoystickNames()"
        + ", then this game object will disable itself.")]
     [SerializeField, EditTimeOnly]
-    private string _deviceString = "oculus touch right"; //or "openvr controller right/left"
+    private string _deviceString = "oculus touch controller - right"; //or "openvr controller right/left"
     public string deviceString { get { return _deviceString; } }
 
     [Tooltip("Which hand will hold this controller? This property cannot be changed "


### PR DESCRIPTION
The device strings that Unity's Input.GetJoystickNames() reports for the Oculus Touch Controllers for me are "oculus touch controller - left" and "oculus touch controller - right"

I'm on Unity 5.6.1f1 with Oculus 1.16. If it worked for you before, I suppose this is a change that was introduced by an update to either Unity/OVRPlugin or the Oculus Runtime.
You should probably still confirm that different machines/configurations don't report different strings, although that would be kind of odd.