### PR TITLE
Added equality checks so dirty doesn't happen every frame

### DIFF
--- a/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/Features/BlendShape/LeapBlendShapeData.cs
+++ b/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/Features/BlendShape/LeapBlendShapeData.cs
@@ -77,8 +77,10 @@ namespace Leap.Unity.GraphicalRenderer {
         return _amount;
       }
       set {
-        MarkFeatureDirty();
-        _amount = value;
+        if (value != _amount) {
+          MarkFeatureDirty();
+          _amount = value;
+        }
       }
     }
 

--- a/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/Features/CustomChannel/CustomChannelDataBase.cs
+++ b/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/Features/CustomChannel/CustomChannelDataBase.cs
@@ -62,8 +62,10 @@ namespace Leap.Unity.GraphicalRenderer {
         return _value;
       }
       set {
-        MarkFeatureDirty();
-        _value = value;
+        if (!value.Equals(_value)) {
+          MarkFeatureDirty();
+          _value = value;
+        }
       }
     }
   }

--- a/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/Features/Tint/LeapRuntimeTintData.cs
+++ b/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/Features/Tint/LeapRuntimeTintData.cs
@@ -62,8 +62,10 @@ namespace Leap.Unity.GraphicalRenderer {
         return _color;
       }
       set {
-        MarkFeatureDirty();
-        _color = value;
+        if (value != _color) {
+          MarkFeatureDirty();
+          _color = value;
+        }
       }
     }
   }


### PR DESCRIPTION
For the feature data, check for actual changes before marking the feature dirty, that way if you have some sort of editor script that is assigning a runtime tint on every update it doesn't cause the entire renderer to rebuild every frame, slowing down the whole editor experience!