### PR TITLE
Upgrade camera hacks to use cameraType property

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/LeapXRServiceProvider.cs
+++ b/Assets/LeapMotion/Core/Scripts/LeapXRServiceProvider.cs
@@ -411,17 +411,13 @@ namespace Leap.Unity {
 
     protected void OnPreCullHandTransforms(Camera camera) {
       if (updateHandInPrecull) {
-        #if UNITY_EDITOR
-        //Hard-coded name of the camera used to generate the pre-render view
-        if (camera.gameObject.name == "PreRenderCamera") {
-          return;
+        //Don't update pre cull for preview, reflection, or scene view cameras
+        switch (camera.cameraType) {
+          case CameraType.Preview:
+          case CameraType.Reflection:
+          case CameraType.SceneView:
+            return;
         }
-
-        bool isScenePreviewCamera = camera.gameObject.hideFlags == HideFlags.HideAndDontSave;
-        if (isScenePreviewCamera) {
-          return;
-        }
-        #endif
 
         if (Application.isPlaying
             && !manualUpdateHasBeenCalledSinceUpdate

--- a/Assets/LeapMotion/Core/Scripts/LeapXRServiceProvider.cs
+++ b/Assets/LeapMotion/Core/Scripts/LeapXRServiceProvider.cs
@@ -414,7 +414,9 @@ namespace Leap.Unity {
         //Don't update pre cull for preview, reflection, or scene view cameras
         switch (camera.cameraType) {
           case CameraType.Preview:
+          #if UNITY_2017_1_OR_NEWER
           case CameraType.Reflection:
+          #endif
           case CameraType.SceneView:
             return;
         }

--- a/Assets/LeapMotion/Core/Scripts/Utils/RuntimeGizmoManager.cs
+++ b/Assets/LeapMotion/Core/Scripts/Utils/RuntimeGizmoManager.cs
@@ -175,7 +175,9 @@ namespace Leap.Unity.RuntimeGizmos {
       //Never draw preview or reflection
       switch (camera.cameraType) {
         case CameraType.Preview:
+#if UNITY_2017_1_OR_NEWER
         case CameraType.Reflection:
+#endif
           return;
         case CameraType.Game:
         case CameraType.VR:

--- a/Assets/LeapMotion/Core/Scripts/Utils/RuntimeGizmoManager.cs
+++ b/Assets/LeapMotion/Core/Scripts/Utils/RuntimeGizmoManager.cs
@@ -171,14 +171,18 @@ namespace Leap.Unity.RuntimeGizmos {
 
     protected void onPostRender(Camera camera) {
 #if UNITY_EDITOR
-      //Hard-coded name of the camera used to generate the pre-render view
-      if (camera.gameObject.name == "PreRenderCamera") {
-        return;
-      }
-
-      bool isSceneCamera = camera.gameObject.hideFlags == HideFlags.HideAndDontSave;
-      if (!isSceneCamera && !_displayInGameView) {
-        return;
+      //Always draw scene view
+      //Never draw preview or reflection
+      switch (camera.cameraType) {
+        case CameraType.Preview:
+        case CameraType.Reflection:
+          return;
+        case CameraType.Game:
+        case CameraType.VR:
+          if (!_displayInGameView) {
+            return;
+          }
+          break;
       }
 #endif
 


### PR DESCRIPTION
Before, we were using hacky logic to determine if a camera was a scene view camera, preview camera, ect...  But cameras actually have a handy cameraType property that can tell us without needing to guess!  Use this across our codebase wherever possible.

Fixes #943

To test:
 - [ ] Verify late latching still behaves properly
 - [ ] Verify runtime gizmos still behave properly