### PR TITLE
Renamed Hands.Rig to Hands.CameraRig

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/Utils/HandUtils.cs
+++ b/Assets/LeapMotion/Core/Scripts/Utils/HandUtils.cs
@@ -45,7 +45,7 @@ namespace Leap.Unity {
     /// of the Camera that contains a LeapProvider in one of its children,
     /// or null if there is no such GameObject.
     /// </summary>
-    public static GameObject Rig {
+    public static GameObject CameraRig {
       get {
         if (s_leapRig == null) {
           InitStatic();


### PR DESCRIPTION
Very small convenience fix.  Now when typing Hands.R / Hands.Ri / Hands.Rig , auto-complete will choose Hands.Right instead of Hands.Rig, which is _usually_ what you want.  This way, Hands.Right and Hands.Left both have the same auto complete "priority" 