### PR TITLE
Pulling small changes from particles

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/Query/DirectQueryExtensions.cs
+++ b/Assets/LeapMotion/Core/Scripts/Query/DirectQueryExtensions.cs
@@ -1,0 +1,37 @@
+﻿using System;
+
+namespace Leap.Unity.Query {
+
+  /// <summary>
+  /// Class for extension methods that operate on query wrapper objects.  These 
+  /// methods are located in an extension method because they impose additional 
+  /// constrains on the general parameters of the query, and so cannot live inside
+  /// of the partial class of QueryWrapper.
+  /// </summary>
+  public static class DirectQueryExtensions {
+
+    public static QueryType Min<QueryType, QueryOp>(this QueryWrapper<QueryType, QueryOp> wrapper)
+      where QueryType : IComparable<QueryType>
+      where QueryOp : IQueryOp<QueryType> {
+      return wrapper.Fold((a, b) => a.CompareTo(b) < 0 ? a : b);
+    }
+
+    public static T Min<QueryType, QueryOp, T>(this QueryWrapper<QueryType, QueryOp> wrapper, Func<QueryType, T> selector)
+      where T : IComparable<T>
+      where QueryOp : IQueryOp<QueryType> {
+      return wrapper.Select(selector).Fold((a, b) => a.CompareTo(b) < 0 ? a : b);
+    }
+
+    public static QueryType Max<QueryType, QueryOp>(this QueryWrapper<QueryType, QueryOp> wrapper)
+      where QueryType : IComparable<QueryType>
+      where QueryOp : IQueryOp<QueryType> {
+      return wrapper.Fold((a, b) => a.CompareTo(b) > 0 ? a : b);
+    }
+
+    public static T Max<QueryType, QueryOp, T>(this QueryWrapper<QueryType, QueryOp> wrapper, Func<QueryType, T> selector)
+      where T : IComparable<T>
+      where QueryOp : IQueryOp<QueryType> {
+      return wrapper.Select(selector).Fold((a, b) => a.CompareTo(b) > 0 ? a : b);
+    }
+  }
+}

--- a/Assets/LeapMotion/Core/Scripts/Query/DirectQueryExtensions.cs.meta
+++ b/Assets/LeapMotion/Core/Scripts/Query/DirectQueryExtensions.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: ab1b122103ed58d44b6efb89a24a44d7
+timeCreated: 1500404887
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapMotion/Core/Scripts/Query/DirectQueryOps.cs
+++ b/Assets/LeapMotion/Core/Scripts/Query/DirectQueryOps.cs
@@ -113,6 +113,38 @@ namespace Leap.Unity.Query {
     }
 
     /// <summary>
+    /// Counts the number of distinct elements in the sequence.
+    /// </summary>
+    public int CountUnique() {
+      int unique = 0;
+      var set = Pool<HashSet<QueryType>>.Spawn();
+      try {
+        var op = _op;
+
+        QueryType t;
+        while (op.TryGetNext(out t)) {
+          if (!set.Contains(t)) {
+            unique++;
+            set.Add(t);
+          }
+        }
+      } finally {
+        set.Clear();
+        Pool<HashSet<QueryType>>.Recycle(set);
+      }
+
+      return unique;
+    }
+
+    /// <summary>
+    /// Returns the number of distinct elements in the sequence once it has been mapped
+    /// using a selector function.
+    /// </summary>
+    public int CountUnique<T>(Func<QueryType, T> mapping) {
+      return Select(t => mapping(t)).CountUnique();
+    }
+
+    /// <summary>
     /// Returns the element at a specific index in the sequence.  Will throw an error
     /// if the sequence has no element at that index.
     /// </summary>

--- a/Assets/LeapMotion/Core/Scripts/Query/QueryWrapper.cs
+++ b/Assets/LeapMotion/Core/Scripts/Query/QueryWrapper.cs
@@ -7,6 +7,8 @@
  * between Leap Motion and you, your company or other organization.           *
  ******************************************************************************/
 
