### PR TITLE
Removed weird code that reset the hands rotations

### DIFF
--- a/Assets/LeapMotion/Modules/Playback/Scripts/PlaybackProvider.cs
+++ b/Assets/LeapMotion/Modules/Playback/Scripts/PlaybackProvider.cs
@@ -91,11 +91,6 @@ namespace Leap.Unity.Playback {
 
       _currentFrameIndex = newFrameIndex;
 
-      var f = _recording.frames[_currentFrameIndex];
-      foreach(var hand in f.Hands) {
-        hand.Rotation = LeapQuaternion.Identity;
-      }
-
       _transformedFrame.CopyFrom(_recording.frames[_currentFrameIndex]).Transform(new LeapTransform(transform.position.ToVector(), transform.rotation.ToLeapQuaternion(), transform.lossyScale.ToVector()));
     }
 


### PR DESCRIPTION
This was added way back when for a reason that I don't remember.  Probably had to do with LeapC not supporting rotations at some point.