### PR TITLE
Fix rig scale support for device offsets

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/VR/LeapVRTemporalWarping.cs
+++ b/Assets/LeapMotion/Core/Scripts/VR/LeapVRTemporalWarping.cs
@@ -204,7 +204,7 @@ namespace Leap.Unity {
 
       // Prepare device offset parameters.
       Quaternion deviceTilt   = Quaternion.Euler(deviceTiltXAxis, 0f, 0f);
-      Vector3    deviceOffset = new Vector3(0f, deviceOffsetYAxis, deviceOffsetZAxis);
+      Vector3    deviceOffset = new Vector3(0f, deviceOffsetYAxis, deviceOffsetZAxis).CompMul(this.transform.lossyScale);
 
       // TODO: We no longer use deviceInfo.forwardOffset. We should consider removing it
       // entirely or more approrpriately when we collapse the rig hierarchy. 9/1/17


### PR DESCRIPTION
The fix is pretty simple.

- [x] Check that setting the rig to a uniform scale that isn't all ones produces identical hand alignments to having a unit-scale rig.

Note that dynamically changing your rig's scale at runtime is not supported by the Interaction Engine, so don't expect good results if you do that :D (hand alignment will still work fine though)