+using System;
+using System.Collections;
 using System.Collections.Generic;
 
 namespace Leap.Unity.Query {
@@ -55,7 +57,7 @@ namespace Leap.Unity.Query {
       return new Enumerator(_op);
     }
 
-    public struct Enumerator {
+    public struct Enumerator : IEnumerator<QueryType> {
       private QueryOp _op;
       private QueryType _current;
 
@@ -68,9 +70,24 @@ namespace Leap.Unity.Query {
         return _op.TryGetNext(out _current);
       }
 
+      public void Reset() {
+        _op.Reset();
+        _current = default(QueryType);
+      }
+
+      public void Dispose() {
+        _op.Reset();
+      }
+
       public QueryType Current {
         get {
           return _current;
+        }
+      }
+
+      object IEnumerator.Current {
+        get {
+          throw new NotImplementedException();
         }
       }
     }
@@ -213,8 +230,7 @@ namespace Leap.Unity.Query {
         if (_index >= _list.Count) {
           t = default(T);
           return false;
-        }
-        else {
+        } else {
           t = _list[_index++];
           return true;
         }

--- a/Assets/LeapMotion/Core/Scripts/Utils/Utils.cs
+++ b/Assets/LeapMotion/Core/Scripts/Utils/Utils.cs
@@ -155,6 +155,11 @@ namespace Leap.Unity {
       }
     }
 
+    /// <summary>
+    /// Given a list of comparable types, return an ordering that orders the
+    /// elements into sorted order.  The ordering is a list of indices where each
+    /// index refers to the element located at that index in the original list.
+    /// </summary>
     public static List<int> GetSortedOrder<T>(this IList<T> list) where T : IComparable<T> {
       Assert.IsNotNull(list);
 
@@ -168,6 +173,10 @@ namespace Leap.Unity {
       return ordering;
     }
 
+    /// <summary>
+    /// Given a list and an ordering, order the list according to the ordering.
+    /// This method assumes the ordering is a valid ordering.
+    /// </summary>
     public static void ApplyOrdering<T>(this IList<T> list, List<int> ordering) {
       Assert.IsNotNull(list);
       Assert.IsNotNull(ordering);

--- a/Assets/LeapMotion/Core/Scripts/Utils/Utils.cs
+++ b/Assets/LeapMotion/Core/Scripts/Utils/Utils.cs
@@ -12,7 +12,6 @@ using UnityEngine.Assertions;
 using System;
 using System.IO;
 using System.Collections.Generic;
-using Leap.Unity.Query;
 
 namespace Leap.Unity {
 
@@ -33,7 +32,7 @@ namespace Leap.Unity {
     /// <summary>
     /// Utility extension to swap the elements at index a and index b.
     /// </summary>
-    public static void Swap<T>(this List<T> list, int a, int b) {
+    public static void Swap<T>(this IList<T> list, int a, int b) {
       T temp = list[a];
       list[a] = list[b];
       list[b] = temp;
@@ -56,6 +55,15 @@ namespace Leap.Unity {
       int j = array.Length;
       while (i < mid) {
         array.Swap(i++, --j);
+      }
+    }
+
+    /// <summary>
+    /// Shuffle the given list into a different permutation.
+    /// </summary>
+    public static void Shuffle<T>(this IList<T> list) {
+      for (int i = 0; i < list.Count; i++) {
+        Utils.Swap(list, i, UnityEngine.Random.Range(0, list.Count));
       }
     }
 
@@ -144,6 +152,36 @@ namespace Leap.Unity {
         } else {
           return obj.parent.IsActiveRelativeToParent(parent);
         }
+      }
+    }
+
+    public static List<int> GetSortedOrder<T>(this IList<T> list) where T : IComparable<T> {
+      Assert.IsNotNull(list);
+
+      List<int> ordering = new List<int>();
+      for (int i = 0; i < list.Count; i++) {
+        ordering.Add(i);
+      }
+
+      ordering.Sort((a, b) => list[a].CompareTo(list[b]));
+
+      return ordering;
+    }
+
+    public static void ApplyOrdering<T>(this IList<T> list, List<int> ordering) {
+      Assert.IsNotNull(list);
+      Assert.IsNotNull(ordering);
+      Assert.AreEqual(list.Count, ordering.Count, "List must be the same length as the ordering.");
+
+      List<T> copy = Pool<List<T>>.Spawn();
+      try {
+        copy.AddRange(list);
+        for (int i = 0; i < list.Count; i++) {
+          list[i] = copy[ordering[i]];
+        }
+      } finally {
+        copy.Clear();
+        Pool<List<T>>.Recycle(copy);
       }
     }
 
@@ -417,10 +455,10 @@ namespace Leap.Unity {
     /// <summary>
     /// Similar to Unity's Transform.LookAt(), but resolves the forward vector of this
     /// Transform to point away from the argument Transform.
-    ///
+    /// 
     /// Useful for billboarding Quads and UI elements whose forward vectors should match
     /// rather than oppose the Main Camera's forward vector.
-    ///
+    /// 
     /// Optionally, you may also pass an upwards vector, which will be provided to the underlying
     /// Quaternion.LookRotation. Vector3.up will be used by default.
     /// </summary>
@@ -431,7 +469,7 @@ namespace Leap.Unity {
     /// <summary>
     /// Similar to Unity's Transform.LookAt(), but resolves the forward vector of this
     /// Transform to point away from the argument Transform.
-    ///
+    /// 
     /// Allows specifying an upwards parameter; this is passed as the upwards vector to the Quaternion.LookRotation.
     /// </summary>
     /// <param name="thisTransform"></param>
@@ -596,7 +634,7 @@ namespace Leap.Unity {
       DrawArc(360, center, planeA, normal, radius, color, quality);
     }
 
-    /* Adapted from: Zarrax (http://math.stackexchange.com/users/3035/zarrax), Parametric Equation of a Circle in 3D Space?,
+    /* Adapted from: Zarrax (http://math.stackexchange.com/users/3035/zarrax), Parametric Equation of a Circle in 3D Space?, 
      * URL (version: 2014-09-09): http://math.stackexchange.com/q/73242 */
     public static void DrawArc(float arc,
                            Vector3 center,


### PR DESCRIPTION
Making sure that UnityModules continues to be a superset of the particles repo.  Pulling over some minor utility functions that were added:
 - [x] Min/Max extension methods to automatically fold over comparable types.
 - [x] CountUnique query operation to count the number of distinct elements.
 - [x] Make query enumerators actually implement the IEnumerable interface
 - [x] Made Utils.Swap use IList instead of List.
 - [x] Added Utils.Shuffle to shuffle a list into a random permutation.
 - [x] Added methods to Utils to generate and apply orderings for lists.