### PR TITLE
Make graphics prefer same group

### DIFF
--- a/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/LeapGraphic.cs
+++ b/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/LeapGraphic.cs
@@ -321,7 +321,12 @@ namespace Leap.Unity.GraphicalRenderer {
 
     protected virtual void Awake() {
       if (isAttachedToGroup && !attachedGroup.graphics.Contains(this)) {
+        var preferredGroup = attachedGroup;
         OnDetachedFromGroup();
+
+        //If this fails for any reason don't worry, we will be auto-added
+        //to a group if we can.
+        preferredGroup.TryAddGraphic(this);
       }
     }
 


### PR DESCRIPTION
When they are duplicated or copy/pasted graphics will now automatically try to re-add themselves back to the same group they came from instead of waiting for an auto-assignment