### PR TITLE
Add ArrayToString() extension for T[]s

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/Utils/Utils.cs
+++ b/Assets/LeapMotion/Core/Scripts/Utils/Utils.cs
@@ -364,6 +364,28 @@ namespace Leap.Unity {
     }
     #endregion
 
+    #region Array Utils
+
+    /// <summary>
+    /// Prints the elements of an array in a bracket-enclosed, comma-delimited list,
+    /// prefixed by the elements' type.
+    /// </summary>
+    public static string ToArrayString<T>(this T[] arr) {
+      var str = "[" + typeof(T).Name + ": ";
+      for (int i = 0; i < arr.Length; i++) {
+        if (i == arr.Length - 1) {
+          str += arr[i];
+        }
+        else {
+          str += arr[i].ToString() + ", ";
+        }
+      }
+      str += "]";
+      return str;
+    }
+
+    #endregion
+
     #region Math Utils
 
     public static int Repeat(int x, int m) {

--- a/Assets/LeapMotion/Core/Scripts/Utils/Utils.cs
+++ b/Assets/LeapMotion/Core/Scripts/Utils/Utils.cs
@@ -364,23 +364,25 @@ namespace Leap.Unity {
     }
     #endregion
 
-    #region Array Utils
+    #region Print Utils
 
     /// <summary>
     /// Prints the elements of an array in a bracket-enclosed, comma-delimited list,
     /// prefixed by the elements' type.
     /// </summary>
-    public static string ToArrayString<T>(this T[] arr) {
+    public static string ToArrayString<T>(this IEnumerable<T> enumerable) {
       var str = "[" + typeof(T).Name + ": ";
-      for (int i = 0; i < arr.Length; i++) {
-        if (i == arr.Length - 1) {
-          str += arr[i];
+      bool addedFirstElement = false;
+      foreach (var t in enumerable) {
+        if (addedFirstElement) {
+          str += ", ";
         }
-        else {
-          str += arr[i].ToString() + ", ";
-        }
+        str += t.ToString();
+
+        addedFirstElement = true;
       }
       str += "]";
+
       return str;
     }
 


### PR DESCRIPTION
When testing the Shuffle PR I was kind of surprised we didn't have a quick debug method for printing the contents of an array in one line, so here you go.

There are of course a couple of ways to expand upon the utility of this, like supporting string formatting parameters for float arrays and Vector3 arrays, and also supporting Lists and the like. This one's just quick and simple for arrays.