### PR TITLE
Added struct constraints to the query wrapper

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/Query/Concat.cs
+++ b/Assets/LeapMotion/Core/Scripts/Query/Concat.cs
@@ -42,7 +42,7 @@ namespace Leap.Unity.Query {
     }
   }
 
-  public partial struct QueryWrapper<QueryType, QueryOp> where QueryOp : IQueryOp<QueryType> {
+  public partial struct QueryWrapper<QueryType, QueryOp> {
 
     /// <summary>
     /// Returns a new query operation representing the concatenation of the current query sequence to
@@ -54,7 +54,7 @@ namespace Leap.Unity.Query {
     ///   (A, B, C, D, E, F, G, H)
     /// </summary>
     public QueryWrapper<QueryType, ConcatOp<QueryType, QueryOp, SourceBOp>> Concat<SourceBOp>(QueryWrapper<QueryType, SourceBOp> sourceB)
-      where SourceBOp : IQueryOp<QueryType> {
+      where SourceBOp : struct, IQueryOp<QueryType> {
       return new QueryWrapper<QueryType, ConcatOp<QueryType, QueryOp, SourceBOp>>(new ConcatOp<QueryType, QueryOp, SourceBOp>(_op, sourceB._op));
     }
 

--- a/Assets/LeapMotion/Core/Scripts/Query/DirectQueryExtensions.cs
+++ b/Assets/LeapMotion/Core/Scripts/Query/DirectQueryExtensions.cs
@@ -22,78 +22,78 @@ namespace Leap.Unity.Query {
 
     public static QueryType Min<QueryType, QueryOp>(this QueryWrapper<QueryType, QueryOp> wrapper)
       where QueryType : IComparable<QueryType>
-      where QueryOp : IQueryOp<QueryType> {
+      where QueryOp : struct, IQueryOp<QueryType> {
       return wrapper.Fold((a, b) => a.CompareTo(b) < 0 ? a : b);
     }
 
     public static T Min<QueryType, QueryOp, T>(this QueryWrapper<QueryType, QueryOp> wrapper, Func<QueryType, T> selector)
       where T : IComparable<T>
-      where QueryOp : IQueryOp<QueryType> {
+      where QueryOp : struct, IQueryOp<QueryType> {
       return wrapper.Select(selector).Fold((a, b) => a.CompareTo(b) < 0 ? a : b);
     }
 
     public static QueryType Max<QueryType, QueryOp>(this QueryWrapper<QueryType, QueryOp> wrapper)
       where QueryType : IComparable<QueryType>
-      where QueryOp : IQueryOp<QueryType> {
+      where QueryOp : struct, IQueryOp<QueryType> {
       return wrapper.Fold((a, b) => a.CompareTo(b) > 0 ? a : b);
     }
 
     public static T Max<QueryType, QueryOp, T>(this QueryWrapper<QueryType, QueryOp> wrapper, Func<QueryType, T> selector)
       where T : IComparable<T>
-      where QueryOp : IQueryOp<QueryType> {
+      where QueryOp : struct, IQueryOp<QueryType> {
       return wrapper.Select(selector).Fold((a, b) => a.CompareTo(b) > 0 ? a : b);
     }
 
     public static QueryWrapper<byte, SelectOp<QueryType, byte, QueryOp>> ToBytes<QueryType, QueryOp>(this QueryWrapper<QueryType, QueryOp> wrapper)
-      where QueryOp : IQueryOp<QueryType>
+      where QueryOp : struct, IQueryOp<QueryType>
       where QueryType : IConvertible {
       return wrapper.Select(FormatHelper<QueryType>.toByte);
     }
 
     public static QueryWrapper<ushort, SelectOp<QueryType, ushort, QueryOp>> ToUShorts<QueryType, QueryOp>(this QueryWrapper<QueryType, QueryOp> wrapper)
-      where QueryOp : IQueryOp<QueryType>
+      where QueryOp : struct, IQueryOp<QueryType>
       where QueryType : IConvertible {
       return wrapper.Select(FormatHelper<QueryType>.toUShort);
     }
 
     public static QueryWrapper<short, SelectOp<QueryType, short, QueryOp>> ToShorts<QueryType, QueryOp>(this QueryWrapper<QueryType, QueryOp> wrapper)
-      where QueryOp : IQueryOp<QueryType>
+      where QueryOp : struct, IQueryOp<QueryType>
       where QueryType : IConvertible {
       return wrapper.Select(FormatHelper<QueryType>.toShort);
     }
 
     public static QueryWrapper<uint, SelectOp<QueryType, uint, QueryOp>> ToUInts<QueryType, QueryOp>(this QueryWrapper<QueryType, QueryOp> wrapper)
-      where QueryOp : IQueryOp<QueryType>
+      where QueryOp : struct, IQueryOp<QueryType>
       where QueryType : IConvertible {
       return wrapper.Select(FormatHelper<QueryType>.toUInt);
     }
 
     public static QueryWrapper<int, SelectOp<QueryType, int, QueryOp>> ToInts<QueryType, QueryOp>(this QueryWrapper<QueryType, QueryOp> wrapper)
-      where QueryOp : IQueryOp<QueryType>
+      where QueryOp : struct, IQueryOp<QueryType>
       where QueryType : IConvertible {
       return wrapper.Select(FormatHelper<QueryType>.toInt);
     }
 
     public static QueryWrapper<ulong, SelectOp<QueryType, ulong, QueryOp>> ToULong<QueryType, QueryOp>(this QueryWrapper<QueryType, QueryOp> wrapper)
-      where QueryOp : IQueryOp<QueryType>
+      where QueryOp : struct, IQueryOp<QueryType>
       where QueryType : IConvertible {
       return wrapper.Select(FormatHelper<QueryType>.toULong);
     }
 
     public static QueryWrapper<long, SelectOp<QueryType, long, QueryOp>> ToLongs<QueryType, QueryOp>(this QueryWrapper<QueryType, QueryOp> wrapper)
-      where QueryOp : IQueryOp<QueryType>
+      where QueryOp : struct, IQueryOp<QueryType>
       where QueryType : IConvertible {
       return wrapper.Select(FormatHelper<QueryType>.toLong);
     }
 
     public static QueryWrapper<float, SelectOp<QueryType, float, QueryOp>> ToFloats<QueryType, QueryOp>(this QueryWrapper<QueryType, QueryOp> wrapper)
-      where QueryOp : IQueryOp<QueryType>
+      where QueryOp : struct, IQueryOp<QueryType>
       where QueryType : IConvertible {
       return wrapper.Select(FormatHelper<QueryType>.toFloat);
     }
 
     public static QueryWrapper<double, SelectOp<QueryType, double, QueryOp>> ToDoubles<QueryType, QueryOp>(this QueryWrapper<QueryType, QueryOp> wrapper)
-      where QueryOp : IQueryOp<QueryType>
+      where QueryOp : struct, IQueryOp<QueryType>
       where QueryType : IConvertible {
       return wrapper.Select(FormatHelper<QueryType>.toDouble);
     }

--- a/Assets/LeapMotion/Core/Scripts/Query/DirectQueryOps.cs
+++ b/Assets/LeapMotion/Core/Scripts/Query/DirectQueryOps.cs
@@ -12,7 +12,7 @@ using System.Collections.Generic;
 
 namespace Leap.Unity.Query {
 
-  public partial struct QueryWrapper<QueryType, QueryOp> where QueryOp : IQueryOp<QueryType> {
+  public partial struct QueryWrapper<QueryType, QueryOp> {
 
     /// <summary>
     /// Returns true if all elements in the sequence satisfy the predicate.

--- a/Assets/LeapMotion/Core/Scripts/Query/OfType.cs
+++ b/Assets/LeapMotion/Core/Scripts/Query/OfType.cs
@@ -40,7 +40,7 @@ namespace Leap.Unity.Query {
     }
   }
 
-  public partial struct QueryWrapper<QueryType, QueryOp> where QueryOp : IQueryOp<QueryType> {
+  public partial struct QueryWrapper<QueryType, QueryOp> {
 
     /// <summary>
     /// Returns a new query operation representing only the items of the current sequence that

--- a/Assets/LeapMotion/Core/Scripts/Query/QueryWrapper.cs
+++ b/Assets/LeapMotion/Core/Scripts/Query/QueryWrapper.cs
@@ -95,7 +95,10 @@ namespace Leap.Unity.Query {
 
   /// <summary>
   /// The interface all query operations must follow.  It is a modified version of the 
-  /// IEnumerator interface, optimized for speed and conciseness.
+  /// IEnumerator interface, optimized for speed and conciseness.  It uses a single
+  /// TryGetNext method with an out param instead of a single MoveNext method with a
+  /// current getter.  By combining these two concepts into a single method we can get
+  /// a roughly 2x speedup compared to using IEnumerator.
   /// </summary>
   public interface IQueryOp<T> {
 

--- a/Assets/LeapMotion/Core/Scripts/Query/QueryWrapper.cs
+++ b/Assets/LeapMotion/Core/Scripts/Query/QueryWrapper.cs
@@ -25,7 +25,7 @@ namespace Leap.Unity.Query {
   ///
   /// myList.Query().Where(someCondition).First();
   /// </summary>
-  public partial struct QueryWrapper<QueryType, QueryOp> where QueryOp : IQueryOp<QueryType> {
+  public partial struct QueryWrapper<QueryType, QueryOp> where QueryOp : struct, IQueryOp<QueryType> {
     private QueryOp _op;
 
     /// <summary>

--- a/Assets/LeapMotion/Core/Scripts/Query/QueryWrapper.cs
+++ b/Assets/LeapMotion/Core/Scripts/Query/QueryWrapper.cs
@@ -99,6 +99,10 @@ namespace Leap.Unity.Query {
   /// TryGetNext method with an out param instead of a single MoveNext method with a
   /// current getter.  By combining these two concepts into a single method we can get
   /// a roughly 2x speedup compared to using IEnumerator.
+  /// 
+  /// Sequences must be deterministic!  Any randomization must be seeded so that a given
+  /// query op will always return the same sequence, otherwise undefined behavior will
+  /// occur.
   /// </summary>
   public interface IQueryOp<T> {
 

--- a/Assets/LeapMotion/Core/Scripts/Query/QueryWrapper.cs
+++ b/Assets/LeapMotion/Core/Scripts/Query/QueryWrapper.cs
@@ -94,11 +94,14 @@ namespace Leap.Unity.Query {
   }
 
   /// <summary>
-  /// The interface all query operations must follow.  It is a modified version of the 
-  /// IEnumerator interface, optimized for speed and conciseness.  It uses a single
-  /// TryGetNext method with an out param instead of a single MoveNext method with a
-  /// current getter.  By combining these two concepts into a single method we can get
-  /// a roughly 2x speedup compared to using IEnumerator.
+  /// The interface all query operations must follow.  Implementers of IQueryOp must be
+  /// non-nullable value types -- i.e., structs. If you attempt to construct a
+  /// QueryWrapper around a non-struct IQueryOp, you will get a compile error.
+  /// 
+  /// IQueryOp is a modified version of the IEnumerator interface, optimized for speed
+  /// and conciseness.  It uses a single TryGetNext method with an out param instead of
+  /// a single MoveNext method with a current getter.  By combining these two concepts
+  /// into a single method we can get a roughly 2x speedup compared to using IEnumerator.
   /// 
   /// Sequences must be deterministic!  Any randomization must be seeded so that a given
   /// query op will always return the same sequence, otherwise undefined behavior will

--- a/Assets/LeapMotion/Core/Scripts/Query/Repeat.cs
+++ b/Assets/LeapMotion/Core/Scripts/Query/Repeat.cs
@@ -50,7 +50,7 @@ namespace Leap.Unity.Query {
     }
   }
 
-  public partial struct QueryWrapper<QueryType, QueryOp> where QueryOp : IQueryOp<QueryType> {
+  public partial struct QueryWrapper<QueryType, QueryOp> {
 
     /// <summary>
     /// Returns a new query operation representing the current sequence repeated a number of

--- a/Assets/LeapMotion/Core/Scripts/Query/Select.cs
+++ b/Assets/LeapMotion/Core/Scripts/Query/Select.cs
@@ -37,7 +37,7 @@ namespace Leap.Unity.Query {
     }
   }
 
-  public partial struct QueryWrapper<QueryType, QueryOp> where QueryOp : IQueryOp<QueryType> {
+  public partial struct QueryWrapper<QueryType, QueryOp> {
 
     /// <summary>
     /// Returns a new query operation representing the current query sequence mapped element-by-element

--- a/Assets/LeapMotion/Core/Scripts/Query/SelectMany.cs
+++ b/Assets/LeapMotion/Core/Scripts/Query/SelectMany.cs
@@ -13,7 +13,7 @@ namespace Leap.Unity.Query {
 
   public struct SelectManyOp<SourceType, ResultType, SourceOp, ResultOp> : IQueryOp<ResultType>
     where SourceOp : IQueryOp<SourceType>
-    where ResultOp : IQueryOp<ResultType> {
+    where ResultOp : struct, IQueryOp<ResultType> {
 
     private SourceOp _source;
     private Func<SourceType, QueryWrapper<ResultType, ResultOp>> _selector;
@@ -66,7 +66,7 @@ namespace Leap.Unity.Query {
     }
   }
 
-  public partial struct QueryWrapper<QueryType, QueryOp> where QueryOp : IQueryOp<QueryType> {
+  public partial struct QueryWrapper<QueryType, QueryOp> {
 
     /// <summary>
     /// Returns a new query operation representing the current query sequence where each element has been
@@ -80,7 +80,7 @@ namespace Leap.Unity.Query {
     ///   ("1", "2", "2", "3", "3", "3", "4", "4", "4", "4")
     /// </summary>
     public QueryWrapper<NewType, SelectManyOp<QueryType, NewType, QueryOp, NewOp>> SelectMany<NewType, NewOp>(Func<QueryType, QueryWrapper<NewType, NewOp>> selector)
-      where NewOp : IQueryOp<NewType> {
+      where NewOp : struct, IQueryOp<NewType> {
       return new QueryWrapper<NewType, SelectManyOp<QueryType, NewType, QueryOp, NewOp>>(new SelectManyOp<QueryType, NewType, QueryOp, NewOp>(_op, selector));
     }
   }

--- a/Assets/LeapMotion/Core/Scripts/Query/SkipCount.cs
+++ b/Assets/LeapMotion/Core/Scripts/Query/SkipCount.cs
@@ -41,7 +41,7 @@ namespace Leap.Unity.Query {
     }
   }
 
-  public partial struct QueryWrapper<QueryType, QueryOp> where QueryOp : IQueryOp<QueryType> {
+  public partial struct QueryWrapper<QueryType, QueryOp> {
 
     /// <summary>
     /// Returns a new query operation representing the current query operation but without a

--- a/Assets/LeapMotion/Core/Scripts/Query/SkipWhile.cs
+++ b/Assets/LeapMotion/Core/Scripts/Query/SkipWhile.cs
@@ -46,7 +46,7 @@ namespace Leap.Unity.Query {
     }
   }
 
-  public partial struct QueryWrapper<QueryType, QueryOp> where QueryOp : IQueryOp<QueryType> {
+  public partial struct QueryWrapper<QueryType, QueryOp> {
 
     /// <summary>
     /// Returns a new query operation that skips values while the predicate returns true.  As soon

--- a/Assets/LeapMotion/Core/Scripts/Query/TakeCount.cs
+++ b/Assets/LeapMotion/Core/Scripts/Query/TakeCount.cs
@@ -37,7 +37,7 @@ namespace Leap.Unity.Query {
     }
   }
 
-  public partial struct QueryWrapper<QueryType, QueryOp> where QueryOp : IQueryOp<QueryType> {
+  public partial struct QueryWrapper<QueryType, QueryOp> {
 
     /// <summary>
     /// Returns a new query operation representing only the first few elements of the current sequence.

--- a/Assets/LeapMotion/Core/Scripts/Query/TakeWhile.cs
+++ b/Assets/LeapMotion/Core/Scripts/Query/TakeWhile.cs
@@ -47,7 +47,7 @@ namespace Leap.Unity.Query {
     }
   }
 
-  public partial struct QueryWrapper<QueryType, QueryOp> where QueryOp : IQueryOp<QueryType> {
+  public partial struct QueryWrapper<QueryType, QueryOp> {
 
     /// <summary>
     /// Returns a new query operation that takes values while the predicate returns true.  As soon

--- a/Assets/LeapMotion/Core/Scripts/Query/Where.cs
+++ b/Assets/LeapMotion/Core/Scripts/Query/Where.cs
@@ -37,7 +37,7 @@ namespace Leap.Unity.Query {
     }
   }
 
-  public partial struct QueryWrapper<QueryType, QueryOp> where QueryOp : IQueryOp<QueryType> {
+  public partial struct QueryWrapper<QueryType, QueryOp> {
 
     /// <summary>
     /// Returns a new query operation representing only the elements of the sequence for which

--- a/Assets/LeapMotion/Core/Scripts/Query/WithPrevious.cs
+++ b/Assets/LeapMotion/Core/Scripts/Query/WithPrevious.cs
@@ -72,7 +72,7 @@ namespace Leap.Unity.Query {
     }
   }
 
-  public partial struct QueryWrapper<QueryType, QueryOp> where QueryOp : IQueryOp<QueryType> {
+  public partial struct QueryWrapper<QueryType, QueryOp> {
 
     /// <summary>
     /// Returns a new query operation where each new element in the sequence is an instance of the PrevPair struct.

--- a/Assets/LeapMotion/Core/Scripts/Query/Zip.cs
+++ b/Assets/LeapMotion/Core/Scripts/Query/Zip.cs
@@ -43,7 +43,7 @@ namespace Leap.Unity.Query {
     }
   }
 
-  public partial struct QueryWrapper<QueryType, QueryOp> where QueryOp : IQueryOp<QueryType> {
+  public partial struct QueryWrapper<QueryType, QueryOp> {
 
     /// <summary>
     /// Returns a new query operation that represents the combination of this query sequence with another
@@ -58,7 +58,7 @@ namespace Leap.Unity.Query {
     ///   (AE, BF, CG, DH)
     /// </summary>
     public QueryWrapper<NewType, ZipOp<NewType, QueryType, OtherType, QueryOp, OtherOp>> Zip<NewType, OtherType, OtherOp>(QueryWrapper<OtherType, OtherOp> sourceB, Func<QueryType, OtherType, NewType> resultSelector)
-      where OtherOp : IQueryOp<OtherType> {
+      where OtherOp : struct, IQueryOp<OtherType> {
       return new QueryWrapper<NewType, ZipOp<NewType, QueryType, OtherType, QueryOp, OtherOp>>(new ZipOp<NewType, QueryType, OtherType, QueryOp, OtherOp>(_op, sourceB._op, resultSelector));
     }
   }


### PR DESCRIPTION
Query wrapper assumes that all ops are structs, but did not have the proper constraints to actually enforce this, leading to very strange behavior with some ops that took advantage of this assumption.  This PR adds in the required generic constraints to make sure that the query op generic param of the query wrapper is always a struct.

As a side note, the ops now refrain from declaring the generic constraint altogether, instead declaring no constraint.  This way if we ever need to change the constraint again it only needs to be changed in one place (the query wrapper)

To test: 
 - [ ] Make sure all tests still pass.
 - [ ] Try to construct a query wrapper with an interface or a class as the op param and verify it does not compile.