### PR TITLE
Bugfixes for graphic renderer

### DIFF
--- a/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/Features/BlendShape/LeapBlendShapeData.cs
+++ b/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/Features/BlendShape/LeapBlendShapeData.cs
@@ -82,15 +82,21 @@ namespace Leap.Unity.GraphicalRenderer {
       }
     }
 
+    /// <summary>
+    /// Returns the blended vertices based on the current mesh 
+    /// this blend shape is attached to.  If you want to ensure
+    /// this blend shape data is up-to-date, make sure to call
+    /// RefreshMeshData on the graphic itself first.
+    /// </summary>
     public bool TryGetBlendShape(List<Vector3> blendVerts) {
       if (!(graphic is LeapMeshGraphicBase)) {
         return false;
       }
 
       var meshGraphic = graphic as LeapMeshGraphicBase;
-      meshGraphic.RefreshMeshData();
 
       var mesh = meshGraphic.mesh;
+
       if (mesh == null) {
         return false;
       }

--- a/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/LeapGraphicFeature.cs
+++ b/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/LeapGraphicFeature.cs
@@ -88,7 +88,9 @@ namespace Leap.Unity.GraphicalRenderer {
     }
 
     public override LeapFeatureData CreateFeatureDataForGraphic(LeapGraphic graphic) {
-      return new DataType();
+      DataType data = new DataType();
+      data.graphic = graphic;
+      return data;
     }
   }
 

--- a/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/LeapGraphicGroup.cs
+++ b/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/LeapGraphicGroup.cs
@@ -500,17 +500,6 @@ namespace Leap.Unity.GraphicalRenderer {
             canAttach = attachEnum.MoveNext();
           }
 
-          //TODO: this is gonna need to be optimized
-          //Make sure to call this before OnAttachedToGroup or else the graphic
-          //will not have the correct feature data when it gets attached!
-          RebuildFeatureData();
-          RebuildFeatureSupportInfo();
-
-          for (int i = newGraphicStart; i < _graphics.Count; i++) {
-            var anchor = _renderer.space == null ? null : LeapSpaceAnchor.GetAnchor(attachEnum.Current.transform);
-            _graphics[i].OnAttachedToGroup(this, anchor);
-          }
-
           //We remove any graphics that did not have a matching add.  This 
           //only happens if more graphics were removed than were added this
           //frame.
@@ -523,6 +512,20 @@ namespace Leap.Unity.GraphicalRenderer {
             detachEnum.Current.OnDetachedFromGroup();
 
             canDetach = detachEnum.MoveNext();
+          }
+
+          //TODO: this is gonna need to be optimized
+          //Make sure to call this before OnAttachedToGroup or else the graphic
+          //will not have the correct feature data when it gets attached!
+          RebuildFeatureData();
+          RebuildFeatureSupportInfo();
+
+          //newGraphicStart is either less than _graphics.Count because we added 
+          //new graphics, or it is greater than _graphics.Count because we removed
+          //some graphics.
+          for (int i = newGraphicStart; i < _graphics.Count; i++) {
+            var anchor = _renderer.space == null ? null : LeapSpaceAnchor.GetAnchor(attachEnum.Current.transform);
+            _graphics[i].OnAttachedToGroup(this, anchor);
           }
 
           attachEnum.Dispose();

--- a/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/RenderingMethods/LeapDynamicRenderer.cs
+++ b/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/RenderingMethods/LeapDynamicRenderer.cs
@@ -30,6 +30,8 @@ namespace Leap.Unity.GraphicalRenderer {
     #endregion
 
     public void OnAddRemoveGraphics(List<int> dirtyIndexes) {
+      MeshCache.Clear();
+
       while (_meshes.Count > group.graphics.Count) {
         _meshes.RemoveMesh(_meshes.Count - 1);
       }

--- a/Assets/LeapMotion/Modules/GraphicRenderer/Testing/Scripts/ReflectionExtensions.cs
+++ b/Assets/LeapMotion/Modules/GraphicRenderer/Testing/Scripts/ReflectionExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Leap.Unity.GraphicalRenderer.Tests {
+
+  public static class ReflectionExtensions {
+
+    public static object GetField<T>(this T t, string fieldName) {
+      return t.GetType().GetField(fieldName).GetValue(t);
+    }
+
+  }
+}

--- a/Assets/LeapMotion/Modules/GraphicRenderer/Testing/Scripts/ReflectionExtensions.cs.meta
+++ b/Assets/LeapMotion/Modules/GraphicRenderer/Testing/Scripts/ReflectionExtensions.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 2ea369784806bcd4e80b2e5db991a2c0
+timeCreated: 1500414812
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapMotion/Modules/GraphicRenderer/Testing/Scripts/Tests/TestAddRemove.cs
+++ b/Assets/LeapMotion/Modules/GraphicRenderer/Testing/Scripts/Tests/TestAddRemove.cs
@@ -307,6 +307,46 @@ namespace Leap.Unity.GraphicalRenderer.Tests {
 
       yield return null;
     }
+
+    [UnityTest]
+    public IEnumerator CanAddAndRemoveManyOnSameFrame([Values(true, false)] bool addMany) {
+      InitTest("OneEmptyDynamicGroupWith4Features");
+      yield return null;
+
+      var first = CreateGraphic("DisabledMeshGraphic");
+      var second = CreateGraphic("DisabledMeshGraphic");
+      var third = CreateGraphic("DisabledMeshGraphic");
+
+      if (addMany) {
+        firstGroup.TryAddGraphic(first);
+      } else {
+        firstGroup.TryAddGraphic(second);
+        firstGroup.TryAddGraphic(third);
+      }
+
+      yield return null;
+
+      if (addMany) {
+        firstGroup.TryAddGraphic(second);
+        firstGroup.TryAddGraphic(third);
+        first.TryDetach();
+      } else {
+        firstGroup.TryAddGraphic(first);
+        second.TryDetach();
+        third.TryDetach();
+      }
+
+      yield return null;
+
+      foreach (var feature in firstGroup.features) {
+        var featureData = feature.GetField("featureData") as IList;
+        Assert.That(featureData.Count, Is.EqualTo(firstGroup.graphics.Count));
+        for (int i = 0; i < featureData.Count; i++) {
+          LeapFeatureData data = featureData[i] as LeapFeatureData;
+          Assert.That(data.graphic, Is.EqualTo(firstGroup.graphics[i]));
+        }
+      }
+    }
   }
 }
 #endif

--- a/Assets/LeapMotion/Modules/GraphicRenderer/Testing/Scripts/Tests/TestAddRemove.cs
+++ b/Assets/LeapMotion/Modules/GraphicRenderer/Testing/Scripts/Tests/TestAddRemove.cs
@@ -308,6 +308,10 @@ namespace Leap.Unity.GraphicalRenderer.Tests {
       yield return null;
     }
 
+    /// <summary>
+    /// Verify behavior when we add/remove graphics on the same frame.  Validate both the
+    /// case where we add more than we remove, and when we remove more than we add.
+    /// </summary>
     [UnityTest]
     public IEnumerator CanAddAndRemoveManyOnSameFrame([Values(true, false)] bool addMany) {
       InitTest("OneEmptyDynamicGroupWith4Features");


### PR DESCRIPTION
 - Blend shape data no longer forces recalculation of the mesh in order to generate blend shapes
 - Dynamic renderer makes sure to clear the mesh cache before building mesh data
 - LeapGraphicGroup makes sure graphics list is completely correct before rebuilding feature data (introduced by #782)
 - Added tests to handle the above case