### PR TITLE
Merge latest additions/fixes from Particles

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/Utils/Utils.cs
+++ b/Assets/LeapMotion/Core/Scripts/Utils/Utils.cs
@@ -299,6 +299,24 @@ namespace Leap.Unity {
       return d0 <= d && d <= d1;
     }
 
+    /// <summary>
+    /// Extrapolates using time values for positions a and b at extrapolatedTime.
+    /// </summary>
+    public static Vector3 TimedExtrapolate(Vector3 a, float aTime,
+                                           Vector3 b, float bTime,
+                                           float extrapolatedTime) {
+      return Vector3.LerpUnclamped(a, b, extrapolatedTime.MapUnclamped(aTime, bTime, 0f, 1f));
+    }
+
+    /// <summary>
+    /// Extrapolates using time values for rotations a and b at extrapolatedTime.
+    /// </summary>
+    public static Quaternion TimedExtrapolate(Quaternion a, float aTime,
+                                              Quaternion b, float bTime,
+                                              float extrapolatedTime) {
+      return Quaternion.SlerpUnclamped(a, b, extrapolatedTime.MapUnclamped(aTime, bTime, 0f, 1f));
+    }
+
     #endregion
 
     #region Value Mapping Utils
@@ -379,6 +397,33 @@ namespace Leap.Unity {
                         value.y.MapUnclamped(valueMin, valueMax, resultMin, resultMax),
                         value.z.MapUnclamped(valueMin, valueMax, resultMin, resultMax),
                         value.w.MapUnclamped(valueMin, valueMax, resultMin, resultMax));
+    }
+
+    /// <summary>
+    /// Returns a vector between resultMin and resultMax based on the input value's position
+    /// between valueMin and valueMax.
+    /// The input value is clamped between valueMin and valueMax.
+    /// </summary>
+    public static Vector2 Map(float input, float valueMin, float valueMax, Vector2 resultMin, Vector2 resultMax) {
+      return Vector2.Lerp(resultMin, resultMax, Mathf.InverseLerp(valueMin, valueMax, input));
+    }
+
+    /// <summary>
+    /// Returns a vector between resultMin and resultMax based on the input value's position
+    /// between valueMin and valueMax.
+    /// The input value is clamped between valueMin and valueMax.
+    /// </summary>
+    public static Vector3 Map(float input, float valueMin, float valueMax, Vector3 resultMin, Vector3 resultMax) {
+      return Vector3.Lerp(resultMin, resultMax, Mathf.InverseLerp(valueMin, valueMax, input));
+    }
+
+    /// <summary>
+    /// Returns a vector between resultMin and resultMax based on the input value's position
+    /// between valueMin and valueMax.
+    /// The input value is clamped between valueMin and valueMax.
+    /// </summary>
+    public static Vector4 Map(float input, float valueMin, float valueMax, Vector4 resultMin, Vector4 resultMax) {
+      return Vector4.Lerp(resultMin, resultMax, Mathf.InverseLerp(valueMin, valueMax, input));
     }
 
     /// <summary>
@@ -863,6 +908,40 @@ namespace Leap.Unity {
     /// </summary>
     public static Rect PadInner(this Rect r, float padding) {
       return new Rect(r.x + padding, r.y + padding, r.width - (padding * 2), r.height - (padding * 2));
+    }
+
+    #endregion
+
+    #region List Utils
+
+    public static void EnsureListExists<T>(ref List<T> list) {
+      if (list == null) {
+        list = new List<T>();
+      }
+    }
+
+    public static void EnsureListCount<T>(this List<T> list, int count) {
+      if (list.Count == count) return;
+
+      while (list.Count < count) {
+        list.Add(default(T));
+      }
+
+      while (list.Count > count) {
+        list.RemoveAt(list.Count - 1);
+      }
+    }
+
+    public static void EnsureListCount<T>(this List<T> list, int count, Func<T> createT, Action<T> deleteT) {
+      while (list.Count < count) {
+        list.Add(createT());
+      }
+
+      while (list.Count > count) {
+        T tempT = list[list.Count - 1];
+        list.RemoveAt(list.Count - 1);
+        deleteT(tempT);
+      }
     }
 
     #endregion

--- a/Assets/LeapMotion/Core/Scripts/Utils/Utils.cs
+++ b/Assets/LeapMotion/Core/Scripts/Utils/Utils.cs
@@ -932,7 +932,7 @@ namespace Leap.Unity {
       }
     }
 
