### PR TITLE
Fixed failing template tests

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/Utils/BitConverterNonAlloc.cs
+++ b/Assets/LeapMotion/Core/Scripts/Utils/BitConverterNonAlloc.cs
@@ -9,7 +9,7 @@
 
 using System;
 
-namespace Leap.Unity.Tests {
+namespace Leap.Unity {
 
   public class BitConverterNonAlloc {
 

--- a/Assets/LeapMotion/Core/Scripts/Utils/BitConverterNonAlloc.cs
+++ b/Assets/LeapMotion/Core/Scripts/Utils/BitConverterNonAlloc.cs
@@ -9,7 +9,7 @@
 
 using System;
 
-namespace Leap.Unity {
+namespace Leap.Unity.Tests {
 
   public class BitConverterNonAlloc {
 

--- a/Assets/LeapMotion/Core/Scripts/Utils/Editor/BitConverterNonAllocTests.cs
+++ b/Assets/LeapMotion/Core/Scripts/Utils/Editor/BitConverterNonAllocTests.cs
@@ -9,8 +9,6 @@
 
 using System;
 using System.Linq;
-using System.Collections.Generic;
-using UnityEngine;
 using NUnit.Framework;
 
 namespace Leap.Unity {

--- a/Assets/LeapMotion/Core/Scripts/Utils/Editor/BitConverterNonAllocTests.cs
+++ b/Assets/LeapMotion/Core/Scripts/Utils/Editor/BitConverterNonAllocTests.cs
@@ -11,7 +11,7 @@ using System;
 using System.Linq;
 using NUnit.Framework;
 
-namespace Leap.Unity.Tests {
+namespace Leap.Unity {
 
   public class BitConverterTests {
 

--- a/Assets/LeapMotion/Core/Scripts/Utils/Editor/BitConverterNonAllocTests.cs
+++ b/Assets/LeapMotion/Core/Scripts/Utils/Editor/BitConverterNonAllocTests.cs
@@ -11,7 +11,7 @@ using System;
 using System.Linq;
 using NUnit.Framework;
 
-namespace Leap.Unity {
+namespace Leap.Unity.Tests {
 
   public class BitConverterTests {
 

--- a/Assets/LeapMotion/Generation/BitConverter/BitConverterGenerator.cs
+++ b/Assets/LeapMotion/Generation/BitConverter/BitConverterGenerator.cs
@@ -22,6 +22,7 @@ namespace Leap.Unity.Generation {
     public const string END_KEY = "//END";
     public const string TEMPLATE_NAMESPACE = "Leap.Unity.Generation";
     public const string TARGET_NAMESPACE = "Leap.Unity.Tests";
+    public const string TEST_NAMESPACE = "Leap.Unity";
 
     public TextAsset codeTemplate;
     public TextAsset testTemplate;
@@ -32,11 +33,11 @@ namespace Leap.Unity.Generation {
     public string[] primitiveTypes;
 
     public override void Generate() {
-      replaceCenterCode(codeTemplate, targetFolder, "_Primitive_", "BitConverterNonAlloc.cs");
-      replaceCenterCode(testTemplate, testFolder, "Single", "BitConverterNonAllocTests.cs");
+      replaceCenterCode(codeTemplate, targetFolder, "_Primitive_", "BitConverterNonAlloc.cs", TARGET_NAMESPACE);
+      replaceCenterCode(testTemplate, testFolder, "Single", "BitConverterNonAllocTests.cs", TEST_NAMESPACE);
     }
 
-    private void replaceCenterCode(TextAsset template, AssetFolder folder, string toReplace, string filename) {
+    private void replaceCenterCode(TextAsset template, AssetFolder folder, string toReplace, string filename, string targetNamespace) {
       List<string> lines = new List<string>();
       using (var reader = new StringReader(template.text)) {
         while (true) {
@@ -45,7 +46,7 @@ namespace Leap.Unity.Generation {
             break;
           }
 
-          lines.Add(line.Replace(TEMPLATE_NAMESPACE, TARGET_NAMESPACE).
+          lines.Add(line.Replace(TEMPLATE_NAMESPACE, targetNamespace).
                          Replace("_Template_", "").
                          Replace("_BitConverterTestMock_", "BitConverterNonAlloc"));
         }

--- a/Assets/LeapMotion/Generation/BitConverter/BitConverterGenerator.cs
+++ b/Assets/LeapMotion/Generation/BitConverter/BitConverterGenerator.cs
@@ -21,7 +21,7 @@ namespace Leap.Unity.Generation {
     public const string BEGIN_KEY = "//BEGIN";
     public const string END_KEY = "//END";
     public const string TEMPLATE_NAMESPACE = "Leap.Unity.Generation";
-    public const string TARGET_NAMESPACE = "Leap.Unity";
+    public const string TARGET_NAMESPACE = "Leap.Unity.Tests";
 
     public TextAsset codeTemplate;
     public TextAsset testTemplate;

--- a/Assets/LeapMotion/Generation/BitConverter/BitConverterGenerator.cs
+++ b/Assets/LeapMotion/Generation/BitConverter/BitConverterGenerator.cs
@@ -73,7 +73,10 @@ namespace Leap.Unity.Generation {
         writer.Write(beforeCode);
 
         foreach (var primitiveType in primitiveTypes) {
-          writer.Write(codeTemplate.Replace(toReplace, primitiveType));
+          //Replace Single with the actual primitive
+          //Also uncomment the Test attribute
+          writer.Write(codeTemplate.Replace(toReplace, primitiveType).
+                                    Replace("//[Test]", "[Test]"));
         }
 
         writer.Write(afterCode);

--- a/Assets/LeapMotion/Generation/BitConverter/BitConverterGenerator.cs
+++ b/Assets/LeapMotion/Generation/BitConverter/BitConverterGenerator.cs
@@ -21,8 +21,8 @@ namespace Leap.Unity.Generation {
     public const string BEGIN_KEY = "//BEGIN";
     public const string END_KEY = "//END";
     public const string TEMPLATE_NAMESPACE = "Leap.Unity.Generation";
-    public const string TARGET_NAMESPACE = "Leap.Unity.Tests";
-    public const string TEST_NAMESPACE = "Leap.Unity";
+    public const string TARGET_NAMESPACE = "Leap.Unity";
+    public const string TEST_NAMESPACE = "Leap.Unity.Tests";
 
     public TextAsset codeTemplate;
     public TextAsset testTemplate;

--- a/Assets/LeapMotion/Generation/BitConverter/Editor/BitConverterTestsTemplate.cs
+++ b/Assets/LeapMotion/Generation/BitConverter/Editor/BitConverterTestsTemplate.cs
@@ -7,12 +7,8 @@
  * between Leap Motion and you, your company or other organization.           *
  ******************************************************************************/
 
-#if UNITY_EDITOR
-
 using System;
 using System.Linq;
-using System.Collections.Generic;
-using UnityEngine;
 using NUnit.Framework;
 
 namespace Leap.Unity.Generation {
@@ -30,7 +26,7 @@ namespace Leap.Unity.Generation {
     }
     //BEGIN
 
-    [Test]
+    //[Test]
     public void TestToSingle() {
       Single expected = BitConverter.ToSingle(_bytes, 0);
       Single actual = _BitConverterTestMock_.ToSingle(_bytes, 0);
@@ -38,7 +34,7 @@ namespace Leap.Unity.Generation {
       Assert.That(actual, Is.EqualTo(expected));
     }
 
-    [Test]
+    //[Test]
     public void TestFromSingle() {
       Single value = (Single)UnityEngine.Random.Range(float.MinValue, float.MaxValue);
       var actual = BitConverter.GetBytes(value);
@@ -52,5 +48,3 @@ namespace Leap.Unity.Generation {
     //END
   }
 }
-
-#endif

--- a/Assets/LeapMotion/Generation/Editor/GeneratorEditor.cs
+++ b/Assets/LeapMotion/Generation/Editor/GeneratorEditor.cs
@@ -26,6 +26,8 @@ namespace Leap.Unity.Generation {
           Debug.LogException(e);
         }
       }
+      AssetDatabase.Refresh();
+      AssetDatabase.SaveAssets();
     }
 
     protected override void OnEnable() {
@@ -41,6 +43,9 @@ namespace Leap.Unity.Generation {
         foreach (var target in targets) {
           target.Generate();
         }
+
+        AssetDatabase.Refresh();
+        AssetDatabase.SaveAssets();
       }
 
       base.OnInspectorGUI();


### PR DESCRIPTION
The template for the BitConverter tests was showing up in the test window!  They were of course failing because they are templates and not actual tests, so I tweaked the template/generation to have the tests commented out, and get activated during generation.

Also added a small tweak to make sure that the AssetDatabase is correctly refreshed after generation happens.

To test:
 - [x] Make sure BitConverter tests pass
 - [x] Make sure that the _template_ tests no longer show up in the test window
 - [x] Make sure generation does not change the files