### PR TITLE
Adding AssetFolder Property

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/DataStructures/AssetFolder.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/AssetFolder.cs
@@ -1,4 +1,13 @@
-﻿using System;
+/******************************************************************************
+ * Copyright (C) Leap Motion, Inc. 2011-2017.                                 *
+ * Leap Motion proprietary and  confidential.                                 *
+ *                                                                            *
+ * Use subject to the terms of the Leap Motion SDK Agreement available at     *
+ * https://developer.leapmotion.com/sdk_agreement, or another agreement       *
+ * between Leap Motion and you, your company or other organization.           *
+ ******************************************************************************/
+
+using System;
 using UnityEngine;
 using UnityObject = UnityEngine.Object;
 #if UNITY_EDITOR

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/AssetFolder.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/AssetFolder.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using UnityEngine;
+using UnityObject = UnityEngine.Object;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+namespace Leap.Unity {
+
+  /// <summary>
+  /// A convenient serializable representation of an asset folder.
+  /// Only useful for editor scripts since asset folder structure
+  /// is not preserved for builds.  The asset folder struct itself is
+  /// still available at runtime for serialization ease, but the Path
+  /// property will not be available.
+  /// </summary>
+  [Serializable]
+  public struct AssetFolder {
+
+    [SerializeField]
+    private UnityObject _assetFolder;
+
+#if UNITY_EDITOR
+    /// <summary>
+    /// Gets or sets the folder path.  This path will always be a path
+    /// relative to the asset folder, and matches the format expected and
+    /// returned by AssetDatabase.
+    /// </summary>
+    public string Path {
+      get {
+        if (_assetFolder != null) {
+          return AssetDatabase.GetAssetPath(_assetFolder);
+        } else {
+          return null;
+        }
+      }
+      set {
+        _assetFolder = AssetDatabase.LoadAssetAtPath<DefaultAsset>(value);
+      }
+    }
+#endif
+  }
+}

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/AssetFolder.cs.meta
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/AssetFolder.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: ac1d9b7288d0c794f824f89bfad6a013
+timeCreated: 1501873455
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/Editor/AssetFolderPropertyDrawer.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/Editor/AssetFolderPropertyDrawer.cs
@@ -1,0 +1,50 @@
+﻿using UnityEngine;
+using UnityEditor;
+
+namespace Leap.Unity {
+
+  [CustomPropertyDrawer(typeof(AssetFolder))]
+  public class AssetFolderPropertyDrawer : PropertyDrawer {
+
+    public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
+      Rect left, right;
+      position.SplitHorizontallyWithRight(out left, out right, position.height);
+      left.width -= 2;
+
+      Object folderAsset = null;
+      string folderPath = "";
+
+      SerializedProperty folderProp = property.FindPropertyRelative("_assetFolder");
+      if (folderProp.hasMultipleDifferentValues) {
+        EditorGUI.showMixedValue = true;
+      } else {
+        folderAsset = folderProp.objectReferenceValue;
+        if (folderAsset != null) {
+          folderPath = AssetDatabase.GetAssetPath(folderAsset);
+        }
+      }
+
+      EditorGUI.TextField(left, label, folderPath);
+
+      var content = EditorGUIUtility.IconContent("Folder Icon");
+
+      if (GUI.Button(right, content, GUIStyle.none)) {
+        string resultPath = EditorUtility.OpenFolderPanel("Select Folder", folderPath, "");
+        if (!string.IsNullOrEmpty(resultPath)) {
+          string relativePath = Utils.MakeRelativePath(Application.dataPath, resultPath);
+          var asset = AssetDatabase.LoadAssetAtPath<DefaultAsset>(relativePath);
+
+          if (asset != null) {
+            folderProp.objectReferenceValue = asset;
+          }
+        }
+      }
+
+      EditorGUI.showMixedValue = false;
+    }
+
+    public override float GetPropertyHeight(SerializedProperty property, GUIContent label) {
+      return EditorGUIUtility.singleLineHeight;
+    }
+  }
+}

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/Editor/AssetFolderPropertyDrawer.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/Editor/AssetFolderPropertyDrawer.cs
@@ -1,5 +1,6 @@
 ﻿using UnityEngine;
 using UnityEditor;
