### PR TITLE
Address physics stutter when physics timestep != update timestep

### DIFF
--- a/Assets/LeapMotion/Modules/InteractionEngine/Examples/1. Interaction Objects/Interaction Objects.unity
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Examples/1. Interaction Objects/Interaction Objects.unity
@@ -1154,7 +1154,7 @@ Rigidbody:
   m_AngularDrag: 0.05
   m_UseGravity: 0
   m_IsKinematic: 1
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
 --- !u!23 &124275133
@@ -1427,7 +1427,7 @@ Prefab:
     - target: {fileID: 54494498398590960, guid: 5a1fb53528997fe478560ab3120da9cb,
         type: 2}
       propertyPath: m_Interpolate
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 5a1fb53528997fe478560ab3120da9cb, type: 2}
@@ -1716,7 +1716,7 @@ Rigidbody:
   m_AngularDrag: 0.05
   m_UseGravity: 0
   m_IsKinematic: 1
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
 --- !u!23 &224207163
@@ -1864,7 +1864,7 @@ Rigidbody:
   m_AngularDrag: 0.05
   m_UseGravity: 0
   m_IsKinematic: 1
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
 --- !u!23 &236842560
@@ -2199,7 +2199,7 @@ Rigidbody:
   m_AngularDrag: 0.05
   m_UseGravity: 0
   m_IsKinematic: 0
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 1
 --- !u!65 &255649384
@@ -2463,7 +2463,7 @@ Rigidbody:
   m_AngularDrag: 0.05
   m_UseGravity: 0
   m_IsKinematic: 1
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
 --- !u!23 &307306923
@@ -2611,7 +2611,7 @@ Rigidbody:
   m_AngularDrag: 0.05
   m_UseGravity: 0
   m_IsKinematic: 1
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
 --- !u!23 &309724707
@@ -2972,7 +2972,7 @@ Prefab:
     - target: {fileID: 54989536721116318, guid: 8998b2da307be7f419e285784a8495a6,
         type: 2}
       propertyPath: m_Interpolate
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 8998b2da307be7f419e285784a8495a6, type: 2}
@@ -3124,7 +3124,7 @@ Rigidbody:
   m_AngularDrag: 0.05
   m_UseGravity: 0
   m_IsKinematic: 1
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
 --- !u!23 &412698729
@@ -3294,7 +3294,7 @@ Prefab:
     - target: {fileID: 54989536721116318, guid: 8998b2da307be7f419e285784a8495a6,
         type: 2}
       propertyPath: m_Interpolate
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents:
     - {fileID: 0}
@@ -3404,7 +3404,7 @@ Rigidbody:
   m_AngularDrag: 0.05
   m_UseGravity: 0
   m_IsKinematic: 1
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
 --- !u!23 &444300109
@@ -3539,7 +3539,7 @@ Rigidbody:
   m_AngularDrag: 0.05
   m_UseGravity: 0
   m_IsKinematic: 1
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
 --- !u!23 &445421616
@@ -3739,7 +3739,7 @@ Prefab:
     - target: {fileID: 54494498398590960, guid: 5a1fb53528997fe478560ab3120da9cb,
         type: 2}
       propertyPath: m_Interpolate
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 5a1fb53528997fe478560ab3120da9cb, type: 2}
@@ -3825,7 +3825,7 @@ Rigidbody:
   m_AngularDrag: 0.05
   m_UseGravity: 0
   m_IsKinematic: 1
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
 --- !u!23 &618037989
@@ -3984,7 +3984,7 @@ Rigidbody:
   m_AngularDrag: 0.05
   m_UseGravity: 0
   m_IsKinematic: 1
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
 --- !u!23 &660863413
@@ -4170,7 +4170,7 @@ Prefab:
     - target: {fileID: 54989536721116318, guid: 8998b2da307be7f419e285784a8495a6,
         type: 2}
       propertyPath: m_Interpolate
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 8998b2da307be7f419e285784a8495a6, type: 2}
@@ -4284,7 +4284,7 @@ Rigidbody:
   m_AngularDrag: 0.05
   m_UseGravity: 0
   m_IsKinematic: 1
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
 --- !u!23 &793958699
