### PR TITLE
Fix BitConverter generator build

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/Utils/BitConverterNonAlloc.cs
+++ b/Assets/LeapMotion/Core/Scripts/Utils/BitConverterNonAlloc.cs
@@ -8,7 +8,6 @@
  ******************************************************************************/
 
 using System;
-using NUnit.Framework;
 
 namespace Leap.Unity {
 

--- a/Assets/LeapMotion/Generation/BitConverter/BitConverterTemplate.cs
+++ b/Assets/LeapMotion/Generation/BitConverter/BitConverterTemplate.cs
@@ -8,7 +8,6 @@
  ******************************************************************************/
 
 using System;
-using NUnit.Framework;
 
 namespace Leap.Unity.Generation {
 

--- a/Assets/LeapMotion/Generation/BitConverter/BitConverterTestsTemplate.cs
+++ b/Assets/LeapMotion/Generation/BitConverter/BitConverterTestsTemplate.cs
@@ -7,6 +7,8 @@
  * between Leap Motion and you, your company or other organization.           *
  ******************************************************************************/
 
+#if UNITY_EDITOR
+
 using System;
 using System.Linq;
 using System.Collections.Generic;
@@ -50,3 +52,5 @@ namespace Leap.Unity.Generation {
     //END
   }
 }
+
+#endif


### PR DESCRIPTION
This PR:

- [x] Removes an unused NUnit dependency in the BitConverter script
- [x] #ifdefs out the test script content in the BitConverter test script generator

These changes fix the build for develop.

To test:

- [x] Validate examples scenes work
- [x] Check the build
- [x] Go to the generator asset in the LeapMotion/Generation/BitConverter folder and click generate, make sure the files produced don't break compilation or the build
- [x] Use the Tests Runner window to verify that the BitConverter tests still pass