### PR TITLE
Adding provider field to the interaction hand

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/Utils/HandUtils.cs
+++ b/Assets/LeapMotion/Core/Scripts/Utils/HandUtils.cs
@@ -31,9 +31,16 @@ namespace Leap.Unity {
     private static void InitStaticOnNewScene(Scene unused, Scene unused2) {
       InitStatic();
     }
+
     private static void InitStatic() {
-      s_provider = GameObject.FindObjectOfType<LeapProvider>();
-      if (s_provider == null) return;
+      s_provider = Object.FindObjectOfType<LeapServiceProvider>();
+      if (s_provider == null) {
+        s_provider = Object.FindObjectOfType<LeapProvider>();
+        if (s_provider == null) {
+          return;
+        }
+      }
+
       Camera providerCamera = s_provider.GetComponentInParent<Camera>();
       if (providerCamera == null) return;
       if (providerCamera.transform.parent == null) return;

--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/Editor/InteractionHandEditor.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/Editor/InteractionHandEditor.cs
@@ -27,7 +27,14 @@ namespace Leap.Unity.Interaction {
       
       _handTex = EditorResources.Load<Texture2D>("HandTex");
 
+      hideField("_leapProvider");
+      specifyCustomDecorator("manager", drawProvider);
+
       specifyCustomDrawer("enabledPrimaryHoverFingertips", drawPrimaryHoverFingertipsEditor);
+    }
+
+    private void drawProvider(SerializedProperty p) {
+      EditorGUILayout.PropertyField(serializedObject.FindProperty("_leapProvider"));
     }
 
     private void drawPrimaryHoverFingertipsEditor(SerializedProperty property) {

--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/Editor/InteractionManagerEditor.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/Editor/InteractionManagerEditor.cs
@@ -172,7 +172,7 @@ namespace Leap.Unity.Interaction {
       }
 
       EditorGUILayout.BeginVertical();
-      
+
       _leftVRNodeController = null;
       _rightVRNodeController = null;
       foreach (var controller in target.interactionControllers) {

--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/Editor/InteractionManagerEditor.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/Editor/InteractionManagerEditor.cs
@@ -172,9 +172,7 @@ namespace Leap.Unity.Interaction {
       }
 
       EditorGUILayout.BeginVertical();
-
-      _leftHand = null;
-      _rightHand = null;
+      
       _leftVRNodeController = null;
       _rightVRNodeController = null;
       foreach (var controller in target.interactionControllers) {
@@ -284,8 +282,6 @@ namespace Leap.Unity.Interaction {
     }
 
     private LeapProvider _provider = null;
-    private InteractionHand _leftHand = null;
-    private InteractionHand _rightHand = null;
 
     private void checkInteractionHandStatus(InteractionHand intHand,
                                             List<ControllerStatusMessage> messages) {
@@ -320,20 +316,22 @@ namespace Leap.Unity.Interaction {
       }
 
       // Check if the player has multiple left hands or multiple right hands.
-      if (intHand.handDataMode == HandDataMode.PlayerLeft && _leftHand != null
-       || intHand.handDataMode == HandDataMode.PlayerRight && _rightHand != null) {
-        messages.Add(new ControllerStatusMessage() {
-          message = "Duplicate Hand",
-          tooltip = "You already have a hand with this data mode in your scene. "
-                  + "You should remove one of the duplicates.",
-          color = Colors.Problem
-        });
-      }
-      if (_leftHand == null && intHand.handDataMode == HandDataMode.PlayerLeft) {
-        _leftHand = intHand;
-      }
-      else if (_rightHand == null && intHand.handDataMode == HandDataMode.PlayerRight) {
-        _rightHand = intHand;
+      if (intHand.handDataMode != HandDataMode.Custom) {
+        int index = target.interactionControllers.Query().IndexOf(intHand);
+
+        if (target.interactionControllers.Query().
+                                          Take(index).
+                                          OfType<InteractionHand>().
+                                          Where(h => h.handDataMode == intHand.handDataMode).
+                                          Where(h => h.leapProvider == intHand.leapProvider).
+                                          Any()) {
+          messages.Add(new ControllerStatusMessage() {
+            message = "Duplicate Hand",
+            tooltip = "You already have a hand with this data mode in your scene. "
+                    + "You should remove one of the duplicates.",
+            color = Colors.Problem
+          });
+        }
       }
     }
 

--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionHand.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionHand.cs
@@ -180,6 +180,12 @@ namespace Leap.Unity.Interaction {
       }
     }
 
+    private void OnDestroy() {
+      if (_leapProvider != null) {
+        _leapProvider.OnFixedFrame -= onProviderFixedFrame;
+      }
+    }
+
     private void onProviderFixedFrame(Leap.Frame frame) {
       _hand = handAccessorFunc(frame);
 

--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionHand.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionHand.cs
@@ -27,6 +27,9 @@ namespace Leap.Unity.Interaction {
 
     #region Inspector
 
+    [SerializeField]
+    private LeapProvider _leapProvider;
+
     [Header("Hand Configuration")]
 
     [Tooltip("Should the data for the underlying Leap hand come from the player's left "
@@ -54,8 +57,6 @@ namespace Leap.Unity.Interaction {
     #endregion
 
     #region Hand Data
-
-    private LeapProvider _leapProvider;
     /// <summary>
     /// If the hand data mode for this InteractionHand is set to Custom, you must also
     /// manually specify the provider from which to retrieve Leap frames containing


### PR DESCRIPTION
 - InteractionHand now has a field where you can optionally specify the provider to use for this hand
 - InteractionHand will still automatically find a provider if none is specified (Hands.Provider is still used)
 - InteractionManager interface has been updated to allow duplicate hands as long as they use different providers
 - Hands.Provider has been tweaked to always prefer a ServiceProvider, but will still settle for a different kind of provider if it cannot find one.