@@ -4432,7 +4432,7 @@ Rigidbody:
   m_AngularDrag: 0.05
   m_UseGravity: 0
   m_IsKinematic: 1
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
 --- !u!23 &811384334
@@ -4792,7 +4792,7 @@ Rigidbody:
   m_AngularDrag: 0.05
   m_UseGravity: 0
   m_IsKinematic: 1
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
 --- !u!23 &912334417
@@ -5093,7 +5093,7 @@ Rigidbody:
   m_AngularDrag: 0.05
   m_UseGravity: 0
   m_IsKinematic: 1
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
 --- !u!23 &960290470
@@ -5328,7 +5328,7 @@ Rigidbody:
   m_AngularDrag: 0.05
   m_UseGravity: 0
   m_IsKinematic: 1
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
 --- !u!23 &990935694
@@ -5516,7 +5516,7 @@ Rigidbody:
   m_AngularDrag: 0.05
   m_UseGravity: 0
   m_IsKinematic: 1
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
 --- !u!23 &1066024316
@@ -5682,7 +5682,7 @@ Rigidbody:
   m_AngularDrag: 0.05
   m_UseGravity: 0
   m_IsKinematic: 1
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
 --- !u!23 &1087592058
@@ -5813,7 +5813,7 @@ Rigidbody:
   m_AngularDrag: 0.05
   m_UseGravity: 0
   m_IsKinematic: 1
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
 --- !u!23 &1130429106
@@ -6996,7 +6996,7 @@ Prefab:
     - target: {fileID: 54553201331445640, guid: 88a926f39f5ae5c40976d0ff02c7fd2f,
         type: 2}
       propertyPath: m_Interpolate
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 88a926f39f5ae5c40976d0ff02c7fd2f, type: 2}
@@ -7085,7 +7085,7 @@ Prefab:
     - target: {fileID: 54494498398590960, guid: 5a1fb53528997fe478560ab3120da9cb,
         type: 2}
       propertyPath: m_Interpolate
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 5a1fb53528997fe478560ab3120da9cb, type: 2}
@@ -7171,7 +7171,7 @@ Rigidbody:
   m_AngularDrag: 0.05
   m_UseGravity: 0
   m_IsKinematic: 1
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
 --- !u!23 &1306528556
@@ -7311,7 +7311,7 @@ Prefab:
     - target: {fileID: 54728075337958320, guid: e2b312b753498524289c413de369c1fc,
         type: 2}
       propertyPath: m_Interpolate
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: e2b312b753498524289c413de369c1fc, type: 2}
@@ -7420,7 +7420,7 @@ Rigidbody:
   m_AngularDrag: 0.05
   m_UseGravity: 0
   m_IsKinematic: 1
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
 --- !u!23 &1404154280
@@ -7568,7 +7568,7 @@ Rigidbody:
   m_AngularDrag: 0.05
   m_UseGravity: 0
   m_IsKinematic: 1
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
 --- !u!23 &1436522782
@@ -7896,7 +7896,7 @@ Rigidbody:
   m_AngularDrag: 0.05
   m_UseGravity: 0
   m_IsKinematic: 1
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
 --- !u!23 &1493018505
@@ -8262,7 +8262,7 @@ Prefab:
     - target: {fileID: 54989536721116318, guid: 8998b2da307be7f419e285784a8495a6,
         type: 2}
       propertyPath: m_Interpolate
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 8998b2da307be7f419e285784a8495a6, type: 2}
@@ -8371,7 +8371,7 @@ Rigidbody:
   m_AngularDrag: 0.05
   m_UseGravity: 0
   m_IsKinematic: 1
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
 --- !u!23 &1604363487
@@ -8594,7 +8594,7 @@ Rigidbody:
   m_AngularDrag: 0.05
   m_UseGravity: 0
   m_IsKinematic: 1
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
 --- !u!1 &1815998821
@@ -8673,7 +8673,7 @@ Rigidbody:
   m_AngularDrag: 0.05
   m_UseGravity: 0
   m_IsKinematic: 1
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
 --- !u!23 &1815998826
