### PR TITLE
Tiny fix for the InteractionBehaviour custom editor

### DIFF
--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/Editor/InteractionBehaviourEditor.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/Editor/InteractionBehaviourEditor.cs
@@ -34,8 +34,7 @@ namespace Leap.Unity.Interaction {
       specifyConditionalDrawing(() => !targets.Query().All(intObj => intObj.ignoreGrasping),
                                 "_allowMultiGrasp",
                                 "_moveObjectWhenGrasped",
-                                "graspedMovementType",
-                                "graspHoldWarpingEnabled__curIgnored");
+                                "graspedMovementType");
 
       // Layer Overrides
       specifyConditionalDrawing(() => targets.Query().Any(intObj => intObj.overrideInteractionLayer),


### PR DESCRIPTION
Since we removed the "grasp hold warping __ unused" option, I needed to also remove it from the custom editor.