-    public static void EnsureListCount<T>(this List<T> list, int count, Func<T> createT, Action<T> deleteT) {
+    public static void EnsureListCount<T>(this List<T> list, int count, Func<T> createT, Action<T> deleteT = null) {
       while (list.Count < count) {
         list.Add(createT());
       }
@@ -940,7 +940,10 @@ namespace Leap.Unity {
       while (list.Count > count) {
         T tempT = list[list.Count - 1];
         list.RemoveAt(list.Count - 1);
-        deleteT(tempT);
+        
+        if (deleteT != null) {
+          deleteT(tempT);
+        }
       }
     }
 

--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionController.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionController.cs
@@ -137,6 +137,11 @@ namespace Leap.Unity.Interaction {
     public bool isRight { get { return !isLeft; } }
 
     /// <summary>
+    /// Returns the current position of this controller.
+    /// </summary>
+    public abstract Vector3 position { get; }
+
+    /// <summary>
     /// Returns the current velocity of this controller.
     /// </summary>
     public abstract Vector3 velocity { get; }

--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionHand.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionHand.cs
@@ -245,7 +245,7 @@ namespace Leap.Unity.Interaction {
     /// Gets the velocity of the underlying tracked Leap hand.
     /// </summary>
     public override Vector3 velocity {
-      get { return isTracked ? Vector3.zero : leapHand.PalmVelocity.ToVector3(); }
+      get { return isTracked ? leapHand.PalmVelocity.ToVector3() : Vector3.zero; }
     }
 
     /// <summary>

--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionHand.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionHand.cs
@@ -235,6 +235,13 @@ namespace Leap.Unity.Interaction {
     }
 
     /// <summary>
+    /// Gets the last-tracked position of the underlying Leap hand.
+    /// </summary>
+    public override Vector3 position {
+      get { return _handData.PalmPosition.ToVector3(); }
+    }
+
+    /// <summary>
     /// Gets the velocity of the underlying tracked Leap hand.
     /// </summary>
     public override Vector3 velocity {

--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionVRController.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionVRController.cs
@@ -289,6 +289,15 @@ namespace Leap.Unity.Interaction {
     }
 
     /// <summary>
+    /// Gets the last-tracked position of the controller.
+    /// </summary>
+    public override Vector3 position {
+      get {
+        return this.transform.position;
+      }
+    }
+
+    /// <summary>
     /// Gets the current velocity of the controller.
     /// </summary>
     public override Vector3 velocity {

--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/UI/Anchors/Tests/AnchorScoreTest.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/UI/Anchors/Tests/AnchorScoreTest.cs
@@ -27,6 +27,9 @@ namespace Leap.Unity.Interaction {
     [Range(5F, 90F)]
     public float maxAngle = 60F;
 
+    [Range(0f, 1f)]
+    public float alwaysAttachDistance = 0f;
+
     [Header("Generated")]
     public Texture2D textureXY;
     public Texture2D textureXZ;
@@ -68,7 +71,7 @@ namespace Leap.Unity.Interaction {
                            + (dir1 * i * widthPerPixel - (dir1 * center))
                            + (dir2 * j * widthPerPixel - (dir2 * center));
 
-        float score = AnchorableBehaviour.GetAnchorScore(anchObjPos, anchObjVel, anchorPos, maxRange, maxRange / 2F, Mathf.Cos(maxAngle * Mathf.Deg2Rad));
+        float score = AnchorableBehaviour.GetAnchorScore(anchObjPos, anchObjVel, anchorPos, maxRange, maxRange * 0.40F, Mathf.Cos(maxAngle * Mathf.Deg2Rad), alwaysAttachDistance);
         Color pixel = Color.HSVToRGB(Mathf.Lerp(1F, 0F, score), Mathf.Lerp(0F, 1F, score), Mathf.Lerp(0F, 1F, score));
         _pixels[i + j * tex.width] = pixel;
       }

--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/UI/Anchors/Tests/AnchorScoreTest.unity
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/UI/Anchors/Tests/AnchorScoreTest.unity
@@ -42,7 +42,7 @@ RenderSettings:
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 9
+  serializedVersion: 11
   m_GIWorkflowMode: 0
   m_GISettings:
     serializedVersion: 2
@@ -54,7 +54,7 @@ LightmapSettings:
     m_EnableBakedLightmaps: 1
     m_EnableRealtimeLightmaps: 1
   m_LightmapEditorSettings:
-    serializedVersion: 8
+    serializedVersion: 9
     m_Resolution: 2
     m_BakeResolution: 40
     m_TextureWidth: 1024
@@ -71,7 +71,7 @@ LightmapSettings:
     m_FinalGatherFiltering: 1
     m_FinalGatherRayCount: 256
     m_ReflectionCompression: 2
-    m_MixedBakeMode: 3
+    m_MixedBakeMode: 2
     m_BakeBackend: 0
     m_PVRSampling: 1
     m_PVRDirectSampleCount: 32
@@ -87,7 +87,7 @@ LightmapSettings:
     m_PVRFilteringAtrousNormalSigma: 1
     m_PVRFilteringAtrousPositionSigma: 1
   m_LightingDataAsset: {fileID: 0}
-  m_ShadowMaskMode: 2
+  m_UseShadowmask: 1
 --- !u!196 &4
 NavMeshSettings:
   serializedVersion: 2
@@ -122,7 +122,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &376211934
 Transform:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
This PR does some stuff:

- [x] Optional (zero by default) `alwaysAttachDistance` for AnchorableBehaviours. Previously you were guaranteed to miss an anchor if you had `useTrajectory` enabled and the user releases _juust_ past an anchor when moving towards it. So the effective object position is shifted backwards in time a bit when the anchorable object has a significant velocity, and this parameter can also create a radius around which only distance matters, overriding trajectory information. See the test scene in the IE/UI/Anchors/Tests folder for a visualization.
- [x] `position` is now a valid thing to ask an InteractionController for. I just realized that we provide `velocity` but not `position`, and not all InteractionControllers set their transform positions with position tracking information!
- [x] `interactionHand.velocity` was totally, embarrassingly bugged. Now it works. Check out the shameful diff. >_<
- [x] Some Utils from Particles' NewUtils.cs for Utils.cs.