### PR TITLE
Don't generate soft contacts for grasped objects

### DIFF
--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionController.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionController.cs
@@ -1130,7 +1130,8 @@ namespace Leap.Unity.Interaction {
               IInteractionBehaviour intObj;
               if (manager.interactionObjectBodies.TryGetValue(_softContactColliderBuffer[i].attachedRigidbody, out intObj)) {
                 // Skip soft contact if the object is ignoring contact.
-                if (manager.interactionObjectBodies[_softContactColliderBuffer[i].attachedRigidbody].ignoreContact) continue;
+                if (intObj.ignoreContact) continue;
+                if (intObj.isGrasped) continue;
               }
 
               PhysicsUtility.generateSphereContact(boneSphere, 0, _softContactColliderBuffer[i],
@@ -1157,7 +1158,8 @@ namespace Leap.Unity.Interaction {
               IInteractionBehaviour intObj;
               if (manager.interactionObjectBodies.TryGetValue(_softContactColliderBuffer[i].attachedRigidbody, out intObj)) {
                 // Skip soft contact if the object is ignoring contact.
-                if (manager.interactionObjectBodies[_softContactColliderBuffer[i].attachedRigidbody].ignoreContact) continue;
+                if (intObj.ignoreContact) continue;
+                if (intObj.isGrasped) continue;
               }
 
               PhysicsUtility.generateCapsuleContact(boneCapsule, 0,
@@ -1190,7 +1192,8 @@ namespace Leap.Unity.Interaction {
               IInteractionBehaviour intObj;
               if (manager.interactionObjectBodies.TryGetValue(_softContactColliderBuffer[i].attachedRigidbody, out intObj)) {
                 // Skip soft contact if the object is ignoring contact.
-                if (manager.interactionObjectBodies[_softContactColliderBuffer[i].attachedRigidbody].ignoreContact) continue;
+                if (intObj.ignoreContact) continue;
+                if (intObj.isGrasped) continue;
               }
 
               PhysicsUtility.generateBoxContact(boneBox, 0, _softContactColliderBuffer[i],


### PR DESCRIPTION
We should still get contact callbacks, but we shouldn't be generating nor applying soft contacts for any controllers when the relevant object is grasped by any controller.

- [ ] Make sure you can get contact callbacks from, say, your right hand, on an object held in the left hand
- [x] Make sure soft contact still feels good
- [x] Give it that ol' selstad inspection