### PR TITLE
Fixed two enable/disable issues

### DIFF
--- a/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/LeapGraphicGroup.cs
+++ b/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/LeapGraphicGroup.cs
@@ -434,6 +434,7 @@ namespace Leap.Unity.GraphicalRenderer {
       for (int i = 0; i < _features.Count; i++) {
         _features[i].AssignFeatureReferences();
         _features[i].ClearDataObjectReferences();
+        _features[i].isDirty = true;
         foreach (var graphic in _graphics) {
           _features[i].AddFeatureData(graphic.featureData[i]);
         }

--- a/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/RenderingMethods/LeapTextRenderer.cs
+++ b/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/RenderingMethods/LeapTextRenderer.cs
@@ -103,7 +103,9 @@ namespace Leap.Unity.GraphicalRenderer {
           using (new ProfilerSample("Draw Meshes")) {
             for (int i = 0; i < group.graphics.Count; i++) {
               var graphic = group.graphics[i];
-              Graphics.DrawMesh(_meshData[i], graphic.transform.localToWorldMatrix, _material, 0);
+              if (graphic.isActiveAndEnabled) {
+                Graphics.DrawMesh(_meshData[i], graphic.transform.localToWorldMatrix, _material, 0);
+              }
             }
           }
         } else if (renderer.space is LeapRadialSpace) {


### PR DESCRIPTION
Make sure to mark all features dirty when a graphic renderer is enabled, or else renderers might not correctly re-upload feature data, leading to undefined results.

Make sure to correctly check for enabled/disabled status for the text renderer in the normal-space codepath.