### PR TITLE
Fixed handmodelbase provider hand logic

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/Hands/HandModelBase.cs
+++ b/Assets/LeapMotion/Core/Scripts/Hands/HandModelBase.cs
@@ -62,7 +62,26 @@ namespace Leap.Unity {
 #if UNITY_EDITOR
     void Update() {
       if (!EditorApplication.isPlaying && SupportsEditorPersistence()) {
-        Hand hand = Handedness == Chirality.Left ? Hands.Left : Hands.Right;
+        LeapProvider provider = null;
+
+        //First try to get the provider from a parent HandModelManager
+        if (transform.parent != null) {
+          var manager = transform.parent.GetComponent<HandModelManager>();
+          provider = manager.leapProvider;
+        }
+
+        //If not found, use any old provider from the Hands.Provider getter
+        if (provider == null) {
+          provider = Hands.Provider;
+        }
+
+        Hand hand = null;
+        //If we found a provider, pull the hand from that
+        if (provider != null) {
+          hand = provider.CurrentFrame.Get(Handedness);
+        }
+
+        //If we still have a null hand, construct one manually
         if (hand == null) {
           hand = TestHandFactory.MakeTestHand(Handedness == Chirality.Left, unitType: TestHandFactory.UnitType.LeapUnits);
           hand.Transform(transform.GetLeapMatrix());


### PR DESCRIPTION
Previous logic didn't work correctly in all situations.  Now, a HandModelBase has a list of things it tries in order to get the hand to display:

 - If a parent HandModelManager has a non-null provider, use that provider as a hand source
 - Else, use the Hands.Provider to try to get a hand of the correct handedness
 - Else, construct a hand from the test hand factory

To test:
 - [x] Visit an example scene duplicate the rig, observe that the duplicated hands now correctly bind to the new provider instead of the old one
 - [x] Visit an example scene and create a new service provider.  Change the HandModelManager to point to the new provider instead of the old, note that the hands correctly change to follow the new provider