+using Leap.Unity.Query;
 
 namespace Leap.Unity {
 
@@ -41,6 +42,21 @@ namespace Leap.Unity {
       }
 
       EditorGUI.showMixedValue = false;
+
+      if (position.Contains(Event.current.mousePosition)) {
+        var draggedFolder = DragAndDrop.objectReferences.Query().OfType<DefaultAsset>().FirstOrDefault();
+        if (draggedFolder != null) {
+          switch (Event.current.type) {
+            case EventType.DragUpdated:
+              DragAndDrop.visualMode = DragAndDropVisualMode.Link;
+              break;
+            case EventType.DragPerform:
+              DragAndDrop.AcceptDrag();
+              folderProp.objectReferenceValue = draggedFolder;
+              break;
+          }
+        }
+      }
     }
 
     public override float GetPropertyHeight(SerializedProperty property, GUIContent label) {

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/Editor/AssetFolderPropertyDrawer.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/Editor/AssetFolderPropertyDrawer.cs
@@ -1,4 +1,13 @@
-﻿using UnityEngine;
+/******************************************************************************
+ * Copyright (C) Leap Motion, Inc. 2011-2017.                                 *
+ * Leap Motion proprietary and  confidential.                                 *
+ *                                                                            *
+ * Use subject to the terms of the Leap Motion SDK Agreement available at     *
+ * https://developer.leapmotion.com/sdk_agreement, or another agreement       *
+ * between Leap Motion and you, your company or other organization.           *
+ ******************************************************************************/
+
+using UnityEngine;
 using UnityEditor;
 using Leap.Unity.Query;
 
@@ -37,6 +46,8 @@ namespace Leap.Unity {
 
           if (asset != null) {
             folderProp.objectReferenceValue = asset;
+          } else {
+            EditorUtility.DisplayDialog("Could not select folder!", "That folder is not an asset folder, make sure to select a folder that is located inside of the project Assets directory.", "ok");
           }
         }
       }

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/Editor/AssetFolderPropertyDrawer.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/Editor/AssetFolderPropertyDrawer.cs
@@ -47,7 +47,7 @@ namespace Leap.Unity {
           if (asset != null) {
             folderProp.objectReferenceValue = asset;
           } else {
-            EditorUtility.DisplayDialog("Could not select folder!", "That folder is not an asset folder, make sure to select a folder that is located inside of the project Assets directory.", "ok");
+            EditorUtility.DisplayDialog("Could not select folder.", "The specified folder is not an asset folder. Asset folders must be inside project's Assets directory.", "OK");
           }
         }
       }

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/Editor/AssetFolderPropertyDrawer.cs.meta
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/Editor/AssetFolderPropertyDrawer.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 17c14ee8f4ac2aa43912bf678dd28430
+timeCreated: 1501873546
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapMotion/Core/Scripts/Utils/Utils.cs
+++ b/Assets/LeapMotion/Core/Scripts/Utils/Utils.cs
@@ -10,6 +10,7 @@
 using UnityEngine;
 using UnityEngine.Assertions;
 using System;
+using System.IO;
 using System.Collections.Generic;
 using Leap.Unity.Query;
 
@@ -144,6 +145,25 @@ namespace Leap.Unity {
           return obj.parent.IsActiveRelativeToParent(parent);
         }
       }
