### PR TITLE
Removed buggy on-validate check and added error catch

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/Utils/RuntimeGizmoManager.cs
+++ b/Assets/LeapMotion/Core/Scripts/Utils/RuntimeGizmoManager.cs
@@ -515,7 +515,7 @@ namespace Leap.Unity.RuntimeGizmos {
     public void DrawSphere(Vector3 center, float radius) {
       //Throw an error here so we can give a more specific error than the more
       //general one which will be thrown later for a null mesh.
-      if (sphereMesh) {
+      if (sphereMesh == null) {
         throw new InvalidOperationException("Cannot draw a sphere because the Runtime Gizmo Manager does not have a sphere mesh assigned!");
       }
 

--- a/Assets/LeapMotion/Core/Scripts/Utils/RuntimeGizmoManager.cs
+++ b/Assets/LeapMotion/Core/Scripts/Utils/RuntimeGizmoManager.cs
@@ -102,13 +102,6 @@ namespace Leap.Unity.RuntimeGizmos {
         _gizmoShader = Shader.Find(DEFAULT_SHADER_NAME);
       }
 
-      if (_sphereMesh == null) {
-        GameObject tempSphere = GameObject.CreatePrimitive(PrimitiveType.Sphere);
-        tempSphere.hideFlags = HideFlags.HideAndDontSave;
-        _sphereMesh = tempSphere.GetComponent<MeshFilter>().sharedMesh;
-        tempSphere.GetComponent<MeshFilter>().sharedMesh = null;
-      }
-
       if (_frontDrawer != null && _backDrawer != null) {
         assignDrawerParams();
       }
@@ -520,6 +513,12 @@ namespace Leap.Unity.RuntimeGizmos {
     /// Draws a filled gizmo sphere at the given position with the given radius.
     /// </summary>
     public void DrawSphere(Vector3 center, float radius) {
+      //Throw an error here so we can give a more specific error than the more
+      //general one which will be thrown later for a null mesh.
+      if (sphereMesh) {
+        throw new InvalidOperationException("Cannot draw a sphere because the Runtime Gizmo Manager does not have a sphere mesh assigned!");
+      }
+
       DrawMesh(sphereMesh, center, Quaternion.identity, Vector3.one * radius * 2);
     }
 
@@ -628,8 +627,7 @@ namespace Leap.Unity.RuntimeGizmos {
             }
             DrawWireCapsule(capsule.center + capsuleDir * (capsule.height / 2F - capsule.radius),
                             capsule.center - capsuleDir * (capsule.height / 2F - capsule.radius), capsule.radius);
-          }
-          else {
+          } else {
             Vector3 size = Vector3.zero;
             size += Vector3.one * capsule.radius * 2;
             size += new Vector3(capsule.direction == 0 ? 1 : 0,


### PR DESCRIPTION
Unity likes to throw errors when you instantiate primitives from within OnValidate.  We were only doing this  to get a reference to a sphere mesh if the user decides to null out the sphere mesh in the inspector.  This is pretty unusual behavior so we just elect to throw an error yelling at them to assign it :)

