### PR TITLE
Fix property height in CombinablePropertyDrawer

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/Attributes/Editor/CombinablePropertyDrawer.cs
+++ b/Assets/LeapMotion/Core/Scripts/Attributes/Editor/CombinablePropertyDrawer.cs
@@ -44,6 +44,10 @@ namespace Leap.Unity.Attributes {
       }
     }
 
+    public override float GetPropertyHeight(SerializedProperty property, GUIContent label) {
+      return EditorGUI.GetPropertyHeight(property);
+    }
+
     public override void OnGUI(Rect position, SerializedProperty property, GUIContent label) {
       getAttributes(property);
 


### PR DESCRIPTION
The default implementation of GetPropertyHeight apparently just reports a height of a single line, strangely.  This is strange because many properties require more than one line even without custom property drawers!  For example Vector2 through Vector4 require more than one line if you squish the inspector small enough.  This PR simply makes use of the existing util in EditorGUI to correctly calculate how tall the property needs to be.

Fixes #969

To test:
 - [ ] Verify multi-line properties display properly now when attributed with a combinable attribute.  (LeapPanelGraphic is a good one that has a Vector2 with a MinValue already on it)