+    }
+
+    public static string MakeRelativePath(string relativeTo, string path) {
+      if (string.IsNullOrEmpty(relativeTo)) throw new ArgumentNullException("relativeTo");
+      if (string.IsNullOrEmpty(path)) throw new ArgumentNullException("path");
+
+      Uri relativeToUri = new Uri(relativeTo);
+      Uri pathUri = new Uri(path);
+
+      if (relativeToUri.Scheme != pathUri.Scheme) { return path; } // path can't be made relative.
+
+      Uri relativeUri = relativeToUri.MakeRelativeUri(pathUri);
+      string relativePath = Uri.UnescapeDataString(relativeUri.ToString());
+
+      if (pathUri.Scheme.Equals("file", StringComparison.InvariantCultureIgnoreCase)) {
+        relativePath = relativePath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+      }
+
+      return relativePath;
     }
 
     #endregion

--- a/Assets/LeapMotion/Modules/Package/Editor/PackageDefinitionEditor.cs
+++ b/Assets/LeapMotion/Modules/Package/Editor/PackageDefinitionEditor.cs
@@ -185,7 +185,7 @@ namespace Leap.Unity.Packaging {
       if (GUI.Button(right, "Change")) {
         string chosenFolder = openAction("Select Folder", Application.dataPath, "");
         if (!string.IsNullOrEmpty(chosenFolder)) {
-          string relativePath = makeRelativePath(Application.dataPath, chosenFolder);
+          string relativePath = Utils.MakeRelativePath(Application.dataPath, chosenFolder);
           if (!string.IsNullOrEmpty(relativePath) && !relativePath.StartsWith("..")) {
             if (relativePath != property.stringValue) {
               property.stringValue = relativePath;
@@ -193,25 +193,6 @@ namespace Leap.Unity.Packaging {
           }
         }
       }
-    }
-
-    private static string makeRelativePath(string fromPath, string toPath) {
-      if (string.IsNullOrEmpty(fromPath)) throw new ArgumentNullException("fromPath");
-      if (string.IsNullOrEmpty(toPath)) throw new ArgumentNullException("toPath");
-
-      Uri fromUri = new Uri(fromPath);
-      Uri toUri = new Uri(toPath);
-
-      if (fromUri.Scheme != toUri.Scheme) { return toPath; } // path can't be made relative.
-
-      Uri relativeUri = fromUri.MakeRelativeUri(toUri);
-      string relativePath = Uri.UnescapeDataString(relativeUri.ToString());
-
-      if (toUri.Scheme.Equals("file", StringComparison.InvariantCultureIgnoreCase)) {
-        relativePath = relativePath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
-      }
-
-      return relativePath;
     }
 
     private void generateBuildMenuScript() {

--- a/Assets/LeapMotion/Testing/Scripts/EnableLeapTests.cs
+++ b/Assets/LeapMotion/Testing/Scripts/EnableLeapTests.cs
@@ -10,7 +10,9 @@
 using System;
 using System.Linq;
 using System.Reflection;
+#if UNITY_EDITOR
 using UnityEditor;
+#endif
 
 namespace Leap.Unity.Testing {
 
@@ -19,6 +21,7 @@ namespace Leap.Unity.Testing {
 
   public static class EnableLeapTests {
 
+#if UNITY_EDITOR
     [MenuItem("Assets/Enable Leap Tests")]
     public static void enableTests() {
       var assemblies = AppDomain.CurrentDomain.GetAssemblies();
@@ -36,5 +39,6 @@ namespace Leap.Unity.Testing {
       string defines = PlayerSettings.GetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup);
       PlayerSettings.SetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup, defines + " LEAP_TESTS");
     }
+#endif
   }
 }


### PR DESCRIPTION
Adding a new property type named AssetFolder.  It allows you to easily serialized references to folders that persist event when the folder is renamed or moved.  It is an editor-only feature since folder structure doesn't really exist at runtime.  The property provides:
 - Access to get/set of the folder path
 - Ability to use the folder dialog to set the folder
 - Ability to drag/drop a folder into the property inspector

This also moves the relative path code into Utils where it belongs instead of the package management code.

To test:
 - [ ] Verify that you can create a script that can serialize an AssetFolder property
 - [ ] Verify that the inspector gui for the AssetFolder behaves correctly