### PR TITLE
Fix Button Parent Scales

### DIFF
--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/UI/Editor/InteractionButtonEditor.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/UI/Editor/InteractionButtonEditor.cs
@@ -56,6 +56,10 @@ namespace Leap.Unity.Interaction {
         }
       }
 
+      EditorGUILayout.EndHorizontal();
+
+      EditorGUILayout.BeginHorizontal();
+
       if (!isRoot) {
         bool isUniform = (button.transform.parent.lossyScale.x.NearlyEquals(button.transform.parent.lossyScale.y) &&
                           button.transform.parent.lossyScale.y.NearlyEquals(button.transform.parent.lossyScale.z) &&

--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/UI/Editor/InteractionButtonEditor.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/UI/Editor/InteractionButtonEditor.cs
@@ -55,6 +55,16 @@ namespace Leap.Unity.Interaction {
           Undo.SetTransformParent(button.transform, buttonBaseTransform.transform, "Child " + button.gameObject.name + " to its Base");
         }
       }
+
+      if (!isRoot) {
+        bool isUniform = (button.transform.parent.lossyScale.x.NearlyEquals(button.transform.parent.lossyScale.y) &&
+                          button.transform.parent.lossyScale.y.NearlyEquals(button.transform.parent.lossyScale.z) &&
+                          button.transform.parent.lossyScale.x.NearlyEquals(button.transform.parent.lossyScale.z));
+        if (!isUniform) {
+          EditorGUILayout.HelpBox("This button exists within a non-uniformly scaled space!  Please check the parent transforms for non-uniform scale...", MessageType.Warning);
+        }
+      }
+
       EditorGUILayout.EndHorizontal();
 
       Rigidbody currentBody = button.GetComponent<Rigidbody>();

--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/UI/InteractionButton.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/UI/InteractionButton.cs
@@ -213,9 +213,9 @@ namespace Leap.Unity.Interaction {
           Vector3 originalLocalVelocity = localPhysicsVelocity;
 
           // Spring force
-          localPhysicsVelocity += Mathf.Clamp(_springForce * 10000F * (initialLocalPosition.z - Mathf.Lerp(minMaxHeight.x, minMaxHeight.y, restingHeight) - localPhysicsPosition.z), -100f, 100f)
-                                * Time.fixedDeltaTime
-                                * Vector3.forward;
+          localPhysicsVelocity += Mathf.Clamp(_springForce * 10000F * (initialLocalPosition.z - Mathf.Lerp(minMaxHeight.x, minMaxHeight.y, restingHeight) - localPhysicsPosition.z), -100f / transform.parent.lossyScale.x, 100f / transform.parent.lossyScale.x)
+                                              * Time.fixedDeltaTime
+                                              * Vector3.forward;
 
           // Friction & Drag
           float velMag = originalLocalVelocity.magnitude;
@@ -224,12 +224,12 @@ namespace Leap.Unity.Interaction {
 
             // Friction force
             Vector3 frictionForce = resistanceDir * velMag * FRICTION_COEFFICIENT;
-            localPhysicsVelocity = localPhysicsVelocity + (frictionForce /* assume unit mass */ * Time.fixedDeltaTime);
+            localPhysicsVelocity += (frictionForce /* assume unit mass */ * Time.fixedDeltaTime * transform.parent.lossyScale.x);
 
             // Drag force
             float velSqrMag = velMag * velMag;
             Vector3 dragForce = resistanceDir * velSqrMag * DRAG_COEFFICIENT;
-            localPhysicsVelocity = localPhysicsVelocity + (dragForce /* assume unit mass */ * Time.fixedDeltaTime);
+            localPhysicsVelocity += (dragForce /* assume unit mass */ * Time.fixedDeltaTime * transform.parent.lossyScale.x);
           }
         }
 


### PR DESCRIPTION
Prior buttons assumed that the button parent transform existed in unit space (which the examples were designed to satisfy).   Breaking this assumption drastically changed the scale of the forces upon the button.

This PR adjusts the drag and spring forces to take into account the lossy scale of the button parent.