### PR TITLE
Switch HandModelBase to use edit time frames

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/Hands/HandModelBase.cs
+++ b/Assets/LeapMotion/Core/Scripts/Hands/HandModelBase.cs
@@ -62,18 +62,11 @@ namespace Leap.Unity {
 #if UNITY_EDITOR
     void Update() {
       if (!EditorApplication.isPlaying && SupportsEditorPersistence()) {
-        Transform editorPoseSpace;
-        LeapServiceProvider leapServiceProvider = FindObjectOfType<LeapServiceProvider>();
-        LeapTransform poseTransform = LeapTransform.Identity;
-        if (leapServiceProvider != null) {
-          editorPoseSpace = leapServiceProvider.transform;
-          poseTransform = TestHandFactory.GetTestPoseLeftHandTransform(leapServiceProvider.editTimePose);
-        } else {
-          editorPoseSpace = transform;
+        Hand hand = Handedness == Chirality.Left ? Hands.Left : Hands.Right;
+        if (hand == null) {
+          hand = TestHandFactory.MakeTestHand(Handedness == Chirality.Left, unitType: TestHandFactory.UnitType.LeapUnits);
+          hand.Transform(transform.GetLeapMatrix());
         }
-
-        Hand hand = TestHandFactory.MakeTestHand(Handedness == Chirality.Left, poseTransform)
-                                   .TransformedCopy(UnityMatrixExtension.GetLeapMatrix(editorPoseSpace));
 
         if (GetLeapHand() == null) {
           SetLeapHand(hand);


### PR DESCRIPTION
Now that a provider can provide actual edit time frames, this PR upgrades the HandModelBase to use those frames instead of constructing their own!  This simplifies the code as well as supporting edit time feedback when using the hierarchy recorder!

If there is no provider in the scene the hands will still be constructed on their own.

To test:
 - [x] Make sure that example scenes still function as expected in the editor (provider should control the pose of the hands)
 - [x] Make sure that a hand on it's own, when there is no provider in the scene, still renders correctly as expected
 - [x] Make sure this all works for both rigged hands and capsule hands