### PR TITLE
Override default quality for Core Rigged Hands

### DIFF
--- a/Assets/LeapMotion/Core/Prefabs/HandModelsNonHuman/LoPoly_Rigged_Hand_Left.prefab
+++ b/Assets/LeapMotion/Core/Prefabs/HandModelsNonHuman/LoPoly_Rigged_Hand_Left.prefab
@@ -1139,7 +1139,7 @@ SkinnedMeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   serializedVersion: 2
-  m_Quality: 0
+  m_Quality: 4
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: 4300000, guid: 5413bab15c3dd4a4085a9fe254a17e96, type: 3}

--- a/Assets/LeapMotion/Core/Prefabs/HandModelsNonHuman/LoPoly_Rigged_Hand_Right.prefab
+++ b/Assets/LeapMotion/Core/Prefabs/HandModelsNonHuman/LoPoly_Rigged_Hand_Right.prefab
@@ -1140,7 +1140,7 @@ SkinnedMeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   serializedVersion: 2
-  m_Quality: 0
+  m_Quality: 4
   m_UpdateWhenOffscreen: 1
   m_SkinnedMotionVectors: 1
   m_Mesh: {fileID: 4300000, guid: ce6112dd14179d448958c91c5b4e8de2, type: 3}


### PR DESCRIPTION
Core's Rigged Hands have their prefab skinned mesh renderer's quality set to 0 (Auto) instead of 4, which causes the bone weights to mess up on lower quality settings (the hands require at least 4 Bone weighting to render correctly).

This PR fixes that.