### PR TITLE
Fix handpool serialization bug

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/HandPool.cs
+++ b/Assets/LeapMotion/Core/Scripts/HandPool.cs
@@ -12,6 +12,7 @@ using UnityEngine.Assertions;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine.Serialization;
+using System;
 #if UNITY_EDITOR
 using UnityEditor;
 #endif
@@ -61,10 +62,10 @@ namespace Leap.Unity {
       public IHandModel RightModel;
       [HideInInspector]
       public bool IsRightToBeSpawned;
-      [HideInInspector]
       public List<IHandModel> modelList = new List<IHandModel>();
-      [HideInInspector]
       public List<IHandModel> modelsCheckedOut = new List<IHandModel>();
+      [NonSerialized]
+      [NonSerialized]
       public bool IsEnabled = true;
       public bool CanDuplicate;
 

--- a/Assets/LeapMotion/Core/Scripts/HandPool.cs
+++ b/Assets/LeapMotion/Core/Scripts/HandPool.cs
@@ -62,10 +62,10 @@ namespace Leap.Unity {
       public IHandModel RightModel;
       [HideInInspector]
       public bool IsRightToBeSpawned;
+      [NonSerialized]
       public List<IHandModel> modelList = new List<IHandModel>();
+      [NonSerialized]
       public List<IHandModel> modelsCheckedOut = new List<IHandModel>();
-      [NonSerialized]
-      [NonSerialized]
       public bool IsEnabled = true;
       public bool CanDuplicate;
 
@@ -325,7 +325,7 @@ namespace Leap.Unity {
       }
     }
 
-    private bool shouldBeSpawned(Object model) {
+    private bool shouldBeSpawned(UnityEngine.Object model) {
       var prefabType = PrefabUtility.GetPrefabType(model);
       if (PrefabUtility.GetPrefabType(this) != PrefabType.Prefab) {
         return prefabType == PrefabType.Prefab;


### PR DESCRIPTION
This PR marks the `modelList` and `modelsCheckedOut` properties in HandGroups to NonSerialized to prevent them from getting serialized into a bad state at runtime.

To test:
- [x] Confirm that example scenes still work properly
- [x] Double-check that setting up a HandPool with new Hand Groups in a new scene still works as expected.