### PR TITLE
Add ability to specify key ratio

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/DataStructures/Editor/SerializableDictionaryEditor.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/Editor/SerializableDictionaryEditor.cs
@@ -115,10 +115,11 @@ namespace Leap.Unity {
 
     private void drawElementCallback(Rect rect, int index, bool isActive, bool isFocused) {
       Rect leftRect = rect;
-      leftRect.width *= 0.5f;
+      leftRect.width *= (fieldInfo.GetValue(_currProperty.serializedObject.targetObject) as ISerializableDictionary).KeyDisplayRatio();
 
-      Rect rightRect = leftRect;
-      rightRect.x += rightRect.width;
+      Rect rightRect = rect;
+      rightRect.x += leftRect.width;
+      rightRect.width -= leftRect.width;
 
       Pair pair = _pairs[index];
 

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/SerializableDictionary.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/SerializableDictionary.cs
@@ -27,19 +27,34 @@ namespace Leap.Unity {
 #endif
   }
 
+  public interface ISerializableDictionary {
+    float KeyDisplayRatio();
+  }
+
   /// <summary>
   /// In order to have this class be serialized, you will always need to create your own
   /// non-generic version specific to your needs.  This is the same workflow that exists
   /// for using the UnityEvent class as well. 
   /// </summary>
-  public class SerializableDictionary<TKey, TValue> : Dictionary<TKey, TValue>, ICanReportDuplicateInformation, ISerializationCallbackReceiver {
+  public class SerializableDictionary<TKey, TValue> : Dictionary<TKey, TValue>,
+    ICanReportDuplicateInformation,
+    ISerializationCallbackReceiver,
+    ISerializableDictionary {
 
     [SerializeField]
     private List<TKey> _keys;
 
     [SerializeField]
     private List<TValue> _values;
-    
+
+    /// <summary>
+    /// Returns how much of the display space should be allocated to the key.
+    /// Should be a value in the range 0-1.
+    /// </summary>
+    public virtual float KeyDisplayRatio() {
+      return 0.5f;
+    }
+
     public override string ToString() {
       StringBuilder toReturn = new StringBuilder();
       List<TKey> keys = Keys.ToList<TKey>();
@@ -52,7 +67,7 @@ namespace Leap.Unity {
         toReturn.Append(values[i].ToString());
         toReturn.Append("}, \n");
       }
-      toReturn.Remove(toReturn.Length-3, 3);
+      toReturn.Remove(toReturn.Length - 3, 3);
       toReturn.Append("]");
       return toReturn.ToString();
     }


### PR DESCRIPTION
Can no specify the key ratio used when displaying the key and value for the serializable dictionary.