### PR TITLE
Minor IE performance improvements

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/DataStructures/Maybe.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/Maybe.cs
@@ -89,8 +89,12 @@ namespace Leap.Unity {
     /// will have a value.  If the value is null, this maybe will have no value.
     /// </summary>
     public Maybe(T t) {
-      hasValue = t != null;
-      _t = t;
+      using (new ProfilerSample("set hasValue")) {
+        hasValue = t != null;
+      }
+      using (new ProfilerSample("_t = t")) {
+        _t = t;
+      }
     }
 
     /// <summary>

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/Maybe.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/Maybe.cs
@@ -16,7 +16,7 @@ namespace Leap.Unity {
     public static readonly NoneType None = new NoneType();
 
     public static Maybe<T> Some<T>(T value) {
-      return Maybe<T>.Some(value);
+      return new Maybe<T>(value);
     }
 
     public static void MatchAll<A, B>(Maybe<A> maybeA, Maybe<B> maybeB, Action<A, B> action) {
@@ -65,7 +65,7 @@ namespace Leap.Unity {
     public readonly static Maybe<T> None = new Maybe<T>();
 
     /// <summary>
-    /// Returns whether or not this Maybe contains a value or not.
+    /// Returns whether or not this Maybe contains a value.
     /// </summary>
     public readonly bool hasValue;
 
@@ -85,24 +85,27 @@ namespace Leap.Unity {
     private readonly T _t;
 
     /// <summary>
-    /// Constructs a Maybe given a value.  If the value is non-null, this maybe
-    /// will have a value.  If the value is null, this maybe will have no value.
+    /// Constructs a Maybe given a value. If the value is not null, this maybe will have
+    /// a value. If the value is null, this maybe will have no value. For value types,
+    /// the Maybe struct will always have a value. (Use Maybe.None to refer to "no value.")
     /// </summary>
     public Maybe(T t) {
-      using (new ProfilerSample("set hasValue")) {
+      if (Type<T>.isValueType) {
+        hasValue = true;
+      }
+      else {
         hasValue = t != null;
       }
-      using (new ProfilerSample("_t = t")) {
-        _t = t;
-      }
+
+      _t = t;
     }
 
     /// <summary>
-    /// Constructs a Maybe given a specific value.  This value needs to always be
-    /// non-null.
+    /// Constructs a Maybe given a specific value. This value needs to always be
+    /// non-null if the type is a reference type.
     /// </summary>
     public static Maybe<T> Some(T t) {
-      if (t == null) {
+      if (Type<T>.isValueType && t == null) {
         throw new ArgumentNullException("Cannot use Some with a null argument.");
       }
 

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/Maybe.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/Maybe.cs
@@ -105,7 +105,7 @@ namespace Leap.Unity {
     /// non-null if the type is a reference type.
     /// </summary>
     public static Maybe<T> Some(T t) {
-      if (Type<T>.isValueType && t == null) {
+      if (!Type<T>.isValueType && t == null) {
         throw new ArgumentNullException("Cannot use Some with a null argument.");
       }
 

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/Pose.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/Pose.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 
 namespace Leap.Unity {
 
@@ -7,7 +8,7 @@ namespace Leap.Unity {
   /// multiplication, but Poses always have unit scale.
   /// </summary>
   [System.Serializable]
-  public struct Pose {
+  public struct Pose : IEquatable<Pose> {
 
     public Vector3    position;
     public Quaternion rotation;

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/Type.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/Type.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Leap.Unity {
+
+  public static class Type<T> {
+    public static readonly bool isValueType;
+
+    static Type() {
+      isValueType = typeof(T).IsValueType;
+    }
+  }
+
+}

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/Type.cs.meta
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/Type.cs.meta
@@ -1,0 +1,13 @@
+fileFormatVersion: 2
+guid: 7945555ee9403b245a649495d9b2c2a1
+timeCreated: 1511228773
+licenseType: Free
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionBehaviour.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionBehaviour.cs
@@ -811,62 +811,9 @@ namespace Leap.Unity.Interaction {
     public void FixedUpdateObject() {
       if (!ignoreGrasping) fixedUpdateGrasping();
       fixedUpdateLayers();
-      fixedUpdatePose();
 
       if (_appliedForces) { FixedUpdateForces(); }
     }
-
-    #region Pose & Movement
-
-    private Pose _worldPose;
-    private Maybe<Pose> _worldPoseLastFrame = Maybe.None;
-    private bool _recordLastPose = false;
-    private int _framesSinceLastDeltaPoseRequest = 0;
-    private const int DELTA_POSE_FRAMES_TIMEOUT = 20;
-
-    public Pose worldPose {
-      get {
-        return new Pose(rigidbody.position, rigidbody.rotation);
-      }
-    }
-
-    public Pose worldDeltaPose {
-      get {
-        if (!_recordLastPose) _recordLastPose = true;
-        _framesSinceLastDeltaPoseRequest = 0;
-
-        if (!_worldPoseLastFrame.hasValue) return Pose.identity;
-        else {
-          return worldPose.From(_worldPoseLastFrame.valueOrDefault);
-        }
-      }
-    }
-
-    private void fixedUpdatePose() {
-      using (new ProfilerSample("InteractionBehaviour: fixedUpdatePose")) {
-        if (!_recordLastPose) { return; }
-        else {
-          if (_framesSinceLastDeltaPoseRequest >= DELTA_POSE_FRAMES_TIMEOUT) {
-            _recordLastPose = false;
-            _worldPoseLastFrame = Maybe.None;
-            return;
-          }
-          else {
-            using (new ProfilerSample("InteractionBehaviour: set _worldPoseLastFrame")) {
-              _worldPoseLastFrame = _worldPose;
-            }
-
-            using (new ProfilerSample("InteractionBehaviour: set _worldPose with new Pose")) {
-              _worldPose = new Pose(rigidbody.position, rigidbody.rotation);
-            }
-          }
-
-          _framesSinceLastDeltaPoseRequest += 1;
-        }
-      }
-    }
-
-    #endregion
 
     #region Hovering
 

--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionController.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionController.cs
@@ -1024,51 +1024,64 @@ namespace Leap.Unity.Interaction {
 
       // Set a fixed rotation for bones; otherwise most friction is lost
       // as any capsule or spherical bones will roll on contact.
-      body.MoveRotation(targetRotation);
+      using (new ProfilerSample("updateContactBone: MoveRotation")) {
+        body.MoveRotation(targetRotation);
+      }
 
       // Calculate how far off its target the contact bone is.
-      Vector3 lastTargetPositionTransformedAhead = contactBone.lastTargetPosition;
-      if (manager.hasMovingFrameOfReference) {
-        manager.TransformAheadByFixedUpdate(contactBone.lastTargetPosition, out lastTargetPositionTransformedAhead);
+      float errorDistance = 0f;
+      float errorFraction = 0f;
+      using (new ProfilerSample("updateContactBone: errorDistance, errorFraction")) {
+        Vector3 lastTargetPositionTransformedAhead = contactBone.lastTargetPosition;
+        if (manager.hasMovingFrameOfReference) {
+          manager.TransformAheadByFixedUpdate(contactBone.lastTargetPosition, out lastTargetPositionTransformedAhead);
+        }
+        errorDistance = Vector3.Distance(lastTargetPositionTransformedAhead, body.position);
+        errorFraction = errorDistance / contactBone.width;
       }
-      float errorDistance = Vector3.Distance(lastTargetPositionTransformedAhead, body.position);
-      float errorFraction = errorDistance / contactBone.width;
 
       // Adjust the mass of the contact bone based on the mass of
       // the object it is currently touching.
-      float speed = velocity.magnitude;
-      float massScale = Mathf.Clamp(1.0F - (errorFraction * 2.0F), 0.1F, 1.0F)
+      float speed = 0f;
+      using (new ProfilerSample("updateContactBone: speed & massScale")) {
+        speed = velocity.magnitude;
+        float massScale = Mathf.Clamp(1.0F - (errorFraction * 2.0F), 0.1F, 1.0F)
                       * Mathf.Clamp(speed * 10F, 1F, 10F);
-      body.mass = massScale * contactBone._lastObjectTouchedAdjustedMass;
+        body.mass = massScale * contactBone._lastObjectTouchedAdjustedMass;
+      }
 
       // Potentially enable Soft Contact if our error is too large.
-      if (!_softContactEnabled && errorDistance >= softContactDislocationDistance
+      using (new ProfilerSample("updateContactBone: maybe enable Soft Contact")) {
+        if (!_softContactEnabled && errorDistance >= softContactDislocationDistance
           && speed < 1.5F
        /* && boneArrayIndex != NUM_FINGERS * BONES_PER_FINGER */) {
-         EnableSoftContact();
+          EnableSoftContact();
+        }
       }
 
       // Attempt to move the contact bone to its target position and rotation
       // by setting its target velocity and angular velocity. Include a "deadzone"
       // for position to avoid tiny vibrations.
-      float deadzone = Mathf.Min(DEAD_ZONE_FRACTION * contactBone.width, 0.01F * scale);
-      Vector3 delta = (targetPosition - body.position);
-      float deltaMag = delta.magnitude;
-      if (deltaMag <= deadzone) {
-        body.velocity = Vector3.zero;
-        contactBone.lastTargetPosition = body.position;
-      }
-      else {
-        delta *= (deltaMag - deadzone) / deltaMag;
-        contactBone.lastTargetPosition = body.position + delta;
+      using (new ProfilerSample("updateContactBone: Move to target, with deadzone")) {
+        float deadzone = Mathf.Min(DEAD_ZONE_FRACTION * contactBone.width, 0.01F * scale);
+        Vector3 delta = (targetPosition - body.position);
+        float deltaMag = delta.magnitude;
+        if (deltaMag <= deadzone) {
+          body.velocity = Vector3.zero;
+          contactBone.lastTargetPosition = body.position;
+        }
+        else {
+          delta *= (deltaMag - deadzone) / deltaMag;
+          contactBone.lastTargetPosition = body.position + delta;
 
-        Vector3 targetVelocity = delta / Time.fixedDeltaTime;
-        float targetVelocityMag = targetVelocity.magnitude;
-        body.velocity = (targetVelocity / targetVelocityMag)
-                      * Mathf.Clamp(targetVelocityMag, 0F, 100F);
+          Vector3 targetVelocity = delta / Time.fixedDeltaTime;
+          float targetVelocityMag = targetVelocity.magnitude;
+          body.velocity = (targetVelocity / targetVelocityMag)
+                        * Mathf.Clamp(targetVelocityMag, 0F, 100F);
+        }
+        Quaternion deltaRot = targetRotation * Quaternion.Inverse(body.rotation);
+        body.angularVelocity = PhysicsUtility.ToAngularVelocity(deltaRot, Time.fixedDeltaTime);
       }
-      Quaternion deltaRot = targetRotation * Quaternion.Inverse(body.rotation);
-      body.angularVelocity = PhysicsUtility.ToAngularVelocity(deltaRot, Time.fixedDeltaTime);
     }
 
     #endregion

--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionHand.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionHand.cs
@@ -376,9 +376,11 @@ namespace Leap.Unity.Interaction {
     protected override void getColliderBoneTargetPositionRotation(int contactBoneIndex,
                                                                   out Vector3 targetPosition,
                                                                   out Quaternion targetRotation) {
-      _handContactBoneMapFunctions[contactBoneIndex](_unwarpedHandData,
-                                                     out targetPosition,
-                                                     out targetRotation);
+      using (new ProfilerSample("InteractionHand: getColliderBoneTargetPositionRotation")) {
+        _handContactBoneMapFunctions[contactBoneIndex](_unwarpedHandData,
+                                                       out targetPosition,
+                                                       out targetRotation);
+      }
     }
 
     protected override bool initContact() {

--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionManager.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionManager.cs
@@ -317,47 +317,51 @@ namespace Leap.Unity.Interaction {
       // (Will be re-set to its original value at the end of the update.)
       var preUpdateAutoSyncTransforms = Physics.autoSyncTransforms;
       Physics.autoSyncTransforms = false;
+      try {
 
-      refreshInteractionControllers();
+        refreshInteractionControllers();
 
 #if UNITY_EDITOR
-      if (!Application.isPlaying) return;
+        if (!Application.isPlaying) return;
 #endif
 
-      using (new ProfilerSample("Interaction Manager FixedUpdate", this.gameObject)) {
-        // Ensure scale information is up-to-date.
-        _scale = this.transform.lossyScale.x;
+        using (new ProfilerSample("Interaction Manager FixedUpdate", this.gameObject)) {
+          // Ensure scale information is up-to-date.
+          _scale = this.transform.lossyScale.x;
 
-        // Update each interaction controller (Leap hands or supported VR controllers).
-        fixedUpdateInteractionControllers();
+          // Update each interaction controller (Leap hands or supported VR controllers).
+          fixedUpdateInteractionControllers();
 
-        // Perform each interaction object's FixedUpdateObject.
-        using (new ProfilerSample("FixedUpdateObject per-InteractionBehaviour")) {
-          foreach (var interactionObj in _interactionObjects) {
-            interactionObj.FixedUpdateObject();
+          // Perform each interaction object's FixedUpdateObject.
+          using (new ProfilerSample("FixedUpdateObject per-InteractionBehaviour")) {
+            foreach (var interactionObj in _interactionObjects) {
+              interactionObj.FixedUpdateObject();
+            }
+          }
+
+          // Apply soft contacts from all controllers in a unified solve.
+          // (This will clear softContacts and originalVelocities as well.)
+          using (new ProfilerSample("Apply Soft Contacts")) {
+            if (_softContacts.Count > 0) {
+              PhysicsUtility.applySoftContacts(_softContacts, _softContactOriginalVelocities);
+            }
           }
         }
 
-        // Apply soft contacts from all controllers in a unified solve.
-        // (This will clear softContacts and originalVelocities as well.)
-        using (new ProfilerSample("Apply Soft Contacts")) {
-          if (_softContacts.Count > 0) {
-            PhysicsUtility.applySoftContacts(_softContacts, _softContactOriginalVelocities);
-          }
+        OnPostPhysicalUpdate();
+
+        updateMovingFrameOfReferenceSupport();
+
+        if (autoGenerateLayers) {
+          autoUpdateContactBoneLayerCollision();
         }
+
       }
-
-      OnPostPhysicalUpdate();
-
-      updateMovingFrameOfReferenceSupport();
-
-      if (autoGenerateLayers) {
-        autoUpdateContactBoneLayerCollision();
+      finally {
+        // Restore the autoSyncTransforms setting to whatever the user had it as before
+        // the Manager FixedUpdate.
+        Physics.autoSyncTransforms = preUpdateAutoSyncTransforms;
       }
-
-      // Restore the autoSyncTransforms setting to whatever the user had it as before
-      // the Manager FixedUpdate.
-      Physics.autoSyncTransforms = preUpdateAutoSyncTransforms;
     }
 
     void LateUpdate() {

--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionManager.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionManager.cs
@@ -267,6 +267,9 @@ namespace Leap.Unity.Interaction {
 
       if (!Application.isPlaying) return;
 
+      // Physics should only be synced once at the beginning of the physics simulation.
+      Physics.autoSyncTransforms = false;
+
       if (s_instance == null) s_instance = this;
 
       if (_autoGenerateLayers) {

--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionManager.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionManager.cs
@@ -267,9 +267,6 @@ namespace Leap.Unity.Interaction {
 
       if (!Application.isPlaying) return;
 
-      // Physics should only be synced once at the beginning of the physics simulation.
-      Physics.autoSyncTransforms = false;
-
       if (s_instance == null) s_instance = this;
 
       if (_autoGenerateLayers) {
@@ -316,6 +313,11 @@ namespace Leap.Unity.Interaction {
     void FixedUpdate() {
       OnPrePhysicalUpdate();
 
+      // Physics should only be synced once at the beginning of the physics simulation.
+      // (Will be re-set to its original value at the end of the update.)
+      var preUpdateAutoSyncTransforms = Physics.autoSyncTransforms;
+      Physics.autoSyncTransforms = false;
+
       refreshInteractionControllers();
 
 #if UNITY_EDITOR
@@ -352,6 +354,10 @@ namespace Leap.Unity.Interaction {
       if (autoGenerateLayers) {
         autoUpdateContactBoneLayerCollision();
       }
+
+      // Restore the autoSyncTransforms setting to whatever the user had it as before
+      // the Manager FixedUpdate.
+      Physics.autoSyncTransforms = preUpdateAutoSyncTransforms;
     }
 
     void LateUpdate() {


### PR DESCRIPTION
This PR:

- [x] `autoSyncTransforms` is set to false in `InteractionManager.Start()`. We need to verify that this doesn't cause any problems in the example scenes, but it does totally remove the performance drops that the auto-syncing was incurring.
- [x] Fixes garbage when constructing Maybe<T>s where T is a struct
- [x] Adds the IEquatable<Pose> interface implementation for Leap.Unity.Pose
- [x] Adds an optimization where we don't actually track the "pose last frame" on an InteractionBehaviour unless the application begins requesting that information for a given InteractionBehaviour regularly (20-frame timeout). Pose-last-frame is intended to be helpful data, not wasteful data -- a single-frame delay is a small price to pay to avoid the extra processing overhead per-object.
- [x] Adds additional ProfilerSamples to make future IE profile runs contain more detailed information