### PR TITLE
Fix extrapolation when in editor targeting android

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/LeapServiceProvider.cs
+++ b/Assets/LeapMotion/Core/Scripts/LeapServiceProvider.cs
@@ -68,7 +68,7 @@ namespace Leap.Unity {
     protected bool _useInterpolation = true;
 
     //Extrapolate on Android to compensate for the latency introduced by its graphics pipeline
-#if UNITY_ANDROID
+#if UNITY_ANDROID && !UNITY_EDITOR
     protected int ExtrapolationAmount = 15;
     protected int BounceAmount = 70;
 #else


### PR DESCRIPTION
Formerly the custom extrapolation/bounce values would be applied in the editor, as long as you were currently _targeting_ an android platform.  Now, the values only affect builds.

To test:
 - [ ] Verify that the custom values are _not_ used when in the editor and targeting android
 - [ ] Verify that the custom values _are_ used when building for an android device