### PR TITLE
Fix terrible forever loop in preferences

### DIFF
--- a/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/Editor/LeapGraphicPreferences.cs
+++ b/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/Editor/LeapGraphicPreferences.cs
@@ -126,7 +126,7 @@ namespace Leap.Unity.GraphicalRenderer {
       int newGraphicMax = EditorGUILayout.DelayedIntField("Max Graphics Per-Group", graphicMax);
       newGraphicMax = Mathf.Min(newGraphicMax, 1023); //maximum array length for Unity shaders is 1023
 
-      if (newGraphicMax > GRAPHIC_COUNT_SOFT_CEILING) {
+      if (newGraphicMax > GRAPHIC_COUNT_SOFT_CEILING && graphicMax <= GRAPHIC_COUNT_SOFT_CEILING) {
         if (!EditorUtility.DisplayDialog("Large Graphic Count",
                                         "Setting the graphic count larger than 144 can cause incorrect rendering " +
                                         "or shader compilation failure on certain systems, are you sure you want " +


### PR DESCRIPTION
Only show dialog if the user changes the state of the value to go from under to over the maximum.  This prevents the terrible forever dialog box that basically spams you until you can manage to close the preferences window.