### PR TITLE
Fix stuck soft contact state

### DIFF
--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionController.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionController.cs
@@ -948,6 +948,9 @@ namespace Leap.Unity.Interaction {
       // Clear contact data if we lose tracking.
       if (!isTracked && _contactBehaviours.Count > 0) {
         _contactBehaviours.Clear();
+
+        // Also clear soft contact state if tracking is lost.
+        _softContactCollisions.Clear();
       }
 
       // Disable contact bone parent if we lose tracking.


### PR DESCRIPTION
Fixes #896.

With apologies to @AntEduard for the turnaround time; turns out the fix was simple, but it took a bit of investigation to find the simplest way to solve the issue.

- [x] Check example scenes don't throw any errors when interacting with objects while the hand loses tracking
- [x] Verify that holding your hand in soft contact mode inside an object and moving your head to lose tracking, then bringing you hand back into view, never gets the hand stuck in soft contact. (Turn on the Draw Controller Runtime Gizmos setting in the Interaction Manager; green colliders mean no soft-contact, white colliders mean soft-contact.)