### PR TITLE
Add features to produce consume buffer

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/DataStructures/ProduceConsumeBuffer.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/ProduceConsumeBuffer.cs
@@ -60,6 +60,22 @@ namespace Leap.Unity {
     }
 
     /// <summary>
+    /// Returns the current number of elements that are held inside the buffer.
+    /// </summary>
+    public int Count {
+      get {
+        int tail = (int)_tail;
+        int head = (int)_head;
+
+        if (tail < head) {
+          tail += Capacity;
+        }
+
+        return tail - head;
+      }
+    }
+
+    /// <summary>
     /// Tries to enqueue a value into the buffer.  If the buffer is already full, this
     /// method will perform no action and return false.  This method is only safe to
     /// be called from a single producer thread.
@@ -71,6 +87,15 @@ namespace Leap.Unity {
       _buffer[_tail] = t;
       _tail = nextTail;
       return true;
+    }
+
+    /// <summary>
+    /// Tries to enqueue a value into the buffer.  If the buffer is already full, this
+    /// method will perform no action and return false.  This method is only safe to
+    /// be called from a single producer thread.
+    /// </summary>
+    public bool TryEnqueue(T t) {
+      return TryEnqueue(ref t);
     }
 
     /// <summary>
@@ -86,6 +111,24 @@ namespace Leap.Unity {
 
       t = _buffer[_head];
       _head = (_head + 1) & _bufferMask;
+      return true;
+    }
+
+    /// <summary>
+    /// Tries to dequeue all values off of the buffer, returning the most recently
+    /// added element.  If there was an element found, this method will return true,
+    /// else it will return false.
+    /// </summary>
+    public bool TryDequeueAll(out T mostRecent) {
+      if (!TryDequeue(out mostRecent)) {
+        return false;
+      }
+
+      T temp;
+      while (TryDequeue(out temp)) {
+        mostRecent = temp;
+      }
+
       return true;
     }
   }


### PR DESCRIPTION
Adding some methods to the Produce Consume buffer for greater ease of use
 - Count, which represents the current number of elements held inside the buffer
 - An overload of TryEnqueue that doesn't require a ref parameter.
 - TryDequeueAll, which removes all items from the buffer and returns the most recent one (if one exists)