### PR TITLE
Null check in handmodelbase for the frame

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/Hands/HandModelBase.cs
+++ b/Assets/LeapMotion/Core/Scripts/Hands/HandModelBase.cs
@@ -78,7 +78,11 @@ namespace Leap.Unity {
         Hand hand = null;
         //If we found a provider, pull the hand from that
         if (provider != null) {
-          hand = provider.CurrentFrame.Get(Handedness);
+          var frame = provider.CurrentFrame;
+
+          if (frame != null) {
+            hand = frame.Get(Handedness);
+          }
         }
 
         //If we still have a null hand, construct one manually


### PR DESCRIPTION
Added a simple null check so that HandModelBase still functions correctly if the example provider does not provide a frame at edit time.