### PR TITLE
Fixing capsule hand scaling issues

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/Hands/CapsuleHand.cs
+++ b/Assets/LeapMotion/Core/Scripts/Hands/CapsuleHand.cs
@@ -189,14 +189,14 @@ namespace Leap.Unity {
 
     private void drawSphere(Vector3 position, float radius = SPHERE_RADIUS) {
       //multiply radius by 2 because the default unity sphere has a radius of 0.5 meters at scale 1.
-      Graphics.DrawMesh(_sphereMesh, Matrix4x4.TRS(position, Quaternion.identity, Vector3.one * radius * 2.0f), _sphereMat, 0);
+      Graphics.DrawMesh(_sphereMesh, Matrix4x4.TRS(position, Quaternion.identity, Vector3.one * radius * 2.0f * transform.lossyScale.x), _sphereMat, 0);
     }
 
     private void drawCylinder(Vector3 a, Vector3 b) {
       float length = (a - b).magnitude;
 
       Graphics.DrawMesh(getCylinderMesh(length),
-                        Matrix4x4.TRS(a, Quaternion.LookRotation(b - a), Vector3.one),
+                        Matrix4x4.TRS(a, Quaternion.LookRotation(b - a), new Vector3(transform.lossyScale.x, transform.lossyScale.x, 1)),
                         _material,
                         gameObject.layer);
     }
@@ -239,8 +239,8 @@ namespace Leap.Unity {
 
         Vector3 spoke = new Vector3(dx, dy, 0);
 
-        verts.Add((p0 + spoke) * transform.lossyScale.x);
-        verts.Add((p1 + spoke) * transform.lossyScale.x);
+        verts.Add(p0 + spoke);
+        verts.Add(p1 + spoke);
 
         colors.Add(Color.white);
         colors.Add(Color.white);


### PR DESCRIPTION
Capsule hand meshes were not being calculated or displayed correctly at different scales.  This PR should allow the hands to be displayed correctly when the camera rig changes its scale.

To test:
 - [x] Visit the example VR scene and scale the camera rig up and down, verify that the capsule hands do not artifact in edit more or in playmode.