### PR TITLE
Overhaul query testing and fixed some bugs!

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/Query/Editor/QueryTests.cs
+++ b/Assets/LeapMotion/Core/Scripts/Query/Editor/QueryTests.cs
@@ -15,24 +15,23 @@ using NUnit.Framework;
 
 namespace Leap.Unity.Tests {
   using Query;
+  using System;
 
   public class QueryTests {
-    public int[] LIST_0 = { 1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 9, 1, 900, int.MinValue, int.MaxValue };
-    public int[] LIST_1 = { 6, 7, 8, 9, 10, 1, 1, 9, 300, 6, 900, int.MaxValue };
 
     [Test]
-    public void AllTest() {
-      Assert.AreEqual(LIST_0.All(i => i < 5),
-                      LIST_0.Query().All(i => i < 5));
+    public void AllTest([ValueSource("list0")] QueryArg arg) {
+      Assert.That(arg.ToQuery().All(i => i < 5), Is.EqualTo(
+                  arg.ToList().All(i => i < 5)));
 
-      Assert.AreEqual(LIST_0.All(i => i != 8),
-                      LIST_0.Query().All(i => i != 8));
+      Assert.That(arg.ToQuery().All(i => i != 8), Is.EqualTo(
+                  arg.ToList().All(i => i != 8)));
     }
 
     [Test]
-    public void AnyTest() {
-      Assert.AreEqual(LIST_0.Any(i => i == 4),
-                      LIST_0.Query().Any(i => i == 4));
+    public void AnyTest([ValueSource("list0")] QueryArg arg) {
+      Assert.That(arg.ToQuery().Any(i => i == 4), Is.EqualTo(
+                  arg.ToList().Query().Any(i => i == 4)));
     }
 
     [Test]
@@ -63,42 +62,48 @@ namespace Leap.Unity.Tests {
     }
 
     [Test]
-    public void ConcatTest() {
-      Assert.That(LIST_0.Concat(LIST_1).ToList(), Is.EquivalentTo(
-                  LIST_0.Query().Concat(LIST_1.Query()).ToList()));
+    public void ConcatTest([ValueSource("list0")] QueryArg arg0, [ValueSource("list0")] QueryArg arg1) {
+      Assert.That(arg0.ToQuery().Concat(arg1.ToList()).ToList(), Is.EquivalentTo(
+                  arg0.ToList().Concat(arg1.ToList()).ToList()));
+
+      Assert.That(arg0.ToQuery().Concat(arg1.ToQuery()).ToList(), Is.EquivalentTo(
+                  arg0.ToList().Concat(arg1.ToList()).ToList()));
     }
 
     [Test]
-    public void ContainsTest() {
-      Assert.AreEqual(LIST_0.Contains(3),
-                      LIST_0.Query().Contains(3));
+    public void ContainsTest([ValueSource("list0")] QueryArg arg) {
+      Assert.That(arg.ToQuery().Contains(3), Is.EqualTo(
+                  arg.ToList().Contains(3)));
 
-      Assert.AreEqual(LIST_0.Contains(9),
-                      LIST_0.Query().Contains(9));
+      Assert.That(arg.ToQuery().Contains(9), Is.EqualTo(
+                  arg.ToList().Contains(9)));
     }
 
     [Test]
-    public void CountTests() {
-      Assert.AreEqual(LIST_0.Count(),
-                      LIST_0.Query().Count());
+    public void CountTests([ValueSource("list0")] QueryArg arg) {
+      Assert.That(arg.ToQuery().Count(), Is.EqualTo(
+                  arg.ToList().Count()));
 
-      Assert.AreEqual(LIST_0.Count(i => i % 2 == 0),
-                      LIST_0.Query().Count(i => i % 2 == 0));
+      Assert.That(arg.ToQuery().Count(i => i % 2 == 0), Is.EqualTo(
+                  arg.ToList().Count(i => i % 2 == 0)));
     }
 
     [Test]
-    public void DistinctTest() {
-      Assert.That(LIST_0.Query().Distinct().OrderBy(t => t).ToList(), Is.EquivalentTo(
-                  LIST_0.Distinct().OrderBy(t => t).ToList()));
+    public void DistinctTest([ValueSource("list0")] QueryArg arg) {
+      Assert.That(arg.ToQuery().Distinct().OrderBy(t => t).ToList(), Is.EquivalentTo(
+                  arg.ToList().Distinct().OrderBy(t => t).ToList()));
     }
 
     [Test]
-    public void ElemenAtTest() {
-      Assert.AreEqual(LIST_0.ElementAt(3),
-                      LIST_0.Query().ElementAt(3));
+    public void ElemenAtTest([ValueSource("list0")] QueryArg arg, [Values(0, 3, 100)] int index) {
+      var list = arg.ToList();
 
-      Assert.AreEqual(LIST_0.ElementAtOrDefault(100),
-                      LIST_0.Query().ElementAtOrDefault(100));
+      if (index >= list.Count) {
+        Assert.That(() => arg.ToQuery().ElementAt(index), Throws.InstanceOf<IndexOutOfRangeException>());
+      } else {
+        Assert.That(arg.ToQuery().ElementAt(index), Is.EqualTo(
+                    arg.ToList().ElementAt(index)));
+      }
     }
 
     [Test]
@@ -107,75 +112,97 @@ namespace Leap.Unity.Tests {
     }
 
     [Test]
-    public void FirstTests() {
-      Assert.AreEqual(LIST_0.First(),
-                      LIST_0.Query().First());
+    public void FirstTests([ValueSource("list0")] QueryArg arg) {
+      var list = arg.ToList();
 
-      Assert.AreEqual(LIST_0.First(i => i % 2 == 0),
-                      LIST_0.Query().First(i => i % 2 == 0));
-    }
-
-    [Test]
-    public void FirstOrDefaultTests() {
-      Assert.AreEqual(LIST_0.FirstOrDefault(),
-                      LIST_0.Query().FirstOrDefault());
-
-      Assert.AreEqual(LIST_0.FirstOrDefault(i => i % 2 == 0),
-                      LIST_0.Query().FirstOrDefault(i => i % 2 == 0));
-
-      Assert.AreEqual(LIST_0.FirstOrDefault(i => i > 10),
-                      LIST_0.Query().FirstOrDefault(i => i > 10));
-    }
-
-    [Test]
-    public void FoldTest() {
-      Assert.AreEqual(LIST_0.Query().Fold((a, b) => a + b),
-                      LIST_0.Sum());
-    }
-
-    [Test]
-    public void ForeachTest() {
-      List<int> found = new List<int>();
-      foreach (var item in LIST_0.Query().Concat(LIST_1.Query())) {
-        found.Add(item);
+      if (list.Count == 0) {
+        Assert.That(() => arg.ToQuery().First(), Throws.InvalidOperationException);
+      } else {
+        Assert.That(arg.ToQuery().First(), Is.EqualTo(
+                    arg.ToList().First()));
       }
-      Assert.That(LIST_0.Concat(LIST_1).ToList(), Is.EquivalentTo(found));
+
+      if (list.Where(i => i % 2 == 0).Count() == 0) {
+        Assert.That(() => arg.ToQuery().Where(i => i % 2 == 0).First(), Throws.InvalidOperationException);
+      } else {
+        Assert.That(arg.ToQuery().First(i => i % 2 == 0), Is.EqualTo(
+                    arg.ToList().First(i => i % 2 == 0)));
+      }
     }
 
     [Test]
-    public void IndexOfTests() {
-      Assert.AreEqual(LIST_0.Query().IndexOf(3), 2);
-      Assert.AreEqual(LIST_0.Query().IndexOf(100), -1);
+    public void FirstOrDefaultTests([ValueSource("list0")] QueryArg arg) {
+      Assert.That(arg.ToQuery().FirstOrDefault(), Is.EqualTo(
+                  arg.ToList().FirstOrDefault()));
+
+      Assert.That(arg.ToQuery().FirstOrDefault(i => i % 2 == 0), Is.EqualTo(
+                  arg.ToList().FirstOrDefault(i => i % 2 == 0)));
+
+      Assert.That(arg.ToQuery().FirstOrDefault(i => i > 10), Is.EqualTo(
+                  arg.ToList().FirstOrDefault(i => i > 10)));
     }
 
     [Test]
-    public void LastTests() {
-      Assert.That(LIST_0.Query().Last(), Is.EqualTo(LIST_0.Last()));
+    public void FoldTest([ValueSource("list0")] QueryArg arg) {
+      var list = arg.ToList();
 
-      var empty = new int[] { };
-
-      Assert.That(() => {
-        empty.Query().Last();
-      }, Throws.InvalidOperationException);
-
-      Assert.That(empty.Query().LastOrDefault(), Is.EqualTo(empty.LastOrDefault()));
+      if (list.Count == 0) {
+        Assert.That(() => arg.ToQuery().Fold((a, b) => a + b), Throws.InvalidOperationException);
+      } else {
+        Assert.That(arg.ToQuery().Fold((a, b) => a + b), Is.EqualTo(
+                    arg.ToList().Sum()));
+      }
     }
 
     [Test]
-    public void MultiFirstTest() {
-      var q = LIST_0.Query();
-
-      q.First();
-
-      Assert.That(() => q.First(), Throws.InvalidOperationException);
+    public void ForeachTest([ValueSource("list0")] QueryArg arg0, [ValueSource("list1")] QueryArg arg1) {
+      List<int> actual = new List<int>();
+      foreach (var item in arg0.ToQuery().Concat(arg1.ToQuery())) {
+        actual.Add(item);
+      }
+      Assert.That(actual, Is.EquivalentTo(
+                  arg0.ToList().Concat(arg1.ToList()).ToList()));
     }
 
     [Test]
-    public void MultiForeachTest() {
+    public void IndexOfTests([ValueSource("list0")] QueryArg arg) {
+      Assert.That(arg.ToQuery().IndexOf(3), Is.EqualTo(
+                  arg.ToList().IndexOf(3)));
+
+      Assert.That(arg.ToQuery().IndexOf(100), Is.EqualTo(
+                  arg.ToList().IndexOf(100)));
+    }
+
+    [Test]
+    public void LastTests([ValueSource("list0")] QueryArg arg) {
+      var list = arg.ToList();
+
+      if (list.Count == 0) {
+        Assert.That(() => arg.ToQuery().Last(), Throws.InvalidOperationException);
+      } else {
+        Assert.That(arg.ToQuery().Last(), Is.EqualTo(
+                    arg.ToList().Last()));
+      }
+
+      Assert.That(arg.ToQuery().LastOrDefault(), Is.EqualTo(
+                  arg.ToList().LastOrDefault()));
+    }
+
+    [Test]
+    public void MultiFirstTest([ValueSource("list0")] QueryArg arg) {
+      var q = arg.ToQuery();
+
+      q.FirstOrDefault();
+
+      Assert.That(() => q.FirstOrDefault(), Throws.InvalidOperationException);
+    }
+
+    [Test]
+    public void MultiForeachTest([ValueSource("list0")] QueryArg arg) {
       List<int> a = new List<int>();
       List<int> b = new List<int>();
 
-      var q = LIST_0.Query();
+      var q = arg.ToQuery();
       foreach (var item in q) {
         a.Add(item);
       }
@@ -199,15 +226,15 @@ namespace Leap.Unity.Tests {
     }
 
     [Test]
-    public void OrderByTest() {
-      Assert.That(LIST_0.Query().OrderBy(i => i).ToList(), Is.EquivalentTo(
-                  LIST_0.OrderBy(i => i).ToList()));
+    public void OrderByTest([ValueSource("list0")] QueryArg arg) {
+      Assert.That(arg.ToQuery().OrderBy(i => i).ToList(), Is.EquivalentTo(
+                  arg.ToList().OrderBy(i => i).ToList()));
     }
 
     [Test]
-    public void OrderByDescendingTest() {
-      Assert.That(LIST_0.Query().OrderByDescending(i => i).ToList(), Is.EquivalentTo(
-                  LIST_0.OrderByDescending(i => i).ToList()));
+    public void OrderByDescendingTest([ValueSource("list0")] QueryArg arg) {
+      Assert.That(arg.ToQuery().OrderByDescending(i => i).ToList(), Is.EquivalentTo(
+                  arg.ToList().OrderByDescending(i => i).ToList()));
     }
 
     [Test]
@@ -236,32 +263,38 @@ namespace Leap.Unity.Tests {
     }
 
     [Test]
-    public void Repeat([Values(0, 1, 2, 3, 100)] int repetitions) {
+    public void Repeat([ValueSource("list0")] QueryArg arg, [Values(0, 1, 2, 3, 100)] int repetitions) {
       List<int> list = new List<int>();
       for (int i = 0; i < repetitions; i++) {
-        list.AddRange(LIST_0);
+        list.AddRange(arg.ToList());
       }
 
-      Assert.That(list, Is.EquivalentTo(
-                  LIST_0.Query().Repeat(repetitions).ToList()));
+      Assert.That(arg.ToQuery().Repeat(repetitions).ToList(), Is.EquivalentTo(
+                  list));
     }
 
     [Test]
-    public void ReverseTest() {
-      Assert.That(LIST_0.Query().Reverse().ToList(), Is.EquivalentTo(
-                  LIST_0.Select(i => i).Reverse().ToList()));
+    public void ReverseTest([ValueSource("list0")] QueryArg arg) {
+      var expected = arg.ToList();
+      expected.Reverse();
+
+      Assert.That(arg.ToQuery().Reverse().ToList(), Is.EquivalentTo(
+                  expected));
     }
 
     [Test]
-    public void SelectTest() {
-      Assert.That(LIST_0.Select(i => i * 23).ToList(), Is.EquivalentTo(
-                  LIST_0.Query().Select(i => i * 23).ToList()));
+    public void SelectTest([ValueSource("list0")] QueryArg arg) {
+      Assert.That(arg.ToQuery().Select(i => i * 23).ToList(), Is.EquivalentTo(
+                  arg.ToList().Select(i => i * 23).ToList()));
     }
 
     [Test]
-    public void SelectManyTest() {
-      Assert.That(LIST_0.SelectMany(i => LIST_1.Select(j => j * i)).ToList(), Is.EquivalentTo(
-                  LIST_0.Query().SelectMany(i => LIST_1.Query().Select(j => j * i)).ToList()));
+    public void SelectManyTest([ValueSource("list0")] QueryArg arg0, [ValueSource("list0")] QueryArg arg1) {
+      Assert.That(arg0.ToQuery().SelectMany(i => arg1.ToQuery().Select(j => j * i)).ToList(), Is.EquivalentTo(
+                  arg0.ToList().SelectMany(i => arg1.ToList().Select(j => j * i)).ToList()));
+
+      Assert.That(arg0.ToQuery().SelectMany(i => arg1.ToList().Select(j => j * i).ToList()).ToList(), Is.EquivalentTo(
+                  arg0.ToList().SelectMany(i => arg1.ToList().Select(j => j * i)).ToList()));
     }
 
     [Test]
@@ -284,100 +317,182 @@ namespace Leap.Unity.Tests {
     }
 
     [Test]
-    public void SkipTest() {
-      Assert.That(LIST_0.Skip(3).ToList(), Is.EquivalentTo(
-                  LIST_0.Query().Skip(3).ToList()));
+    public void SkipTest([ValueSource("list0")] QueryArg arg) {
+      Assert.That(arg.ToQuery().Skip(3).ToList(), Is.EquivalentTo(
+                  arg.ToList().Skip(3).ToList()));
     }
 
     [Test]
-    public void SkipWhileTest() {
-      Assert.That(LIST_0.SkipWhile(i => i < 4).ToList(), Is.EquivalentTo(
-                  LIST_0.Query().SkipWhile(i => i < 4).ToList()));
+    public void SkipWhileTest([ValueSource("list0")] QueryArg arg) {
+      Assert.That(arg.ToQuery().SkipWhile(i => i < 4).ToList(), Is.EquivalentTo(
+                  arg.ToList().SkipWhile(i => i < 4).ToList()));
     }
 
     [Test]
-    public void SortTest() {
-      var expected = new List<int>(LIST_0);
+    public void SortTest([ValueSource("list0")] QueryArg arg) {
+      var expected = arg.ToList();
       expected.Sort();
 
-      Assert.That(LIST_0.Query().Sort().ToList(), Is.EquivalentTo(
+      Assert.That(arg.ToQuery().Sort().ToList(), Is.EquivalentTo(
                   expected));
     }
 
     [Test]
-    public void SortDescendingTests() {
-      var expected = new List<int>(LIST_0);
+    public void SortDescendingTests([ValueSource("list0")] QueryArg arg) {
+      var expected = arg.ToList();
       expected.Sort();
       expected.Reverse();
 
-      Assert.That(LIST_0.Query().SortDescending().ToList(), Is.EquivalentTo(
+      Assert.That(arg.ToQuery().SortDescending().ToList(), Is.EquivalentTo(
                   expected));
     }
 
     [Test]
-    public void TakeTest() {
-      Assert.That(LIST_0.Take(4).ToList(), Is.EquivalentTo(
-                  LIST_0.Query().Take(4).ToList()));
+    public void TakeTest([ValueSource("list0")] QueryArg arg) {
+      Assert.That(arg.ToQuery().Take(4).ToList(), Is.EquivalentTo(
+                  arg.ToList().Take(4).ToList()));
     }
 
     [Test]
-    public void TakeWhileTest() {
-      Assert.That(LIST_0.TakeWhile(i => i < 4).ToList(), Is.EquivalentTo(
-                  LIST_0.Query().TakeWhile(i => i < 4).ToList()));
+    public void TakeWhileTest([ValueSource("list0")] QueryArg arg) {
+      Assert.That(arg.ToQuery().TakeWhile(i => i < 4).ToList(), Is.EquivalentTo(
+                  arg.ToList().TakeWhile(i => i < 4).ToList()));
     }
 
     [Test]
-    public void WithPreviousTest() {
-      Assert.That(LIST_0.Query().WithPrevious().Count(p => p.hasPrev), Is.EqualTo(LIST_0.Length - 1));
-      Assert.That(LIST_0.Query().WithPrevious(includeStart: true).Count(p => !p.hasPrev), Is.EqualTo(1));
-      Assert.That(LIST_0.Query().WithPrevious(includeStart: true).Count(p => p.hasPrev), Is.EqualTo(LIST_0.Length - 1));
+    public void WithPreviousTest([ValueSource("list0")] QueryArg arg) {
+      var list = arg.ToList();
+      if (list.Count == 0) {
+        Assert.That(arg.ToQuery().WithPrevious().Count(), Is.EqualTo(0));
+        Assert.That(arg.ToQuery().WithPrevious(includeStart: true).Count(), Is.EqualTo(0));
+      } else if (list.Count == 1) {
+        Assert.That(arg.ToQuery().WithPrevious().Count(), Is.EqualTo(0));
+        Assert.That(arg.ToQuery().WithPrevious(includeStart: true).Count(), Is.EqualTo(1));
+      } else {
+        Assert.That(arg.ToQuery().WithPrevious().Count(p => p.hasPrev), Is.EqualTo(list.Count - 1));
+        Assert.That(arg.ToQuery().WithPrevious(includeStart: true).Count(p => !p.hasPrev), Is.EqualTo(1));
+        Assert.That(arg.ToQuery().WithPrevious(includeStart: true).Count(p => p.hasPrev), Is.EqualTo(list.Count - 1));
+      }
 
       int index = 0;
-      foreach (var pair in LIST_0.Query().WithPrevious()) {
-        Assert.That(pair.prev, Is.EqualTo(LIST_0[index]));
+      foreach (var pair in arg.ToQuery().WithPrevious()) {
+        Assert.That(pair.prev, Is.EqualTo(list[index]));
         index++;
       }
     }
 
     [Test]
-    public void WithPreviousOffsetTest() {
-      Assert.That(LIST_0.Query().WithPrevious(offset: 4).Count(), Is.EqualTo(LIST_0.Length - 4));
-      Assert.That(LIST_0.Query().WithPrevious(offset: LIST_0.Length + 1).Count(), Is.EqualTo(0));
-      Assert.That(LIST_0.Query().WithPrevious(offset: int.MaxValue).Count(), Is.EqualTo(0));
-
-      var item = LIST_0.Query().WithPrevious(offset: 4).First();
-      Assert.That(item.value, Is.EqualTo(5));
-      Assert.That(item.prev, Is.EqualTo(1));
+    public void WithPreviousOffsetTest([ValueSource("list0")] QueryArg arg) {
+      var list = arg.ToList();
+      if (list.Count == 0) {
+        Assert.That(arg.ToQuery().WithPrevious(offset: 4).Count(), Is.EqualTo(0));
+        Assert.That(arg.ToQuery().WithPrevious(offset: 4, includeStart: true).Count(), Is.EqualTo(0));
+      } else if (list.Count == 1) {
+        Assert.That(arg.ToQuery().WithPrevious(offset: 4).Count(), Is.EqualTo(0));
+        Assert.That(arg.ToQuery().WithPrevious(offset: 4, includeStart: true).Count(), Is.EqualTo(1));
+      } else {
+        Assert.That(arg.ToQuery().WithPrevious(offset: 4).Count(), Is.EqualTo(Mathf.Max(0, list.Count - 4)));
+        Assert.That(arg.ToQuery().WithPrevious(offset: list.Count + 1).Count(), Is.EqualTo(0));
+        Assert.That(arg.ToQuery().WithPrevious(offset: int.MaxValue).Count(), Is.EqualTo(0));
+      }
 
       Assert.That(Values.Range(0, 10).WithPrevious(offset: 2).All(i => i.value - i.prev == 2));
     }
 
     [Test]
-    public void WhereTest() {
-      Assert.That(LIST_0.Where(i => i % 2 == 0).ToList(), Is.EquivalentTo(
-                  LIST_0.Query().Where(i => i % 2 == 0).ToList()));
+    public void WhereTest([ValueSource("list0")] QueryArg arg) {
+      Assert.That(arg.ToQuery().Where(i => i % 2 == 0).ToList(), Is.EquivalentTo(
+                  arg.ToList().Where(i => i % 2 == 0).ToList()));
     }
 
     [Test]
-    public void WithIndicesTest() {
+    public void WithIndicesTest([ValueSource("list0")] QueryArg arg) {
       int index = 0;
-      foreach (var item in LIST_0.Query().WithIndices()) {
+      foreach (var item in arg.ToQuery().WithIndices()) {
         Assert.That(item.index, Is.EqualTo(index));
-        Assert.That(item.value, Is.EqualTo(LIST_0[index]));
+        Assert.That(item.value, Is.EqualTo(arg.ToList()[index]));
         index++;
       }
     }
 
     [Test]
-    public void ZipTest() {
+    public void ZipTest([ValueSource("list0")] QueryArg arg0, [ValueSource("list1")] QueryArg arg1) {
+      var list0 = arg0.ToList();
+      var list1 = arg1.ToList();
+
       List<string> expected = new List<string>();
-      for (int i = 0; i < Mathf.Min(LIST_0.Length, LIST_1.Length); i++) {
-        expected.Add(LIST_0[i].ToString() + LIST_1[i].ToString());
+      for (int i = 0; i < Mathf.Min(list0.Count, list1.Count); i++) {
+        expected.Add(list0[i].ToString() + list1[i].ToString());
       }
 
-      Assert.That(LIST_0.Query().Zip(LIST_1.Query(), (a, b) => a.ToString() + b.ToString()).ToList(), Is.EquivalentTo(
+      Assert.That(arg0.ToQuery().Zip(arg1.ToQuery(), (a, b) => a.ToString() + b.ToString()).ToList(), Is.EquivalentTo(
+                  expected));
+
+      Assert.That(arg0.ToQuery().Zip(arg1.ToList(), (a, b) => a.ToString() + b.ToString()).ToList(), Is.EquivalentTo(
                   expected));
     }
+
+    private static IEnumerable<QueryArg> list0 {
+      get {
+        List<int> values = new List<int>() { 1, 2, 3, 4, 5, 1, 2, 3, 4, 5, 9, 1, 900, int.MinValue, int.MaxValue };
+        List<int> lengths = new List<int>() {
+          0,
+          1,
+          2,
+          int.MaxValue
+        };
+
+        foreach (var length in lengths) {
+          var list = values.Take(length).ToList();
+          yield return new QueryArg(list, list.Count);
+          yield return new QueryArg(list, list.Count * 10 + 10);
+        }
+      }
+    }
+
+    private static IEnumerable<QueryArg> list1 {
+      get {
+        List<int> values = new List<int>() { 6, 7, 8, 9, 10, 1, 1, 9, 300, 6, 900, int.MaxValue };
+        List<int> lengths = new List<int>() {
+          0,
+          1,
+          2,
+          int.MaxValue
+        };
+
+        foreach (var length in lengths) {
+          var list = values.Take(length).ToList();
+          yield return new QueryArg(list, list.Count);
+          yield return new QueryArg(list, list.Count * 10 + 10);
+        }
+      }
+    }
+
+    public class QueryArg {
+      private int[] _array;
+      private int _count;
+
+      public QueryArg(List<int> values, int capacity) {
+        _array = new int[capacity];
+        values.CopyTo(_array);
+        _count = values.Count;
+      }
+
+      public Query<int> ToQuery() {
+        int[] copy = new int[_array.Length];
+        _array.CopyTo(copy, 0);
+        return new Query<int>(copy, _count);
+      }
+
+      public List<int> ToList() {
+        return new List<int>(_array.Take(_count));
+      }
+
+      public override string ToString() {
+        return _array.Length + " : " + Utils.ToArrayString(_array.Take(_count));
+      }
+    }
+
 
     public class TestEnumerator : IEnumerator<int> {
       private int _curr = -1;

--- a/Assets/LeapMotion/Core/Scripts/Query/Editor/QueryTests.cs
+++ b/Assets/LeapMotion/Core/Scripts/Query/Editor/QueryTests.cs
@@ -95,7 +95,7 @@ namespace Leap.Unity.Tests {
     }
 
     [Test]
-    public void ElemenAtTest([ValueSource("list0")] QueryArg arg, [Values(0, 3, 100)] int index) {
+    public void ElementAtTest([ValueSource("list0")] QueryArg arg, [Values(0, 3, 100)] int index) {
       var list = arg.ToList();
 
       if (index >= list.Count) {

--- a/Assets/LeapMotion/Core/Scripts/Query/QueryOperatorExtensions.cs
+++ b/Assets/LeapMotion/Core/Scripts/Query/QueryOperatorExtensions.cs
@@ -24,7 +24,7 @@ namespace Leap.Unity.Query {
       using (var slice = query.Deconstruct()) {
         var dstArray = ArrayPool<T>.Spawn(slice.Count + collection.Count);
 
-        slice.BackingArray.CopyTo(dstArray, 0);
+        Array.Copy(slice.BackingArray, dstArray, slice.Count);
         collection.CopyTo(dstArray, slice.Count);
 
         return new Query<T>(dstArray, slice.Count + collection.Count);
@@ -45,8 +45,8 @@ namespace Leap.Unity.Query {
       using (var otherSlice = other.Deconstruct()) {
         var dstArray = ArrayPool<T>.Spawn(slice.Count + otherSlice.Count);
 
-        slice.BackingArray.CopyTo(dstArray, 0);
-        otherSlice.BackingArray.CopyTo(dstArray, slice.Count);
+        Array.Copy(slice.BackingArray, dstArray, slice.Count);
+        Array.Copy(otherSlice.BackingArray, 0, dstArray, slice.Count, otherSlice.Count);
 
         return new Query<T>(dstArray, slice.Count + otherSlice.Count);
       }
@@ -255,7 +255,7 @@ namespace Leap.Unity.Query {
 
         int targetIndex = 0;
         for (int i = 0; i < slice.Count; i++) {
-          slices[i].BackingArray.CopyTo(dstArray, targetIndex);
+          Array.Copy(slices[i].BackingArray, 0, dstArray, targetIndex, slices[i].Count);
           targetIndex += slices[i].Count;
           slices[i].Dispose();
         }
@@ -283,6 +283,7 @@ namespace Leap.Unity.Query {
       query.Deconstruct(out array, out count);
 
       int resultCount = Mathf.Max(count - toSkip, 0);
+      toSkip = count - resultCount;
       Array.Copy(array, toSkip, array, 0, resultCount);
       Array.Clear(array, resultCount, array.Length - resultCount);
 


### PR DESCRIPTION
The query testing has been overhauled to test a much wider variety of values on all of the different operators available.  This includes multiple different lengths, empty queries, as well as queries where the backing array is significantly larger than the size of the array.

Through this extra testing, I also managed to uncover some subtle bugs in some of the new query operations!   Two occurred when the backing array was significantly larger than the size of the array, and another occurred with small or empty queries.  Now that we have much better coverage, errors like these should be harder to introduce!

To test:
 - [x] Verify code looks good
 - [x] Verify tests pass