### PR TITLE
Query tweaks

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/Query/Editor/QueryTests.cs
+++ b/Assets/LeapMotion/Core/Scripts/Query/Editor/QueryTests.cs
@@ -200,6 +200,28 @@ namespace Leap.Unity.Tests {
     }
 
     [Test]
+    public void MaxTest([ValueSource("list0")] QueryArg arg) {
+      if (arg.ToList().Count == 0) {
+        Assert.Ignore("Ignore empty queries for max tests.");
+        return;
+      }
+
+      Assert.That(arg.ToQuery().Max(), Is.EqualTo(
+                  arg.ToList().Max()));
+    }
+
+    [Test]
+    public void MinTest([ValueSource("list0")] QueryArg arg) {
+      if (arg.ToList().Count == 0) {
+        Assert.Ignore("Ignore empty queries for min tests.");
+        return;
+      }
+
+      Assert.That(arg.ToQuery().Min(), Is.EqualTo(
+                  arg.ToList().Min()));
+    }
+
+    [Test]
     public void MultiFirstTest([ValueSource("list0")] QueryArg arg) {
       var q = arg.ToQuery();
 

--- a/Assets/LeapMotion/Core/Scripts/Query/Editor/QueryTests.cs
+++ b/Assets/LeapMotion/Core/Scripts/Query/Editor/QueryTests.cs
@@ -54,6 +54,17 @@ namespace Leap.Unity.Tests {
     }
 
     [Test]
+    public void AverageTest([ValueSource("list0")] QueryArg arg0) {
+      if (arg0.ToList().Count == 0) {
+        Assert.Ignore("Ignore empty queries for average test.");
+        return;
+      }
+
+      Assert.That(arg0.ToQuery().Select(t => (double)t).Average(), Is.EqualTo(
+                  arg0.ToList().Average()).Within(0.001).Percent);
+    }
+
+    [Test]
     public void CastTest() {
       object[] objs = new object[] { "Hello", "World", "These", "Are", "All", "Strings" };
 
@@ -345,6 +356,17 @@ namespace Leap.Unity.Tests {
 
       Assert.That(arg.ToQuery().SortDescending().ToList(), Is.EquivalentTo(
                   expected));
+    }
+
+    [Test]
+    public void SumTests([ValueSource("list0")] QueryArg arg) {
+      if (arg.ToList().Count == 0) {
+        Assert.Ignore("Ignore empty queries for sum tests.");
+        return;
+      }
+
+      Assert.That(arg.ToQuery().Sum(), Is.EqualTo(
+                  arg.ToList().Sum()));
     }
 
     [Test]

--- a/Assets/LeapMotion/Core/Scripts/Query/QueryCollapseExtensions.cs
+++ b/Assets/LeapMotion/Core/Scripts/Query/QueryCollapseExtensions.cs
@@ -31,19 +31,11 @@ namespace Leap.Unity.Query {
           return true;
         }
 
-        var a = slice[0];
+        var comparer = EqualityComparer<T>.Default;
+
+        var first = slice[0];
         for (int i = 1; i < slice.Count; i++) {
-          var b = slice[i];
-
-          if ((a == null) != (b == null)) {
-            return false;
-          }
-
-          if ((a == null) && (b == null)) {
-            continue;
-          }
-
-          if (!a.Equals(b)) {
+          if (!comparer.Equals(first, slice[i])) {
             return false;
           }
         }
@@ -108,8 +100,9 @@ namespace Leap.Unity.Query {
       int count;
       query.Deconstruct(out array, out count);
 
+      var comparer = EqualityComparer<T>.Default;
       for (int i = 0; i < count; i++) {
-        if (array[i].Equals(item)) {
+        if (comparer.Equals(item, array[i])) {
           ArrayPool<T>.Recycle(array);
           return true;
         }
@@ -283,12 +276,9 @@ namespace Leap.Unity.Query {
     /// </summary>
     public static int IndexOf<T>(this Query<T> query, T t) {
       using (var slice = query.Deconstruct()) {
+        var comparer = EqualityComparer<T>.Default;
         for (int i = 0; i < slice.Count; i++) {
-          if (t == null) {
-            if (slice[i] == null) {
-              return i;
-            }
-          } else if (t.Equals(slice[i])) {
+          if (comparer.Equals(t, slice[i])) {
             return i;
           }
         }
@@ -514,12 +504,9 @@ namespace Leap.Unity.Query {
         var array = slice;
         T reference = array[0];
 
+        var comparer = EqualityComparer<T>.Default;
         for (int i = 1; i < slice.Count; i++) {
-          if (reference == null) {
-            if (array[i] != null) {
-              return Maybe.None;
-            }
-          } else if (!reference.Equals(array[i])) {
+          if (!comparer.Equals(reference, slice[i])) {
             return Maybe.None;
           }
         }

--- a/Assets/LeapMotion/Core/Scripts/Query/QueryCollapseExtensions.cs
+++ b/Assets/LeapMotion/Core/Scripts/Query/QueryCollapseExtensions.cs
@@ -75,6 +75,32 @@ namespace Leap.Unity.Query {
     }
 
     /// <summary>
+    /// Returns the average of a Query of floats.
+    /// </summary>
+    public static float Average(this Query<float> query) {
+      using (var slice = query.Deconstruct()) {
+        float sum = 0;
+        for (int i = 0; i < slice.Count; i++) {
+          sum += slice[i];
+        }
+        return sum / slice.Count;
+      }
+    }
+
+    /// <summary>
+    /// Returns the average of a Query of doubles.
+    /// </summary>
+    public static double Average(this Query<double> query) {
+      using (var slice = query.Deconstruct()) {
+        double sum = 0;
+        for (int i = 0; i < slice.Count; i++) {
+          sum += slice[i];
+        }
+        return sum / slice.Count;
+      }
+    }
+
+    /// <summary>
     /// Returns true if any element in the Query is equal to a specific value.
     /// </summary>
     public static bool Contains<T>(this Query<T> query, T item) {
@@ -354,7 +380,7 @@ namespace Leap.Unity.Query {
     /// Returns the largest element in the Query.
     /// </summary>
     public static T Max<T>(this Query<T> query) where T : IComparable<T> {
-      return query.Fold((a, b) => a.CompareTo(b) > 0 ? a : b);
+      return query.Fold(FoldDelegate<T>.max);
     }
 
     /// <summary>
@@ -368,7 +394,7 @@ namespace Leap.Unity.Query {
     /// Returns the smallest element in the Query.
     /// </summary>
     public static T Min<T>(this Query<T> query) where T : IComparable<T> {
-      return query.Fold((a, b) => a.CompareTo(b) < 0 ? a : b);
+      return query.Fold(FoldDelegate<T>.min);
     }
 
     /// <summary>
@@ -442,6 +468,27 @@ namespace Leap.Unity.Query {
     /// </summary>
     public static Maybe<T> SingleOrNone<T>(this Query<T> query, Func<T, bool> predicate) {
       return query.Where(predicate).SingleOrNone();
+    }
+
+    /// <summary>
+    /// Returns the sum of a Query of ints.
+    /// </summary>
+    public static int Sum(this Query<int> query) {
+      return query.Fold((a, b) => a + b);
+    }
+
+    /// <summary>
+    /// Returns the sum of a Query of floats.
+    /// </summary>
+    public static float Sum(this Query<float> query) {
+      return query.Fold((a, b) => a + b);
+    }
+
+    /// <summary>
+    /// Returns the sum of a Query of doubles.
+    /// </summary>
+    public static double Sum(this Query<double> query) {
+      return query.Fold((a, b) => a + b);
     }
 
     /// <summary>
@@ -583,6 +630,11 @@ namespace Leap.Unity.Query {
     /// </summary>
     public static Dictionary<T, V> ToDictionary<T, V>(this Query<T> query, Func<T, V> valueSelector) {
       return query.ToDictionary(t => t, valueSelector);
+    }
+
+    private static class FoldDelegate<T> where T : IComparable<T> {
+      public readonly static Func<T, T, T> max = (a, b) => a.CompareTo(b) > 0 ? a : b;
+      public readonly static Func<T, T, T> min = (a, b) => a.CompareTo(b) < 0 ? a : b;
     }
   }
 }

--- a/Assets/LeapMotion/Core/Scripts/Query/QueryOperatorExtensions.cs
+++ b/Assets/LeapMotion/Core/Scripts/Query/QueryOperatorExtensions.cs
@@ -119,14 +119,9 @@ namespace Leap.Unity.Query {
       int count;
       query.Deconstruct(out array, out count);
 
-      K[] keys = ArrayPool<K>.Spawn(count);
-      for (int i = 0; i < count; i++) {
-        keys[i] = selector(array[i]);
-      }
-
-      Array.Sort(keys, array, 0, count);
-
-      ArrayPool<K>.Recycle(keys);
+      var comparer = FunctorComparer<T, K>.Ascending(selector);
+      Array.Sort(array, 0, count, comparer);
+      comparer.Clear();
 
       return new Query<T>(array, count);
     }
@@ -136,7 +131,15 @@ namespace Leap.Unity.Query {
     /// to select the values to order by.
     /// </summary>
     public static Query<T> OrderByDescending<T, K>(this Query<T> query, Func<T, K> selector) where K : IComparable<K> {
-      return query.OrderBy(selector).Reverse();
+      T[] array;
+      int count;
+      query.Deconstruct(out array, out count);
+
+      var comparer = FunctorComparer<T, K>.Descending(selector);
+      Array.Sort(array, 0, count, comparer);
+      comparer.Clear();
+
+      return new Query<T>(array, count);
     }
 
     /// <summary>
@@ -574,6 +577,40 @@ namespace Leap.Unity.Query {
     public struct IndexedValue<T> {
       public int index;
       public T value;
+    }
+
+    private class FunctorComparer<T, K> : IComparer<T> where K : IComparable<K> {
+      [ThreadStatic]
+      private static FunctorComparer<T, K> _single;
+
+      private Func<T, K> _functor;
+      private int _sign;
+
+      private FunctorComparer() { }
+
+      public static FunctorComparer<T, K> Ascending(Func<T, K> functor) {
+        return single(functor, 1);
+      }
+
+      public static FunctorComparer<T, K> Descending(Func<T, K> functor) {
+        return single(functor, -1);
+      }
+
+      private static FunctorComparer<T, K> single(Func<T, K> functor, int sign) {
+        if (_single == null) {
+          _single = new FunctorComparer<T, K>();
+        }
+        _single._functor = functor;
+        return _single;
+      }
+
+      public void Clear() {
+        _functor = null;
+      }
+
+      public int Compare(T x, T y) {
+        return _sign * _functor(x).CompareTo(_functor(y));
+      }
     }
   }
 }

--- a/Assets/LeapMotion/Core/Scripts/Query/QueryOperatorExtensions.cs
+++ b/Assets/LeapMotion/Core/Scripts/Query/QueryOperatorExtensions.cs
@@ -601,6 +601,7 @@ namespace Leap.Unity.Query {
           _single = new FunctorComparer<T, K>();
         }
         _single._functor = functor;
+        _single._sign = sign;
         return _single;
       }
 


### PR DESCRIPTION
 - Fixed OrderBy allocating garbage due to not using the generic implementation.  Now cache static comparer objects to use in the Array.Sort method to properly sort by the selector function.
 - Fixed Max and Min allocating small garbage due to delegate allocation by caching the delegates
 - Added tests for Min and Max
 - Added basic Sum and Average collapsing functions and basic tests

To test:
 - [x] Make sure tests pass
 - [x] Make sure code looks good
 - [x] Make sure Min/Max/OrderBy/OrderByDescending do not allocate garbage when used