### PR TITLE
Improve ImplementsInterface inspector experience

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/Attributes/CombinablePropertyAttribute.cs
+++ b/Assets/LeapMotion/Core/Scripts/Attributes/CombinablePropertyAttribute.cs
@@ -17,6 +17,8 @@ using System.Collections.Generic;
 
 namespace Leap.Unity.Attributes {
 
+  using UnityObject = UnityEngine.Object;
+
   public interface IPropertyConstrainer {
 #if UNITY_EDITOR
     void ConstrainValue(SerializedProperty property);
@@ -45,8 +47,8 @@ namespace Leap.Unity.Attributes {
   public interface ISupportDragAndDrop {
 #if UNITY_EDITOR
     Rect GetDropArea(Rect r, SerializedProperty property);
-    bool IsDropValid(UnityEngine.Object obj, SerializedProperty property);
-    void ProcessDroppedObject(UnityEngine.Object droppedObj, SerializedProperty property);
+    bool IsDropValid(UnityObject[] draggedObjects, SerializedProperty property);
+    void ProcessDroppedObjects(UnityObject[] droppedObjects, SerializedProperty property);
 #endif
   }
 
@@ -57,7 +59,7 @@ namespace Leap.Unity.Attributes {
 
   public abstract class CombinablePropertyAttribute : PropertyAttribute {
     public FieldInfo fieldInfo;
-    public UnityEngine.Object[] targets;
+    public UnityObject[] targets;
 
 #if UNITY_EDITOR
     public virtual IEnumerable<SerializedPropertyType> SupportedTypes {

--- a/Assets/LeapMotion/Core/Scripts/Attributes/CombinablePropertyAttribute.cs
+++ b/Assets/LeapMotion/Core/Scripts/Attributes/CombinablePropertyAttribute.cs
@@ -42,6 +42,14 @@ namespace Leap.Unity.Attributes {
 #endif
   }
 
+  public interface ISupportDragAndDrop {
+#if UNITY_EDITOR
+    Rect GetDropArea(Rect r, SerializedProperty property);
+    bool IsDropValid(UnityEngine.Object obj, SerializedProperty property);
+    void ProcessDroppedObject(UnityEngine.Object droppedObj, SerializedProperty property);
+#endif
+  }
+
   public interface IBeforeLabelAdditiveDrawer : IAdditiveDrawer { }
   public interface IAfterLabelAdditiveDrawer : IAdditiveDrawer { }
   public interface IBeforeFieldAdditiveDrawer : IAdditiveDrawer { }

--- a/Assets/LeapMotion/Core/Scripts/Attributes/Editor/CombinablePropertyDrawer.cs
+++ b/Assets/LeapMotion/Core/Scripts/Attributes/Editor/CombinablePropertyDrawer.cs
@@ -12,6 +12,7 @@ using UnityEditor;
 using System.Linq;
 using System.Reflection;
 using System.Collections.Generic;
+using Leap.Unity.Query;
 
 namespace Leap.Unity.Attributes {
 

--- a/Assets/LeapMotion/Core/Scripts/Attributes/Editor/CombinablePropertyDrawer.cs
+++ b/Assets/LeapMotion/Core/Scripts/Attributes/Editor/CombinablePropertyDrawer.cs
@@ -103,7 +103,7 @@ namespace Leap.Unity.Attributes {
       }
 
       Rect r = position;
-      
+
       if (dragAndDropSupport != null) {
         processDragAndDrop(dragAndDropSupport, ref r, property);
       }
@@ -148,6 +148,7 @@ namespace Leap.Unity.Attributes {
       drawAdditive<IAfterFieldAdditiveDrawer>(ref r, property);
 
       EditorGUI.EndDisabledGroup();
+
       bool didChange = EditorGUI.EndChangeCheck();
 
       if (didChange || !property.hasMultipleDifferentValues) {
@@ -184,16 +185,15 @@ namespace Leap.Unity.Attributes {
       Rect dropArea = dragAndDropSupport.GetDropArea(r, property);
 
       switch (curEvent.type) {
+        case EventType.Repaint:
         case EventType.DragUpdated:
         case EventType.DragPerform:
           if (!dropArea.Contains(curEvent.mousePosition, allowInverse: true)) {
             break;
           }
 
-          bool isValidDrop = DragAndDrop.objectReferences
-                                        .Query()
-                                        .All(o => dragAndDropSupport
-                                                    .IsDropValid(o, property));
+          bool isValidDrop = dragAndDropSupport.IsDropValid(
+                               DragAndDrop.objectReferences, property);
 
           if (isValidDrop) {
             DragAndDrop.visualMode = DragAndDropVisualMode.Link;
@@ -205,9 +205,8 @@ namespace Leap.Unity.Attributes {
           if (curEvent.type == EventType.DragPerform && isValidDrop) {
             DragAndDrop.AcceptDrag();
 
-            foreach (var draggedObj in DragAndDrop.objectReferences) {
-              dragAndDropSupport.ProcessDroppedObject(draggedObj, property);
-            }
+            dragAndDropSupport.ProcessDroppedObjects(
+                                 DragAndDrop.objectReferences, property);
           }
 
           break;

--- a/Assets/LeapMotion/Core/Scripts/Attributes/Editor/CombinablePropertyDrawer.cs
+++ b/Assets/LeapMotion/Core/Scripts/Attributes/Editor/CombinablePropertyDrawer.cs
@@ -54,6 +54,8 @@ namespace Leap.Unity.Attributes {
 
       RangeAttribute rangeAttribute = fieldInfo.GetCustomAttributes(typeof(RangeAttribute), true).FirstOrDefault() as RangeAttribute;
 
+      ISupportDragAndDrop dragAndDropSupport = null;
+
       IFullPropertyDrawer fullPropertyDrawer = null;
       foreach (var a in attributes) {
         a.fieldInfo = fieldInfo;
@@ -88,6 +90,10 @@ namespace Leap.Unity.Attributes {
           }
           fullPropertyDrawer = a as IFullPropertyDrawer;
         }
+
+        if (a is ISupportDragAndDrop) {
+          dragAndDropSupport = (a as ISupportDragAndDrop);
+        }
       }
 
       if (fullPropertyDrawer != null && !canUseDefaultDrawer) {
@@ -96,6 +102,11 @@ namespace Leap.Unity.Attributes {
       }
 
       Rect r = position;
+      
+      if (dragAndDropSupport != null) {
+        processDragAndDrop(dragAndDropSupport, ref r, property);
+      }
+
       EditorGUI.BeginChangeCheck();
       EditorGUI.BeginDisabledGroup(shouldDisable);
 
@@ -163,6 +174,42 @@ namespace Leap.Unity.Attributes {
           t.Draw(r, property);
           r.x += r.width;
         }
+      }
+    }
+
+    private void processDragAndDrop(ISupportDragAndDrop dragAndDropSupport,
+                                    ref Rect r, SerializedProperty property) {
+      Event curEvent = Event.current;
+      Rect dropArea = dragAndDropSupport.GetDropArea(r, property);
+
+      switch (curEvent.type) {
+        case EventType.DragUpdated:
+        case EventType.DragPerform:
+          if (!dropArea.Contains(curEvent.mousePosition, allowInverse: true)) {
+            break;
+          }
+
+          bool isValidDrop = DragAndDrop.objectReferences
+                                        .Query()
+                                        .All(o => dragAndDropSupport
+                                                    .IsDropValid(o, property));
+
+          if (isValidDrop) {
+            DragAndDrop.visualMode = DragAndDropVisualMode.Link;
+          }
+          else {
+            DragAndDrop.visualMode = DragAndDropVisualMode.Rejected;
+          }
+
+          if (curEvent.type == EventType.DragPerform && isValidDrop) {
+            DragAndDrop.AcceptDrag();
+
+            foreach (var draggedObj in DragAndDrop.objectReferences) {
+              dragAndDropSupport.ProcessDroppedObject(draggedObj, property);
+            }
+          }
+
+          break;
       }
     }
   }

--- a/Assets/LeapMotion/Core/Scripts/Attributes/ImplementsInterface.cs
+++ b/Assets/LeapMotion/Core/Scripts/Attributes/ImplementsInterface.cs
@@ -21,7 +21,9 @@ using UnityObject = UnityEngine.Object;
 namespace Leap.Unity.Attributes {
 
   public class ImplementsInterfaceAttribute : CombinablePropertyAttribute,
-                                              IPropertyConstrainer {
+                                              IPropertyConstrainer,
+                                              IFullPropertyDrawer,
+                                              ISupportDragAndDrop {
 
 #pragma warning disable 0414
     private Type type;
@@ -37,36 +39,75 @@ namespace Leap.Unity.Attributes {
 #if UNITY_EDITOR
     public void ConstrainValue(SerializedProperty property) {
       if (property.objectReferenceValue != null) {
-        var objectReferenceValue = property.objectReferenceValue;
 
-        if (objectReferenceValue.GetType().ImplementsInterface(type)) {
-          // All good! This object reference implements the interface.
-          return;
+        UnityObject implementingObject = FindImplementer(property.objectReferenceValue);
+
+        if (implementingObject == null) {
+          Debug.LogError(property.objectReferenceValue.GetType().Name + " does not implement " + type.Name);
         }
+
+        property.objectReferenceValue = implementingObject;
+      }
+    }
+
+    /// <summary>
+    /// Checks if the object or one of its associated GameObject components implements
+    /// the interface that this attribute constrains objects to, and returns the object
+    /// that implements that interface, or null if none was found.
+    /// </summary>
+    public UnityObject FindImplementer(UnityObject obj) {
+      if (obj.GetType().ImplementsInterface(type)) {
+        // All good! This object reference implements the interface.
+        return obj;
+      }
+      else {
+        UnityObject implementingObject;
+
+        if (obj is Component) {
+          // If the object is a Component, first search the rest of the GameObject 
+          // for a component that implements the interface. If found, assign it instead,
+          // otherwise null out the property.
+          implementingObject = (obj as Component)
+                               .GetComponents<Component>()
+                               .Query()
+                               .Where(c => c.GetType().ImplementsInterface(type))
+                               .FirstOrDefault();
+        } 
         else {
-          UnityObject implementingObject;
-
-          if (objectReferenceValue is Component) {
-            // If the object is a Component, first search the rest of the GameObject 
-            // for a component that implements the interface. If found, assign it instead,
-            // otherwise null out the property.
-            implementingObject = (objectReferenceValue as Component)
-                                 .GetComponents<Component>()
-                                 .Query()
-                                 .Where(c => c.GetType().ImplementsInterface(type))
-                                 .FirstOrDefault();
-          } 
-          else {
-            // If the object is not a Component, just null out the property.
-            implementingObject = null;
-          }
-
-          if (implementingObject == null) {
-            Debug.LogError(property.objectReferenceValue.GetType().Name + " does not implement " + type.Name);
-          }
-
-          property.objectReferenceValue = implementingObject;
+          // If the object is not a Component, just null out the property.
+          implementingObject = null;
         }
+
+        return implementingObject;
+      }
+    }
+
+    public void DrawProperty(Rect rect, SerializedProperty property, GUIContent label) {
+      if (property.objectReferenceValue != null) {
+        EditorGUI.ObjectField(rect, property, type, label);
+      }
+      else {
+        EditorGUI.ObjectField(rect, label, null, type, false);
+      }
+    }
+
+    public Rect GetDropArea(Rect rect, SerializedProperty property) {
+      return rect;
+    }
+
+    public bool IsDropValid(UnityEngine.Object obj, SerializedProperty property) {
+      return FindImplementer(obj) != null;
+    }
+
+    public void ProcessDroppedObject(UnityEngine.Object droppedObj, SerializedProperty property) {
+      var implementer = FindImplementer(droppedObj);
+
+      if (implementer == null) {
+        Debug.LogError(property.objectReferenceValue.GetType().Name
+                       + " does not implement " + type.Name);
+      }
+      else {
+        property.objectReferenceValue = implementer;
       }
     }
 

--- a/Assets/LeapMotion/Core/Scripts/Attributes/ImplementsInterface.cs
+++ b/Assets/LeapMotion/Core/Scripts/Attributes/ImplementsInterface.cs
@@ -63,6 +63,10 @@ namespace Leap.Unity.Attributes {
       else {
         UnityObject implementingObject;
 
+        if (obj is GameObject) {
+          obj = (obj as GameObject).transform;
+        }
+
         if (obj is Component) {
           // If the object is a Component, first search the rest of the GameObject 
           // for a component that implements the interface. If found, assign it instead,
@@ -95,11 +99,11 @@ namespace Leap.Unity.Attributes {
       return rect;
     }
 
-    public bool IsDropValid(UnityEngine.Object obj, SerializedProperty property) {
+    public bool IsDropValid(UnityObject obj, SerializedProperty property) {
       return FindImplementer(obj) != null;
     }
 
-    public void ProcessDroppedObject(UnityEngine.Object droppedObj, SerializedProperty property) {
+    public void ProcessDroppedObject(UnityObject droppedObj, SerializedProperty property) {
       var implementer = FindImplementer(droppedObj);
 
       if (implementer == null) {


### PR DESCRIPTION
- [x] Now the object field for a MonoBehaviour marked "ImplementsInterface" will display the name of the interface that needs to be satisfied in the field type, as opposed to "MonoBehaviour."

- [x] ISupportDragAndDrop is now an combinable property drawer attribute. This allows you to do things when the user tries to drag and drop things into your drawn property's box.

- [x] You will get an "invalid" cursor when you try to drag an ineligible object into an ImplementsInterface property that doesn't implement the interface.

- [x] Make sure ScriptableObject support isn't broken.