### PR TITLE
Make ImplementsInterface check all attached components

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/Attributes/ImplementsInterface.cs
+++ b/Assets/LeapMotion/Core/Scripts/Attributes/ImplementsInterface.cs
@@ -34,16 +34,25 @@ namespace Leap.Unity.Attributes {
     public void ConstrainValue(SerializedProperty property) {
       if (property.objectReferenceValue != null) {
         var objectReferenceValue = property.objectReferenceValue;
-        var implementer = (objectReferenceValue as Component)
+
+        if (objectReferenceValue.GetType().ImplementsInterface(type)) {
+          // All good! This Component implements the interface.
+          return;
+        }
+        else {
+          // Search the rest of the GameObject for a component that implements the
+          // interface.
+          var implementer = (objectReferenceValue as Component)
                             .GetComponents<Component>()
                             .Query()
                             .Where(c => c.GetType().ImplementsInterface(type))
                             .FirstOrDefault();
-        if (implementer == null) {
-          Debug.LogError(property.objectReferenceValue.GetType().Name + " does not implement " + type.Name);
-        }
+          if (implementer == null) {
+            Debug.LogError(property.objectReferenceValue.GetType().Name + " does not implement " + type.Name);
+          }
 
-        property.objectReferenceValue = implementer;
+          property.objectReferenceValue = implementer;
+        }
       }
     }
 

--- a/Assets/LeapMotion/Core/Scripts/Attributes/ImplementsInterface.cs
+++ b/Assets/LeapMotion/Core/Scripts/Attributes/ImplementsInterface.cs
@@ -13,6 +13,7 @@ using UnityEditor;
 #endif
 using System.Collections.Generic;
 using System;
+using Leap.Unity.Query;
 
 namespace Leap.Unity.Attributes {
 
@@ -32,10 +33,17 @@ namespace Leap.Unity.Attributes {
 #if UNITY_EDITOR
     public void ConstrainValue(SerializedProperty property) {
       if (property.objectReferenceValue != null) {
-        if (!property.objectReferenceValue.GetType().ImplementsInterface(type)) {
+        var objectReferenceValue = property.objectReferenceValue;
+        var implementer = (objectReferenceValue as Component)
+                            .GetComponents<Component>()
+                            .Query()
+                            .Where(c => c.GetType().ImplementsInterface(type))
+                            .FirstOrDefault();
+        if (implementer == null) {
           Debug.LogError(property.objectReferenceValue.GetType().Name + " does not implement " + type.Name);
-          property.objectReferenceValue = null;
         }
+
+        property.objectReferenceValue = implementer;
       }
     }
 


### PR DESCRIPTION
- [x] Make the ImplementsInterface attribute check all attached components of a dragged-in object

- [x] Verify you can drag in a GameObject with various components into a field marked ImplementsInterface as long as it contains an implementing component _somewhere_ in it