### PR TITLE
Clarify that SelectMany requires a Query return type of its selector function

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/Query/SelectMany.cs
+++ b/Assets/LeapMotion/Core/Scripts/Query/SelectMany.cs
@@ -71,7 +71,8 @@ namespace Leap.Unity.Query {
     /// <summary>
     /// Returns a new query operation representing the current query sequence where each element has been
     /// mapped onto an entire query sequence, and then all sequences are concatenated into a single long 
-    /// sequence.
+    /// sequence. Note that your selector function must call .Query() on the collection it returns, or you
+    /// will get a type inference error at compile time!
     /// 
     /// For example:
     ///   (1, 2, 3, 4).Query().SelectMany(count => new List().Fill(count, count.ToString()).Query())


### PR DESCRIPTION
SelectMany is a great way to provide a selector that takes an input and returns a sequence, then perform an operation on the concatenation of every sequence by the selector function. However, if you don't call .Query() on the sequence you return in the selector function, you get a crazy QueryWrapper-related type inference error at compile time. This PR adds an explicit callout to this potential trip-up -- it prevented me from using SelectMany once and it's a shame the fix was so simple!