### PR TITLE
Remove the icon gizmo

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/LeapHandController.cs
+++ b/Assets/LeapMotion/Core/Scripts/LeapHandController.cs
@@ -22,9 +22,6 @@ namespace Leap.Unity {
     protected Dictionary<int, HandRepresentation> graphicsHandReps = new Dictionary<int, HandRepresentation>();
     protected Dictionary<int, HandRepresentation> physicsHandReps = new Dictionary<int, HandRepresentation>();
 
-    // Reference distance from thumb base to pinky base in mm.
-    protected const float GIZMO_SCALE = 5.0f;
-
     protected bool graphicsEnabled = true;
     protected bool physicsEnabled = true;
 
@@ -44,12 +41,6 @@ namespace Leap.Unity {
       set {
         physicsEnabled = value;
       }
-    }
-
-    /** Draws the Leap Motion gizmo when in the Unity editor. */
-    void OnDrawGizmos() {
-      Gizmos.matrix = Matrix4x4.Scale(GIZMO_SCALE * Vector3.one);
-      Gizmos.DrawIcon(transform.position, "leap_motion.png");
     }
 
     protected virtual void OnEnable() {


### PR DESCRIPTION
The gizmo doesn't work since it isn't in the correct folder.  Since the 'correct' folder can _only_ be Assets/Gizmos, which sucks in our specific folder ecosystem I think it's just easier to remove the gizmo entirely.  This ONLY removes it under the condition that is selected!  If it isn't selected, unity still draws it anyway, so it's not bad at all in my opinion.

Fixed #179