### PR TITLE
Fix attachment bug in GR

### DIFF
--- a/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/EditTimeApis/LeapGraphicGroupEditorApi.cs
+++ b/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/EditTimeApis/LeapGraphicGroupEditorApi.cs
@@ -199,7 +199,7 @@ namespace Leap.Unity.GraphicalRenderer {
         }
 
         for (int i = _group._graphics.Count; i-- != 0;) {
-          if (_group._graphics[i] == null) {
+          if (_group._graphics[i] == null || _group.graphics[i].attachedGroup != _group) {
             _group._graphics.RemoveAt(i);
             continue;
           }


### PR DESCRIPTION
Make sure that when we validate the graphic integrity that we also check for the case where a graphic is attached to more than one group at a time.