### PR TITLE
Feature streaming folder

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/DataStructures/AssetFolder.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/AssetFolder.cs
@@ -32,7 +32,8 @@ namespace Leap.Unity {
     /// <summary>
     /// Gets or sets the folder path.  This path will always be a path
     /// relative to the asset folder, and matches the format expected and
-    /// returned by AssetDatabase.
+    /// returned by AssetDatabase.  This operation cannot be performed
+    /// from inside of a build due to Assets no longer existing.
     /// </summary>
     public virtual string Path {
       get {

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/AssetFolder.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/AssetFolder.cs
@@ -24,29 +24,35 @@ namespace Leap.Unity {
   /// property will not be available.
   /// </summary>
   [Serializable]
-  public struct AssetFolder {
+  public class AssetFolder {
 
     [SerializeField]
-    private UnityObject _assetFolder;
+    protected UnityObject _assetFolder;
 
-#if UNITY_EDITOR
     /// <summary>
     /// Gets or sets the folder path.  This path will always be a path
     /// relative to the asset folder, and matches the format expected and
     /// returned by AssetDatabase.
     /// </summary>
-    public string Path {
+    public virtual string Path {
       get {
+#if UNITY_EDITOR
         if (_assetFolder != null) {
           return AssetDatabase.GetAssetPath(_assetFolder);
         } else {
           return null;
         }
+#else
+        throw new InvalidOperationException("Cannot access the Path of an Asset Folder in a build.");
+#endif
       }
       set {
+#if UNITY_EDITOR
         _assetFolder = AssetDatabase.LoadAssetAtPath<DefaultAsset>(value);
+#else
+        throw new InvalidOperationException("Cannot set the Path of an Asset Folder in a build.");
+#endif
       }
     }
-#endif
   }
 }

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/Editor/AssetFolderPropertyDrawer.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/Editor/AssetFolderPropertyDrawer.cs
@@ -13,7 +13,7 @@ using Leap.Unity.Query;
 
 namespace Leap.Unity {
 
-  [CustomPropertyDrawer(typeof(AssetFolder))]
+  [CustomPropertyDrawer(typeof(AssetFolder), useForChildren: true)]
   public class AssetFolderPropertyDrawer : PropertyDrawer {
 
     public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
@@ -44,10 +44,11 @@ namespace Leap.Unity {
           string relativePath = Utils.MakeRelativePath(Application.dataPath, resultPath);
           var asset = AssetDatabase.LoadAssetAtPath<DefaultAsset>(relativePath);
 
-          if (asset != null) {
-            folderProp.objectReferenceValue = asset;
+          string errorMessage;
+          if(!ValidatePath(resultPath, relativePath, out errorMessage)) {
+            EditorUtility.DisplayDialog("Could not select folder.", errorMessage, "OK");
           } else {
-            EditorUtility.DisplayDialog("Could not select folder.", "The specified folder is not an asset folder. Asset folders must be inside project's Assets directory.", "OK");
+            folderProp.objectReferenceValue = asset;
           }
         }
       }
@@ -72,6 +73,17 @@ namespace Leap.Unity {
 
     public override float GetPropertyHeight(SerializedProperty property, GUIContent label) {
       return EditorGUIUtility.singleLineHeight;
+    }
+
+    protected virtual bool ValidatePath(string fullPath, string relativePath, out string errorMessage) {
+      var asset = AssetDatabase.LoadAssetAtPath<DefaultAsset>(relativePath);
+      if(asset != null) {
+        errorMessage = null;
+        return true;
+      } else {
+        errorMessage = "The specified folder is not an asset folder. Asset folders must be inside project's Assets directory.";
+        return false;
+      }
     }
   }
 }

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/Editor/AssetFolderPropertyDrawer.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/Editor/AssetFolderPropertyDrawer.cs
@@ -41,7 +41,7 @@ namespace Leap.Unity {
       var content = EditorGUIUtility.IconContent("Folder Icon");
 
       if (GUI.Button(right, content, GUIStyle.none)) {
-        string resultPath = PrompUserForPath(folderPath);
+        string resultPath = PromptUserForPath(folderPath);
         if (!string.IsNullOrEmpty(resultPath)) {
           string relativePath = Utils.MakeRelativePath(Application.dataPath, resultPath);
           var asset = AssetDatabase.LoadAssetAtPath<DefaultAsset>(relativePath);
@@ -84,7 +84,7 @@ namespace Leap.Unity {
       return EditorGUIUtility.singleLineHeight;
     }
 
-    protected virtual string PrompUserForPath(string currentPath) {
+    protected virtual string PromptUserForPath(string currentPath) {
       return EditorUtility.OpenFolderPanel("Select Folder", currentPath, "");
     }
 

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/Editor/StreamingAssetPropertyDrawer.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/Editor/StreamingAssetPropertyDrawer.cs
@@ -15,7 +15,7 @@ namespace Leap.Unity {
   [CustomPropertyDrawer(typeof(StreamingFolder), useForChildren: true)]
   public class StreamingAssetPropertyDrawer : StreamingFolderPropertyDrawer {
 
-    protected override string PrompUserForPath(string currentPath) {
+    protected override string PromptUserForPath(string currentPath) {
       return EditorUtility.OpenFilePanel("Select File", currentPath, "");
     }
 

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/Editor/StreamingAssetPropertyDrawer.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/Editor/StreamingAssetPropertyDrawer.cs
@@ -1,0 +1,40 @@
+/******************************************************************************
+ * Copyright (C) Leap Motion, Inc. 2011-2017.                                 *
+ * Leap Motion proprietary and  confidential.                                 *
+ *                                                                            *
+ * Use subject to the terms of the Leap Motion SDK Agreement available at     *
+ * https://developer.leapmotion.com/sdk_agreement, or another agreement       *
+ * between Leap Motion and you, your company or other organization.           *
+ ******************************************************************************/
+
+using System.IO;
+using UnityEditor;
+
+namespace Leap.Unity {
+
+  [CustomPropertyDrawer(typeof(StreamingFolder), useForChildren: true)]
+  public class StreamingAssetPropertyDrawer : StreamingFolderPropertyDrawer {
+
+    protected override string PrompUserForPath(string currentPath) {
+      return EditorUtility.OpenFilePanel("Select File", currentPath, "");
+    }
+
+    protected override bool ValidatePath(string fullPath, string relativePath, out string errorMessage) {
+      if (!File.Exists(fullPath)) {
+        errorMessage = "The specified file does not exist!";
+        return false;
+      }
+
+      if ((File.GetAttributes(fullPath) & FileAttributes.Directory) == FileAttributes.Directory) {
+        errorMessage = "You must specify a file and not a directory!";
+        return false;
+      }
+
+      bool isValid = base.ValidatePath(fullPath, relativePath, out errorMessage);
+      if (!isValid) {
+        errorMessage = "The specified file is not a streaming asset. Streaming assets must be inside project's Assets/StreamingAssets directory.";
+      }
+      return isValid;
+    }
+  }
+}

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/Editor/StreamingAssetPropertyDrawer.cs.meta
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/Editor/StreamingAssetPropertyDrawer.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 8b0d052d45ca21f439a8610676ee957b
+timeCreated: 1501873546
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/Editor/StreamingFolderPropertyDrawer.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/Editor/StreamingFolderPropertyDrawer.cs
@@ -1,0 +1,45 @@
+/******************************************************************************
+ * Copyright (C) Leap Motion, Inc. 2011-2017.                                 *
+ * Leap Motion proprietary and  confidential.                                 *
+ *                                                                            *
+ * Use subject to the terms of the Leap Motion SDK Agreement available at     *
+ * https://developer.leapmotion.com/sdk_agreement, or another agreement       *
+ * between Leap Motion and you, your company or other organization.           *
+ ******************************************************************************/
+
+using System;
+using System.IO;
+using UnityEngine;
+using UnityEditor;
+
+namespace Leap.Unity {
+
+  [CustomPropertyDrawer(typeof(StreamingFolder), useForChildren: true)]
+  public class StreamingFolderPropertyDrawer : AssetFolderPropertyDrawer {
+
+    protected override bool ValidatePath(string fullPath, string relativePath, out string errorMessage) {
+      var fullInfo = new DirectoryInfo(fullPath);
+      var streamingInfo = new DirectoryInfo(Application.streamingAssetsPath);
+
+      if (IsInsideOrEqual(fullInfo, streamingInfo)) {
+        errorMessage = null;
+        return true;
+      } else {
+        errorMessage = "The specified folder is not a streaming asset folder. Streaming asset folders must be inside project's Assets/StreamingAssets directory.";
+        return false;
+      }
+    }
+
+    private bool IsInsideOrEqual(DirectoryInfo path, DirectoryInfo folder) {
+      if (path.Parent == null) {
+        return false;
+      }
+
+      if (string.Equals(path.FullName, folder.FullName, StringComparison.InvariantCultureIgnoreCase)) {
+        return true;
+      }
+
+      return IsInsideOrEqual(path.Parent, folder);
+    }
+  }
+}

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/Editor/StreamingFolderPropertyDrawer.cs.meta
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/Editor/StreamingFolderPropertyDrawer.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: ec61e8578a0d3574496a83ed841f3023
+timeCreated: 1501873546
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/StreamingAsset.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/StreamingAsset.cs
@@ -1,0 +1,8 @@
+﻿using System;
+using UnityEngine;
+
+namespace Leap.Unity {
+
+  [Serializable]
+  public class StreamingAsset : StreamingFolder, ISerializationCallbackReceiver { }
+}

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/StreamingAsset.cs.meta
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/StreamingAsset.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 0fea0e0a95c059f46a384933a21749a6
+timeCreated: 1503005167
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/StreamingFolder.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/StreamingFolder.cs
@@ -13,12 +13,18 @@ namespace Leap.Unity {
     [SerializeField]
     private string _relativePath;
 
+    /// <summary>
+    /// Gets the full path to the streaming folder.  This operation is safe to be
+    /// called from within a build or from within the editor, and will always return
+    /// the correct full path to the streaming folder.  Setting the path via code
+    /// is not supported.
+    /// </summary>
     public override string Path {
       get {
         return System.IO.Path.Combine(Application.streamingAssetsPath, _relativePath);
       }
       set {
-        throw new NotImplementedException();
+        throw new InvalidOperationException();
       }
     }
 

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/StreamingFolder.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/StreamingFolder.cs
@@ -32,10 +32,11 @@ namespace Leap.Unity {
 
     public void OnBeforeSerialize() {
 #if UNITY_EDITOR
-      string fullFolder = System.IO.Path.GetFullPath(AssetDatabase.GetAssetPath(_assetFolder));
-      if (string.IsNullOrEmpty(fullFolder)) {
+      string assetPath = AssetDatabase.GetAssetPath(_assetFolder);
+      if (string.IsNullOrEmpty(assetPath)) {
         _relativePath = null;
       } else {
+        string fullFolder = System.IO.Path.GetFullPath(assetPath);
         _relativePath = Utils.MakeRelativePath(Application.streamingAssetsPath, fullFolder);
         _relativePath = string.Join(System.IO.Path.DirectorySeparatorChar.ToString(),
                                     _relativePath.Split(System.IO.Path.DirectorySeparatorChar).Skip(1).ToArray());

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/StreamingFolder.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/StreamingFolder.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Linq;
+using UnityEngine;
+#if UNITY_EDITOR
+using UnityEditor;
+#endif
+
+namespace Leap.Unity {
+
+  [Serializable]
+  public class StreamingFolder : AssetFolder, ISerializationCallbackReceiver {
+
+    [SerializeField]
+    private string _relativePath;
+
+    public override string Path {
+      get {
+        return System.IO.Path.Combine(Application.streamingAssetsPath, _relativePath);
+      }
+      set {
+        throw new NotImplementedException();
+      }
+    }
+
+    public void OnAfterDeserialize() { }
+
+    public void OnBeforeSerialize() {
+#if UNITY_EDITOR
+      string fullFolder = System.IO.Path.GetFullPath(AssetDatabase.GetAssetPath(_assetFolder));
+      if (string.IsNullOrEmpty(fullFolder)) {
+        _relativePath = null;
+      } else {
+        _relativePath = Utils.MakeRelativePath(Application.streamingAssetsPath, fullFolder);
+        _relativePath = string.Join(System.IO.Path.DirectorySeparatorChar.ToString(),
+                                    _relativePath.Split(System.IO.Path.DirectorySeparatorChar).Skip(1).ToArray());
+      }
+#endif
+    }
+  }
+}

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/StreamingFolder.cs.meta
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/StreamingFolder.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: 0d51c114c8b39294d811c11a588c6b81
+timeCreated: 1503005167
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Added StreamingFolder and StreamingAsset, which use the same kind of interface as AssetFolder.  They allow you to serialize references to folders and assets located within the streaming assets folder.  They automatically return the correct full path to the files or directories they reference, both in the build and in the editor.  These references remain correct even if the files referenced get moved or renamed!

To test:
 - [x] Verify that StreamingFolder can only accept folders and StreamingAsset can only accept files
 - [x] Verify that StreamingFolder and StreamingAsset only accept things located within the StreamingAsset folder
 - [x] Verify that all of this works through both the explorer interface (the folder button) and when you drag things into the field.
 - [x] Verify that AssetFolder still works as expected 