### PR TITLE
Fixed typo in spline constructor

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/Animation/CubicHermiteSpline/HermiteSpline.cs
+++ b/Assets/LeapMotion/Core/Scripts/Animation/CubicHermiteSpline/HermiteSpline.cs
@@ -80,8 +80,8 @@ namespace Leap.Unity.Animation {
     /// velocities, and times of the endpoints.
     /// </summary>
     public HermiteSpline(float t0, float t1, float pos0, float pos1, float vel0, float vel1) {
-      this.t0 = 0;
-      this.t1 = 1;
+      this.t0 = t0;
+      this.t1 = t1;
 
       this.vel0 = vel0;
       this.vel1 = vel1;

--- a/Assets/LeapMotion/Core/Scripts/Animation/CubicHermiteSpline/HermiteSpline2.cs
+++ b/Assets/LeapMotion/Core/Scripts/Animation/CubicHermiteSpline/HermiteSpline2.cs
@@ -80,8 +80,8 @@ namespace Leap.Unity.Animation {
     /// velocities, and times of the endpoints.
     /// </summary>
     public HermiteSpline2(float t0, float t1, Vector2 pos0, Vector2 pos1, Vector2 vel0, Vector2 vel1) {
-      this.t0 = 0;
-      this.t1 = 1;
+      this.t0 = t0;
+      this.t1 = t1;
 
       this.vel0 = vel0;
       this.vel1 = vel1;

--- a/Assets/LeapMotion/Core/Scripts/Animation/CubicHermiteSpline/HermiteSpline3.cs
+++ b/Assets/LeapMotion/Core/Scripts/Animation/CubicHermiteSpline/HermiteSpline3.cs
@@ -80,8 +80,8 @@ namespace Leap.Unity.Animation {
     /// velocities, and times of the endpoints.
     /// </summary>
     public HermiteSpline3(float t0, float t1, Vector3 pos0, Vector3 pos1, Vector3 vel0, Vector3 vel1) {
-      this.t0 = 0;
-      this.t1 = 1;
+      this.t0 = t0;
+      this.t1 = t1;
 
       this.vel0 = vel0;
       this.vel1 = vel1;

--- a/Assets/LeapMotion/Generation/CHS/TemplateCHS.cs
+++ b/Assets/LeapMotion/Generation/CHS/TemplateCHS.cs
@@ -80,8 +80,8 @@ namespace Leap.Unity.Animation.Generation {
     /// velocities, and times of the endpoints.
     /// </summary>
     public __CHS__(float t0, float t1, __CHS_T__ pos0, __CHS_T__ pos1, __CHS_T__ vel0, __CHS_T__ vel1) {
-      this.t0 = 0;
-      this.t1 = 1;
+      this.t0 = t0;
+      this.t1 = t1;
 
       this.vel0 = vel0;
       this.vel1 = vel1;


### PR DESCRIPTION
Spline constructor was not using the t0/t1 values passed in by the constructor.