### PR TITLE
Add utils from particles

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/Utils/RuntimeGizmoManager.cs
+++ b/Assets/LeapMotion/Core/Scripts/Utils/RuntimeGizmoManager.cs
@@ -650,6 +650,49 @@ namespace Leap.Unity.RuntimeGizmos {
       PopMatrix();
     }
 
+    /// <summary>
+    /// Draws a simple XYZ-cross position gizmo at the target position, whose size is
+    /// scaled relative to the main camera's distance to the target position (for reliable
+    /// visibility).
+    /// 
+    /// You can also provide a color argument and lerp coefficient towards that color from
+    /// the axes' default colors (red, green, blue). Colors are lerped in HSV space.
+    /// </summary>
+    public void DrawPosition(Vector3 pos, Color lerpColor, float lerpCoeff) {
+      float targetScale = 0.06f; // 6 cm at 1m away.
+
+      var mainCam = Camera.main;
+      var posWorldSpace = matrix * pos;
+      if (mainCam != null) {
+        float camDistance = Vector3.Distance(posWorldSpace, mainCam.transform.position);
+
+        targetScale *= camDistance;
+      }
+
+      float extent = (targetScale / 2f);
+
+      color = Color.red;
+      if (lerpCoeff != 0f) { color = color.LerpHSV(lerpColor, lerpCoeff); }
+      DrawLine(pos - Vector3.right * extent, pos + Vector3.right * extent);
+
+      color = Color.green;
+      if (lerpCoeff != 0f) { color = color.LerpHSV(lerpColor, lerpCoeff); }
+      DrawLine(pos - Vector3.up * extent, pos + Vector3.up * extent);
+
+      color = Color.blue;
+      if (lerpCoeff != 0f) { color = color.LerpHSV(lerpColor, lerpCoeff); }
+      DrawLine(pos - Vector3.forward * extent, pos + Vector3.forward * extent);
+    }
+
+    /// <summary>
+    /// Draws a simple XYZ-cross position gizmo at the target position, whose size is
+    /// scaled relative to the main camera's distance to the target position (for reliable
+    /// visibility).
+    /// </summary>
+    public static void DrawPosition(this RuntimeGizmoDrawer drawer, Vector3 pos) {
+      drawer.DrawPosition(pos, Color.white, 0f);
+    }
+
     public void ClearAllGizmos() {
       _operations.Clear();
       _matrices.Clear();

--- a/Assets/LeapMotion/Core/Scripts/Utils/RuntimeGizmoManager.cs
+++ b/Assets/LeapMotion/Core/Scripts/Utils/RuntimeGizmoManager.cs
@@ -689,8 +689,8 @@ namespace Leap.Unity.RuntimeGizmos {
     /// scaled relative to the main camera's distance to the target position (for reliable
     /// visibility).
     /// </summary>
-    public static void DrawPosition(this RuntimeGizmoDrawer drawer, Vector3 pos) {
-      drawer.DrawPosition(pos, Color.white, 0f);
+    public void DrawPosition(Vector3 pos) {
+      DrawPosition(pos, Color.white, 0f);
     }
 
     public void ClearAllGizmos() {

--- a/Assets/LeapMotion/Core/Scripts/Utils/Utils.cs
+++ b/Assets/LeapMotion/Core/Scripts/Utils/Utils.cs
@@ -504,24 +504,24 @@ namespace Leap.Unity {
     /// but be warned that it's not cheap to call!
     /// </summary>
     public static T FindObjectInHierarchy<T>() where T : UnityEngine.Object {
-      T obj = Resources.FindObjectsOfTypeAll<T>().Query().FirstOrDefault();
-      if (obj == null) return null;
-
+      return Resources.FindObjectsOfTypeAll<T>().Query()
+        .Where(o => {
 #if UNITY_EDITOR
-      // Exclude prefabs.
-      var prefabType = UnityEditor.PrefabUtility.GetPrefabType(obj);
-      if (prefabType == UnityEditor.PrefabType.ModelPrefab
+          // Exclude prefabs.
+          var prefabType = UnityEditor.PrefabUtility.GetPrefabType(o);
+          if (prefabType == UnityEditor.PrefabType.ModelPrefab
           || prefabType == UnityEditor.PrefabType.Prefab) {
-        return null;
-      }
+            return false;
+          }
 #endif
-
-      return obj;
+          return true;
+        })
+        .FirstOrDefault();
     }
 
     #endregion
 
-    #region Transform Utils
+#region Transform Utils
 
     /// <summary>
     /// Returns the children of this Transform in sibling index order.
@@ -558,9 +558,9 @@ namespace Leap.Unity {
       public void Dispose() { }
     }
 
-    #endregion
+#endregion
 
-    #region Orientation Utils
+#region Orientation Utils
 
     /// <summary>
     /// Similar to Unity's Transform.LookAt(), but resolves the forward vector of this
@@ -588,9 +588,9 @@ namespace Leap.Unity {
       thisTransform.rotation = Quaternion.LookRotation(thisTransform.position - transform.position, upwards);
     }
 
-    #endregion
+#endregion
 
-    #region Physics Utils
+#region Physics Utils
 
     public static void IgnoreCollisions(GameObject first, GameObject second, bool ignore = true) {
       if (first == null || second == null)
@@ -609,9 +609,9 @@ namespace Leap.Unity {
       }
     }
 
-    #endregion
+#endregion
 
-    #region Collider Utils
+#region Collider Utils
 
     public static Vector3 GetDirection(this CapsuleCollider capsule) {
       switch (capsule.direction) {
@@ -703,9 +703,9 @@ namespace Leap.Unity {
       }
     }
 
-    #endregion
+#endregion
 
-    #region Color Utils
+#region Color Utils
 
     public static Color WithAlpha(this Color color, float alpha) {
       return new Color(color.r, color.g, color.b, alpha);
@@ -746,9 +746,9 @@ namespace Leap.Unity {
       return Color.HSVToRGB(hL, sL, vL);
     }
 
-    #endregion
+#endregion
 
-    #region Gizmo Utils
+#region Gizmo Utils
 
     public static void DrawCircle(Vector3 center,
                            Vector3 normal,
@@ -802,9 +802,9 @@ namespace Leap.Unity {
       }
     }
 
-    #endregion
+#endregion
 
-    #region Runtime Gizmo Utils
+#region Runtime Gizmo Utils
 
     /// <summary>
     /// Draws a simple XYZ-cross position gizmo at the target position, whose size is
@@ -849,9 +849,9 @@ namespace Leap.Unity {
       drawer.DrawPosition(pos, Color.white, 0f);
     }
 
-    #endregion
+#endregion
 
-    #region Texture Utils
+#region Texture Utils
 
     private static TextureFormat[] _incompressibleFormats = new TextureFormat[] {
       TextureFormat.R16,
@@ -874,9 +874,9 @@ namespace Leap.Unity {
       return Array.IndexOf(_incompressibleFormats, format) < 0;
     }
 
-    #endregion
+#endregion
 
-    #region Rect Utils
+#region Rect Utils
 
     /// <summary>
     /// Returns the area of the Rect, width * height.
@@ -893,7 +893,7 @@ namespace Leap.Unity {
       return new Rect(r.x + padding, r.y + padding, r.width - (padding * 2), r.height - (padding * 2));
     }
 
-    #endregion
+#endregion
 
   }
 

--- a/Assets/LeapMotion/Core/Scripts/Utils/Utils.cs
+++ b/Assets/LeapMotion/Core/Scripts/Utils/Utils.cs
@@ -521,7 +521,7 @@ namespace Leap.Unity {
 
     #endregion
 
-#region Transform Utils
+    #region Transform Utils
 
     /// <summary>
     /// Returns the children of this Transform in sibling index order.
@@ -558,9 +558,9 @@ namespace Leap.Unity {
       public void Dispose() { }
     }
 
-#endregion
+    #endregion
 
-#region Orientation Utils
+    #region Orientation Utils
 
     /// <summary>
     /// Similar to Unity's Transform.LookAt(), but resolves the forward vector of this
@@ -588,9 +588,9 @@ namespace Leap.Unity {
       thisTransform.rotation = Quaternion.LookRotation(thisTransform.position - transform.position, upwards);
     }
 
-#endregion
+    #endregion
 
-#region Physics Utils
+    #region Physics Utils
 
     public static void IgnoreCollisions(GameObject first, GameObject second, bool ignore = true) {
       if (first == null || second == null)
@@ -609,9 +609,9 @@ namespace Leap.Unity {
       }
     }
 
-#endregion
+    #endregion
 
-#region Collider Utils
+    #region Collider Utils
 
     public static Vector3 GetDirection(this CapsuleCollider capsule) {
       switch (capsule.direction) {
@@ -703,9 +703,9 @@ namespace Leap.Unity {
       }
     }
 
-#endregion
+    #endregion
 
-#region Color Utils
+    #region Color Utils
 
     public static Color WithAlpha(this Color color, float alpha) {
       return new Color(color.r, color.g, color.b, alpha);
@@ -746,9 +746,9 @@ namespace Leap.Unity {
       return Color.HSVToRGB(hL, sL, vL);
     }
 
-#endregion
+    #endregion
 
-#region Gizmo Utils
+    #region Gizmo Utils
 
     public static void DrawCircle(Vector3 center,
                            Vector3 normal,
@@ -802,9 +802,9 @@ namespace Leap.Unity {
       }
     }
 
-#endregion
+    #endregion
 
-#region Runtime Gizmo Utils
+    #region Runtime Gizmo Utils
 
     /// <summary>
     /// Draws a simple XYZ-cross position gizmo at the target position, whose size is
@@ -849,9 +849,9 @@ namespace Leap.Unity {
       drawer.DrawPosition(pos, Color.white, 0f);
     }
 
-#endregion
+    #endregion
 
-#region Texture Utils
+    #region Texture Utils
 
     private static TextureFormat[] _incompressibleFormats = new TextureFormat[] {
       TextureFormat.R16,
@@ -874,9 +874,9 @@ namespace Leap.Unity {
       return Array.IndexOf(_incompressibleFormats, format) < 0;
     }
 
-#endregion
+    #endregion
 
-#region Rect Utils
+    #region Rect Utils
 
     /// <summary>
     /// Returns the area of the Rect, width * height.
@@ -893,7 +893,7 @@ namespace Leap.Unity {
       return new Rect(r.x + padding, r.y + padding, r.width - (padding * 2), r.height - (padding * 2));
     }
 
-#endregion
+    #endregion
 
   }
 

--- a/Assets/LeapMotion/Core/Scripts/Utils/Utils.cs
+++ b/Assets/LeapMotion/Core/Scripts/Utils/Utils.cs
@@ -740,10 +740,29 @@ namespace Leap.Unity {
       float h1, s1, v1;
       Color.RGBToHSV(towardsColor, out h1, out s1, out v1);
 
-      float hL = Mathf.Lerp(h0, h1, t);
+      // Cyclically lerp hue. (Input hues are always between 0 and 1.)
+      if (h0 - h1 < -0.5f) h0 += 1f;
+      if (h0 - h1 > 0.5f) h1 += 1f;
+      float hL = Mathf.Lerp(h0, h1, t) % 1f;
+
       float sL = Mathf.Lerp(s0, s1, t);
       float vL = Mathf.Lerp(v0, v1, t);
       return Color.HSVToRGB(hL, sL, vL);
+    }
+
+    /// <summary>
+    /// Cyclically lerps hue arguments by t.
+    /// </summary>
+    public static float LerpHue(float h0, float h1, float t) {
+      // Enforce hue values between 0f and 1f.
+      if (h0 < 0f) h0 = 1f - (-h0 % 1f);
+      if (h1 < 0f) h1 = 1f - (-h1 % 1f);
+      if (h0 > 1f) h0 = h0 % 1f;
+      if (h1 > 1f) h1 = h1 % 1f;
+
+      if (h0 - h1 < -0.5f) h0 += 1f;
+      if (h0 - h1 > 0.5f) h1 += 1f;
+      return Mathf.Lerp(h0, h1, t) % 1f;
     }
 
     #endregion
@@ -800,53 +819,6 @@ namespace Leap.Unity {
       for (float q = step; q <= height; q += step) {
         DrawCircle(origin + direction * q, direction, Mathf.Tan(angle * Constants.DEG_TO_RAD) * q, color, quality * 8, duration, depthTest);
       }
-    }
-
-    #endregion
-
-    #region Runtime Gizmo Utils
-
-    /// <summary>
-    /// Draws a simple XYZ-cross position gizmo at the target position, whose size is
-    /// scaled relative to the main camera's distance to the target position (for reliable
-    /// visibility).
-    /// 
-    /// You can also provide a color argument and lerp coefficient towards that color from
-    /// the axes' default colors (red, green, blue). Colors are lerped in HSV space.
-    /// </summary>
-    public static void DrawPosition(this RuntimeGizmoDrawer drawer, Vector3 pos,
-                                    Color lerpColor, float lerpCoeff) {
-      float targetScale = 0.06f; // 6 cm at 1m away.
-
-      var mainCam = Camera.main;
-      if (mainCam != null) {
-        float camDistance = Vector3.Distance(pos, mainCam.transform.position);
-
-        targetScale *= camDistance;
-      }
-
-      float extent = (targetScale / 2f);
-
-      drawer.color = Color.red;
-      if (lerpCoeff != 0f) { drawer.color = drawer.color.LerpHSV(lerpColor, lerpCoeff); }
-      drawer.DrawLine(pos - Vector3.right * extent, pos + Vector3.right * extent);
-
-      drawer.color = Color.green;
-      if (lerpCoeff != 0f) { drawer.color = drawer.color.LerpHSV(lerpColor, lerpCoeff); }
-      drawer.DrawLine(pos - Vector3.up * extent, pos + Vector3.up * extent);
-
-      drawer.color = Color.blue;
-      if (lerpCoeff != 0f) { drawer.color = drawer.color.LerpHSV(lerpColor, lerpCoeff); }
-      drawer.DrawLine(pos - Vector3.forward * extent, pos + Vector3.forward * extent);
-    }
-
-    /// <summary>
-    /// Draws a simple XYZ-cross position gizmo at the target position, whose size is
-    /// scaled relative to the main camera's distance to the target position (for reliable
-    /// visibility).
-    /// </summary>
-    public static void DrawPosition(this RuntimeGizmoDrawer drawer, Vector3 pos) {
-      drawer.DrawPosition(pos, Color.white, 0f);
     }
 
     #endregion


### PR DESCRIPTION
This PR adds the following utilities (most of which are from NewUtils in particles) -- (and moves one utility)

- [x] Move the Area() extension method from General to Rect Utils
- [x] Adds CompMax and CompMin for Vector2, 3, and 4
- [ ] Adds FindObjectInHierarchy<T> (where T : UnityEngine.Object), which is FindObjectOfType<T> but also returns an object if it inactive in the hierarchy (used for active-state-robust singleton-pattern objects)
- [ ] Adds color.LerpHSV(otherColor, t)
- [ ] Adds DrawPosition(Vector3 v) as a RuntimeGizmoDrawer extension, which draws a little world-space aligned XYZ crosshair whose size is dependent on the distance of the main camera to the point. You can also provide a lerp-target color (HSV-lerped) and lerp-coefficient if you want to render multiple points and differentiate between them. The idea is that this makes debugging positions with RuntimeGizmos very quick to write.