@@ -8821,7 +8821,7 @@ Rigidbody:
   m_AngularDrag: 0.05
   m_UseGravity: 0
   m_IsKinematic: 1
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
 --- !u!23 &1844324950
@@ -9050,7 +9050,7 @@ Rigidbody:
   m_AngularDrag: 0.05
   m_UseGravity: 0
   m_IsKinematic: 1
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
 --- !u!1001 &1962152601
@@ -9204,7 +9204,7 @@ Prefab:
     - target: {fileID: 54494498398590960, guid: 5a1fb53528997fe478560ab3120da9cb,
         type: 2}
       propertyPath: m_Interpolate
-      value: 0
+      value: 1
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 5a1fb53528997fe478560ab3120da9cb, type: 2}
@@ -9323,7 +9323,7 @@ Rigidbody:
   m_AngularDrag: 0.05
   m_UseGravity: 1
   m_IsKinematic: 0
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 1
 --- !u!1 &2048856376
@@ -9402,7 +9402,7 @@ Rigidbody:
   m_AngularDrag: 0.05
   m_UseGravity: 0
   m_IsKinematic: 1
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
 --- !u!23 &2048856381
@@ -9550,7 +9550,7 @@ Rigidbody:
   m_AngularDrag: 0.05
   m_UseGravity: 0
   m_IsKinematic: 1
-  m_Interpolate: 0
+  m_Interpolate: 1
   m_Constraints: 0
   m_CollisionDetection: 0
 --- !u!23 &2071343631

--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/Internal/KinematicGraspedMovement.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/Internal/KinematicGraspedMovement.cs
@@ -24,14 +24,8 @@ namespace Leap.Unity.Interaction {
 
     public void MoveTo(Vector3 solvedPosition, Quaternion solvedRotation,
                        InteractionBehaviour interactionObj, bool justGrasped) {
-      //interactionObj.rigidbody.MovePosition(solvedPosition);
-      //interactionObj.rigidbody.MoveRotation(solvedRotation);
-      interactionObj.rigidbody.transform.position = solvedPosition;
-      interactionObj.rigidbody.transform.rotation = solvedRotation;
-      interactionObj.rigidbody.position = solvedPosition;
-      interactionObj.rigidbody.rotation = solvedRotation;
+      interactionObj.rigidbody.MovePosition(solvedPosition);
+      interactionObj.rigidbody.MoveRotation(solvedRotation);
     }
-
   }
-
 }


### PR DESCRIPTION
We are working towards allowing the IE to support physics timesteps that are not equal to the update timestep.  This is a feature that could be very useful to developers who want to save on performance by computing less physics, or for developers who are stuck on certain physics framerates for other reasons specific to their game (we are in this boat for particles!).  

This PR takes one step closer to supporting this functionality.  Currently our service provider can provide update frames, and physics frames, but until this PR the physics frames were not calculated using correct timestamps, making them jitter!  This PR uses the offset calculated in Update to calculate a correct timestamp from within FixedUpdate.  This will _increase latency_ of the frames provided to the physics system.  Later PR's hope to solve this latency with the same system that helped us out in the old IE, the rigidbody warper (maybe).

Testing:
 - To test a specific physics timestep, go to Edit->Project Settings->Time and set the `Fixed Timestep` and `Maximum Allowed Timestep` both to 1 / the desired framerate.  Use the first interaction example for testing.  The warning dialog will probably pop up and yell at you, but you can ignore it.  Once these sequence of changes are complete, we might be getting rid of it anyway.

 - Run all tests with the interaction behavior GraspMovementBehaviour set both to Kinematic and NonKinematic.  

 - [ ] Make sure interactions still feel good and cause no judder when the physics framerate is equal to 90 when on a desktop device.
 - [ ] Make sure interactions still feel good and cause no judder when the physics framerate is equal to 60 when on a mobile device.
-  [ ] Make sure interactions still feel good and cause no judder when the physics framerate is equal to 60 when on a desktop device.
 - [ ] Make sure interactions still feel good and cause no judder when the physics framerate is equal to 45 when on a mobile device.
