### PR TITLE
Make anchorableBehaviours actually respect anchorRotation property

### DIFF
--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/UI/Anchors/AnchorableBehaviour.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/UI/Anchors/AnchorableBehaviour.cs
@@ -325,7 +325,9 @@ namespace Leap.Unity.Interaction {
         }
 
         updateAnchorAttachment();
-        updateAnchorAttachmentRotation();
+        if (anchorRotation) {
+          updateAnchorAttachmentRotation();
+        }
 
         WhileAttachedToAnchor.Invoke(this, anchor);
 


### PR DESCRIPTION
Herp.

That's all I have to say really

- [x] Verify that an anchorableBehaviour only rotates to match its anchor if anchorRotation is checked