### PR TITLE
Fix dictionary and hashset serializing

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/DataStructures/Editor/SerializableDictionaryEditor.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/Editor/SerializableDictionaryEditor.cs
@@ -14,7 +14,7 @@ using System.Collections.Generic;
 
 namespace Leap.Unity {
 
-  [CustomPropertyDrawer(typeof(SDictionaryAttribute))]
+  [CustomPropertyDrawer(typeof(SerializableDictionaryBase), useForChildren: true)]
   public class SerializableDictionaryEditor : PropertyDrawer {
 
     private ReorderableList _list;

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/Editor/SerializableHashSetEditor.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/Editor/SerializableHashSetEditor.cs
@@ -15,7 +15,7 @@ using UnityEditorInternal;
 
 namespace Leap.Unity {
 
-  [CustomPropertyDrawer(typeof(SHashSetAttribute))]
+  [CustomPropertyDrawer(typeof(SerializableHashSetBase), useForChildren: true)]
   public class SerializableHashSetEditor : PropertyDrawer {
 
     private ReorderableList _list;
@@ -131,7 +131,7 @@ namespace Leap.Unity {
 
     private void onAddCallback(ReorderableList list) {
       SerializedProperty values = _currProperty.FindPropertyRelative("_values");
-      
+
       values.arraySize++;
 
       updatePairsFromProperty(_currProperty);
@@ -139,7 +139,7 @@ namespace Leap.Unity {
 
     private void onRemoveCallback(ReorderableList list) {
       SerializedProperty values = _currProperty.FindPropertyRelative("_values");
-      
+
       actuallyDeleteAt(values, list.index);
 
       updatePairsFromProperty(_currProperty);

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/ReadonlyHashSet.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/ReadonlyHashSet.cs
@@ -41,5 +41,9 @@ namespace Leap.Unity {
     public static implicit operator ReadonlyHashSet<T>(HashSet<T> set) {
       return new ReadonlyHashSet<T>(set);
     }
+
+    public static implicit operator ReadonlyHashSet<T>(SerializableHashSet<T> set) {
+      return (HashSet<T>)set;
+    }
   }
 }

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/SerializableDictionary.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/SerializableDictionary.cs
@@ -44,13 +44,13 @@ namespace Leap.Unity {
                                                       ISerializableDictionary {
 
     [SerializeField]
-    private List<TKey> _keys;
+    private List<TKey> _keys = new List<TKey>();
 
     [SerializeField]
-    private List<TValue> _values;
+    private List<TValue> _values = new List<TValue>();
 
     [NonSerialized]
-    private Dictionary<TKey, TValue> _dictionary;
+    private Dictionary<TKey, TValue> _dictionary = new Dictionary<TKey, TValue>();
 
     #region DICTIONARY API
 

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/SerializableDictionary.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/SerializableDictionary.cs
@@ -8,17 +8,18 @@
  ******************************************************************************/
 
 using UnityEngine;
+using System;
 using System.Text;
 using System.Collections.Generic;
 using System.Linq;
+using System.Collections;
 
 namespace Leap.Unity {
 
-  /// <summary>
-  /// You must mark a serializable dictionary with this attribute in order to 
-  /// use the custom inspector editor.
-  /// </summary>
+  [Obsolete("It is no longer required to annotate SerializableDictionary with an SDictionary attribute")]
   public class SDictionaryAttribute : PropertyAttribute { }
+
+  public abstract class SerializableDictionaryBase { }
 
   public interface ICanReportDuplicateInformation {
 #if UNITY_EDITOR
@@ -36,16 +37,73 @@ namespace Leap.Unity {
   /// non-generic version specific to your needs.  This is the same workflow that exists
   /// for using the UnityEvent class as well. 
   /// </summary>
-  public class SerializableDictionary<TKey, TValue> : Dictionary<TKey, TValue>,
-    ICanReportDuplicateInformation,
-    ISerializationCallbackReceiver,
-    ISerializableDictionary {
+  public class SerializableDictionary<TKey, TValue> : SerializableDictionaryBase,
+                                                      IEnumerable<KeyValuePair<TKey, TValue>>,
+                                                      ICanReportDuplicateInformation,
+                                                      ISerializationCallbackReceiver,
+                                                      ISerializableDictionary {
 
     [SerializeField]
     private List<TKey> _keys;
 
     [SerializeField]
     private List<TValue> _values;
+
+    [NonSerialized]
+    private Dictionary<TKey, TValue> _dictionary;
+
+    #region DICTIONARY API
+
+    public TValue this[TKey key] {
+      get { return _dictionary[key]; }
+      set { _dictionary[key] = value; }
+    }
+
+    public Dictionary<TKey, TValue>.KeyCollection Keys {
+      get { return _dictionary.Keys; }
+    }
+
+    public Dictionary<TKey, TValue>.ValueCollection Values {
+      get { return _dictionary.Values; }
+    }
+
+    public int Count {
+      get { return _dictionary.Count; }
+    }
+
+    public void Add(TKey key, TValue value) {
+      _dictionary.Add(key, value);
+    }
+
+    public void Clear() {
+      _dictionary.Clear();
+    }
+
+    public bool ContainsKey(TKey key) {
+      return _dictionary.ContainsKey(key);
+    }
+
+    public bool ContainsValue(TValue value) {
+      return _dictionary.ContainsValue(value);
+    }
+
+    public bool Remove(TKey key) {
+      return _dictionary.Remove(key);
+    }
+
+    public bool TryGetValue(TKey key, out TValue value) {
+      return _dictionary.TryGetValue(key, out value);
+    }
+
+    public IEnumerator<KeyValuePair<TKey, TValue>> GetEnumerator() {
+      return _dictionary.GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() {
+      return _dictionary.GetEnumerator();
+    }
+
+    #endregion
 
     /// <summary>
     /// Returns how much of the display space should be allocated to the key.
@@ -57,8 +115,8 @@ namespace Leap.Unity {
 
     public override string ToString() {
       StringBuilder toReturn = new StringBuilder();
-      List<TKey> keys = Keys.ToList<TKey>();
-      List<TValue> values = Values.ToList<TValue>();
+      List<TKey> keys = _dictionary.Keys.ToList<TKey>();
+      List<TValue> values = _dictionary.Values.ToList<TValue>();
       toReturn.Append("[");
       for (int i = 0; i < keys.Count; i++) {
         toReturn.Append("{");
@@ -73,7 +131,7 @@ namespace Leap.Unity {
     }
 
     public void OnAfterDeserialize() {
-      Clear();
+      _dictionary.Clear();
 
       if (_keys != null && _values != null) {
         int count = Mathf.Min(_keys.Count, _values.Count);
@@ -85,7 +143,7 @@ namespace Leap.Unity {
             continue;
           }
 
-          this[key] = value;
+          _dictionary[key] = value;
         }
       }
 
@@ -154,14 +212,14 @@ namespace Leap.Unity {
         TKey key = _keys[i];
         if (key == null) continue;
 
-        if (!ContainsKey(key)) {
+        if (!_dictionary.ContainsKey(key)) {
           _keys.RemoveAt(i);
           _values.RemoveAt(i);
         }
       }
 #endif
 
-      Enumerator enumerator = GetEnumerator();
+      Dictionary<TKey, TValue>.Enumerator enumerator = _dictionary.GetEnumerator();
       while (enumerator.MoveNext()) {
         var pair = enumerator.Current;
 

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/SerializableDictionary.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/SerializableDictionary.cs
@@ -103,6 +103,10 @@ namespace Leap.Unity {
       return _dictionary.GetEnumerator();
     }
 
+    public static implicit operator Dictionary<TKey, TValue>(SerializableDictionary<TKey, TValue> serializableDictionary) {
+      return serializableDictionary._dictionary;
+    }
+
     #endregion
 
     /// <summary>

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/SerializableHashSet.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/SerializableHashSet.cs
@@ -7,24 +7,65 @@
  * between Leap Motion and you, your company or other organization.           *
  ******************************************************************************/
 
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 using Leap.Unity.Query;
+using System.Collections;
 
 namespace Leap.Unity {
 
-  /// <summary>
-  /// You must mark a serializable hash set field with this
-  /// attribute in order to use the custom inspector editor
-  /// </summary>
+  [Obsolete("It is no longer required to annotate SerializableHashSets with the SHashSet attribute.")]
   public class SHashSetAttribute : PropertyAttribute { }
 
-  public class SerializableHashSet<T> : HashSet<T>,
-    ICanReportDuplicateInformation,
-    ISerializationCallbackReceiver {
+  public abstract class SerializableHashSetBase { }
+
+  public class SerializableHashSet<T> : SerializableHashSetBase,
+                                        ICanReportDuplicateInformation,
+                                        ISerializationCallbackReceiver,
+                                        IEnumerable<T> {
 
     [SerializeField]
     private List<T> _values;
+
+    [NonSerialized]
+    private HashSet<T> _set = new HashSet<T>();
+
+    #region HASH SET API
+
+    public int Count {
+      get { return _set.Count; }
+    }
+
+    public bool Add(T item) {
+      return _set.Add(item);
+    }
+
+    public void Clear() {
+      _set.Clear();
+    }
+
+    public bool Contains(T item) {
+      return _set.Contains(item);
+    }
+
+    public bool Remove(T item) {
+      return _set.Remove(item);
+    }
+
+    public static implicit operator HashSet<T>(SerializableHashSet<T> serializableHashSet) {
+      return serializableHashSet._set;
+    }
+
+    public IEnumerator<T> GetEnumerator() {
+      return _set.GetEnumerator();
+    }
+
+    IEnumerator IEnumerable.GetEnumerator() {
+      return _set.GetEnumerator();
+    }
+
+    #endregion
 
     public void ClearDuplicates() {
       HashSet<T> takenValues = new HashSet<T>();
@@ -66,12 +107,12 @@ namespace Leap.Unity {
     }
 
     public void OnAfterDeserialize() {
-      Clear();
+      _set.Clear();
 
       if (_values != null) {
         foreach (var value in _values) {
           if (value != null) {
-            Add(value);
+            _set.Add(value);
           }
         }
       }
@@ -94,13 +135,13 @@ namespace Leap.Unity {
           continue;
         }
 
-        if (!Contains(value)) {
+        if (!_set.Contains(value)) {
           _values.RemoveAt(i);
         }
       }
 
       //Add any values not accounted for
-      foreach (var value in this) {
+      foreach (var value in _set) {
         if (isNull(value)) {
           if (!_values.Query().Any(obj => isNull(obj))) {
             _values.Add(value);
@@ -123,8 +164,8 @@ namespace Leap.Unity {
         return true;
       }
 
-      if (obj is Object) {
-        return (obj as Object) == null;
+      if (obj is UnityEngine.Object) {
+        return (obj as UnityEngine.Object) == null;
       }
 
       return false;

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/SerializableHashSet.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/SerializableHashSet.cs
@@ -26,7 +26,7 @@ namespace Leap.Unity {
                                         IEnumerable<T> {
 
     [SerializeField]
-    private List<T> _values;
+    private List<T> _values = new List<T>();
 
     [NonSerialized]
     private HashSet<T> _set = new HashSet<T>();

--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/UI/Anchors/AnchorGroup.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/UI/Anchors/AnchorGroup.cs
@@ -19,7 +19,7 @@ namespace Leap.Unity.Interaction {
 
   public class AnchorGroup : MonoBehaviour {
 
-    [SerializeField, SHashSet]
+    [SerializeField]
     [Tooltip("The anchors that are within this AnchorGroup. Anchorable objects associated "
            + "this AnchorGroup can only be placed in anchors within this group.")]
     private AnchorSet _anchors;


### PR DESCRIPTION
Unfortunately with the advent of .Net4.5, Unity can no longer properly serialize all of the private fields present in HashSet<> and Dictionary<,>, and so we need to resort to completely manual serialization.  SerializableHashSet and SerializableDictionary no longer inherit from HashSet and Dictionary directly, and instead embed a copy of the data structure inside.  That way serialization can be completely controlled.  

The classes have added some methods that mirror the methods present in the regular data structures so they can be used in basically the same way.  If you actually need a HashSet or a Dictionary, you can still cast and get the actual result.  But all the basic needs are covered, you can ask for count, add, remove, and foreach.

Now that the classes are not inheriting directly, we can have them inherit from a non-generic base, allowing the property drawers to be 'always-on' instead of requiring an attribute (which has been marked obsolete).

Fixes #893

To test:
 - [x] Verify no compiler errors in editor or in build
 - [x] Verify that things still work as expected in editor and in build