### PR TITLE
Make anchor requirements readable, fix logic bug

### DIFF
--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/UI/Anchors/AnchorableBehaviour.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/UI/Anchors/AnchorableBehaviour.cs
@@ -496,8 +496,18 @@ namespace Leap.Unity.Interaction {
       Anchor closestAnchor = null;
       float closestDistSqrd = float.PositiveInfinity;
       foreach (var testAnchor in anchorsToCheck) {
-        if ((requireAnchorHasSpace && (!anchor.allowMultipleObjects || anchor.anchoredObjects.Count == 0))
-            || (requireAnchorActiveAndEnabled && !anchor.isActiveAndEnabled)) continue;
+        if (requireAnchorHasSpace) {
+          bool anchorHasSpace = testAnchor.anchoredObjects.Count == 0
+                                || testAnchor.allowMultipleObjects;
+          if (!anchorHasSpace) {
+            // Skip the anchor for consideration.
+            continue;
+          }
+        }
+        if (requireAnchorActiveAndEnabled && !testAnchor.isActiveAndEnabled) {
+          // Skip the anchor for consideration.
+          continue;
+        }
 
         float testDistanceSqrd = (testAnchor.transform.position - this.transform.position).sqrMagnitude;
         if (testDistanceSqrd < closestDistSqrd) {


### PR DESCRIPTION
JCorvinus on the dev forums pointed out an obvious issue with GetNearestValidAnchor's testAnchor checking:

```
foreach (var testAnchor in anchorsToCheck) {
  if ((requireAnchorHasSpace && (!anchor.allowMultipleObjects || anchor.anchoredObjects.Count == 0))
      || (requireAnchorActiveAndEnabled && !anchor.isActiveAndEnabled)) continue;
```

`anchor` != `testAnchor` -- also, the logic here is really unreadable, so I fixed it, and in the process I think I also fixed an error in the logic.