### PR TITLE
Fix Graphic Renderer index error

### DIFF
--- a/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/RenderingMethods/LeapDynamicRenderer.cs
+++ b/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/RenderingMethods/LeapDynamicRenderer.cs
@@ -25,7 +25,6 @@ namespace Leap.Unity.GraphicalRenderer {
     //Curved space
     private const string CURVED_PARAMETERS = LeapGraphicRenderer.PROPERTY_PREFIX + "Curved_GraphicParameters";
     private List<Matrix4x4> _curved_worldToAnchor = new List<Matrix4x4>();
-    private List<Matrix4x4> _curved_meshTransforms = new List<Matrix4x4>();
     private List<Vector4> _curved_graphicParameters = new List<Vector4>();
     #endregion
 
@@ -105,7 +104,6 @@ namespace Leap.Unity.GraphicalRenderer {
           var curvedSpace = renderer.space as LeapRadialSpace;
           using (new ProfilerSample("Build Material Data And Draw Meshes")) {
             _curved_worldToAnchor.Clear();
-            _curved_meshTransforms.Clear();
             _curved_graphicParameters.Clear();
             for (int i = 0; i < _meshes.Count; i++) {
               var graphic = group.graphics[i];
@@ -122,13 +120,11 @@ namespace Leap.Unity.GraphicalRenderer {
               Matrix4x4 total = mainTransform * deform;
 
               _curved_graphicParameters.Add((transformer as IRadialTransformer).GetVectorRepresentation(graphic.transform));
-              _curved_meshTransforms.Add(total);
-
               _curved_worldToAnchor.Add(mainTransform.inverse);
 
               //Safe to do this before we upload material data
               //meshes are drawn at end of frame anyway!
-              drawMesh(_meshes[i], _curved_meshTransforms[i]);
+              drawMesh(_meshes[i], total);
             }
           }
 

--- a/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/RenderingMethods/LeapDynamicRenderer.cs
+++ b/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/RenderingMethods/LeapDynamicRenderer.cs
@@ -108,6 +108,8 @@ namespace Leap.Unity.GraphicalRenderer {
             for (int i = 0; i < _meshes.Count; i++) {
               var graphic = group.graphics[i];
               if (!graphic.isActiveAndEnabled) {
+                _curved_graphicParameters.Add(Vector4.zero);
+                _curved_worldToAnchor.Add(Matrix4x4.identity);
                 continue;
               }
 

--- a/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/RenderingMethods/LeapTextRenderer.cs
+++ b/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/RenderingMethods/LeapTextRenderer.cs
@@ -114,6 +114,8 @@ namespace Leap.Unity.GraphicalRenderer {
             for (int i = 0; i < _meshData.Count; i++) {
               var graphic = group.graphics[i];
               if (!graphic.isActiveAndEnabled) {
+                _curved_graphicParameters.Add(Vector4.zero);
+                _curved_worldToAnchor.Add(Matrix4x4.identity);
                 continue;
               }
 

--- a/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/RenderingMethods/LeapTextRenderer.cs
+++ b/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/RenderingMethods/LeapTextRenderer.cs
@@ -54,7 +54,6 @@ namespace Leap.Unity.GraphicalRenderer {
     //Curved space
     private const string CURVED_PARAMETERS = LeapGraphicRenderer.PROPERTY_PREFIX + "Curved_GraphicParameters";
     private List<Matrix4x4> _curved_worldToAnchor = new List<Matrix4x4>();
-    private List<Matrix4x4> _curved_meshTransforms = new List<Matrix4x4>();
     private List<Vector4> _curved_graphicParameters = new List<Vector4>();
 
     public override SupportInfo GetSpaceSupportInfo(LeapSpace space) {
@@ -111,7 +110,6 @@ namespace Leap.Unity.GraphicalRenderer {
 
           using (new ProfilerSample("Build Material Data And Draw Meshes")) {
             _curved_worldToAnchor.Clear();
-            _curved_meshTransforms.Clear();
             _curved_graphicParameters.Clear();
             for (int i = 0; i < _meshData.Count; i++) {
               var graphic = group.graphics[i];
@@ -128,10 +126,9 @@ namespace Leap.Unity.GraphicalRenderer {
               Matrix4x4 total = mainTransform * deform;
 
               _curved_graphicParameters.Add((transformer as IRadialTransformer).GetVectorRepresentation(graphic.transform));
-              _curved_meshTransforms.Add(total);
               _curved_worldToAnchor.Add(mainTransform.inverse);
 
-              Graphics.DrawMesh(_meshData[i], _curved_meshTransforms[i], _material, 0);
+              Graphics.DrawMesh(_meshData[i], total, _material, 0);
             }
           }
 


### PR DESCRIPTION
Fixes two bugs introduced in the previous enable/disable PR.  Both only occur on dynamic renderers and text renderers when curved spaces are enabled.

To test:
 - [ ] Visit the dynamic renderer example scene and add a curved space to the graphic renderer.  Press play and fiddle with the 1, 2, and 3 keys to toggle on and off the graphics, ensure no warnings or errors are thrown.