### PR TITLE
Generic enum helper

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/Utils/Enum.cs
+++ b/Assets/LeapMotion/Core/Scripts/Utils/Enum.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+public static class Enum<T> {
+  public static readonly string[] names;
+  public static readonly T[] values;
+
+  static Enum() {
+    names = (string[])Enum.GetNames(typeof(T));
+    values = (T[])Enum.GetValues(typeof(T));
+  }
+}

--- a/Assets/LeapMotion/Core/Scripts/Utils/Enum.cs
+++ b/Assets/LeapMotion/Core/Scripts/Utils/Enum.cs
@@ -1,11 +1,14 @@
 ﻿using System;
 
-public static class Enum<T> {
-  public static readonly string[] names;
-  public static readonly T[] values;
+namespace Leap.Unity {
 
-  static Enum() {
-    names = (string[])Enum.GetNames(typeof(T));
-    values = (T[])Enum.GetValues(typeof(T));
+  public static class Enum<T> {
+    public static readonly string[] names;
+    public static readonly T[] values;
+
+    static Enum() {
+      names = (string[])Enum.GetNames(typeof(T));
+      values = (T[])Enum.GetValues(typeof(T));
+    }
   }
 }

--- a/Assets/LeapMotion/Core/Scripts/Utils/Enum.cs.meta
+++ b/Assets/LeapMotion/Core/Scripts/Utils/Enum.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: f863a062dd00b274fbd6194bbbe8e2f9
+timeCreated: 1510942487
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
A teeny tiny helper class that lets you do 
`Enum<T>.names` instead of `(string[])Enum.GetNames(typeof(T))`.  
And 
`Enum<T>.values` instead of `(T[])Enum.GetValues(typeof(T))`.  
As a benefit, it also caches the results automatically, making this method much faster and allocation free after the first access!

To test:
 - [ ] Ensure properties return what you expect.