### PR TITLE
Fix shuffle distribution

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/Utils/Utils.cs
+++ b/Assets/LeapMotion/Core/Scripts/Utils/Utils.cs
@@ -65,7 +65,7 @@ namespace Leap.Unity {
     /// </summary>
     public static void Shuffle<T>(this IList<T> list) {
       for (int i = 0; i < list.Count; i++) {
-        Utils.Swap(list, i, UnityEngine.Random.Range(0, list.Count));
+        Utils.Swap(list, i, UnityEngine.Random.Range(i, list.Count));
       }
     }
 


### PR DESCRIPTION
The shuffle algorithm, which is a direct implementation of the [Fisher–Yates shuffle](https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle) was not implemented correctly!  This caused slightly non-uniform shuffles to be performed.  This PR fixes the typo.