### PR TITLE
Procedural graphics reuse meshes, dynamic renderer clears cache

### DIFF
--- a/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/Graphics/ProceduralMeshGraphics/LeapBoxGraphic.cs
+++ b/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/Graphics/ProceduralMeshGraphics/LeapBoxGraphic.cs
@@ -249,9 +249,14 @@ namespace Leap.Unity.GraphicalRenderer {
         addQuad(tris, frontVertIdx + vx + 1, backVertIdx + vx + 1, backVertIdx + vx, frontVertIdx + vx);
       }
 
-      mesh = new Mesh();
+      if (mesh == null) {
+        mesh = new Mesh();
+      }
+
       mesh.name = "Box Mesh";
       mesh.hideFlags = HideFlags.HideAndDontSave;
+
+      mesh.Clear(keepVertexLayout: false);
       mesh.SetVertices(verts);
       mesh.SetNormals(normals);
       mesh.SetTriangles(tris, 0);

--- a/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/Graphics/ProceduralMeshGraphics/LeapPanelGraphic.cs
+++ b/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/Graphics/ProceduralMeshGraphics/LeapPanelGraphic.cs
@@ -58,9 +58,14 @@ namespace Leap.Unity.GraphicalRenderer {
         }
       }
 
-      mesh = new Mesh();
+      if (mesh == null) {
+        mesh = new Mesh();
+      }
+
       mesh.name = "Panel Mesh";
       mesh.hideFlags = HideFlags.HideAndDontSave;
+
+      mesh.Clear(keepVertexLayout: false);
       mesh.SetVertices(verts);
       mesh.SetTriangles(tris, 0);
       mesh.SetUVs(uvChannel.Index(), uvs);

--- a/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/Graphics/ProceduralMeshGraphics/LeapPanelOutlineGraphic.cs
+++ b/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/Graphics/ProceduralMeshGraphics/LeapPanelOutlineGraphic.cs
@@ -149,9 +149,14 @@ namespace Leap.Unity.GraphicalRenderer {
         }
       }
 
-      mesh = new Mesh();
+      if (mesh == null) {
+        mesh = new Mesh();
+      }
+
       mesh.name = "Panel Outline Mesh";
       mesh.hideFlags = HideFlags.HideAndDontSave;
+
+      mesh.Clear(keepVertexLayout: false);
       mesh.SetVertices(verts);
       mesh.SetTriangles(tris, 0);
       mesh.SetUVs(uvChannel.Index(), uvs);

--- a/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/Graphics/ProceduralMeshGraphics/LeapSpriteGraphic.cs
+++ b/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/Graphics/ProceduralMeshGraphics/LeapSpriteGraphic.cs
@@ -30,9 +30,14 @@ namespace Leap.Unity.GraphicalRenderer {
 
       var sprite = spriteData.sprite;
 
-      mesh = new Mesh();
+      if (mesh == null) {
+        mesh = new Mesh();
+      }
+
       mesh.name = "Sprite Mesh";
       mesh.hideFlags = HideFlags.HideAndDontSave;
+
+      mesh.Clear(keepVertexLayout: false);
       mesh.vertices = sprite.vertices.Query().Select(v => (Vector3)v).ToArray();
       mesh.triangles = sprite.triangles.Query().Select(i => (int)i).ToArray();
 

--- a/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/RenderingMethods/LeapDynamicRenderer.cs
+++ b/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/RenderingMethods/LeapDynamicRenderer.cs
@@ -75,6 +75,8 @@ namespace Leap.Unity.GraphicalRenderer {
           for (int i = 0; i < group.graphics.Count; i++) {
             var graphic = group.graphics[i];
             if (graphic.isRepresentationDirty || _meshes[i] == null) {
+              MeshCache.Clear();
+
               beginMesh(_meshes[i]);
               _generation.graphic = graphic as LeapMeshGraphicBase;
               _generation.graphicIndex = i;


### PR DESCRIPTION
Procedural mesh graphics were always reconstructing their mesh objects every frame, instead of reusing them.  This causes constant memory growth if the procedural graphic was being updated constantly, since unity doesn't clean up objects until something large happens like a scene load.

This was masking another bug, where the dynamic renderer would not clear the mesh cache before updating a graphic at runtime, causing stale values to be read.

Fixes #968

To test:
 - [x] Verify all procedural graphics still work correctly at edit time
 - [x] Verify all procedural graphics can be modified at runtime when using a dynamic renderer