### PR TITLE
Fix occ. "Look rotation viewing vector is zero" in Rigged Hand

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/Hands/RiggedHand.cs
+++ b/Assets/LeapMotion/Core/Scripts/Hands/RiggedHand.cs
@@ -65,8 +65,12 @@ namespace Leap.Unity {
     }
 
     public Quaternion Reorientation() {
+      if (modelFingerPointing == Vector3.zero || modelPalmFacing == Vector3.zero) {
+        return Quaternion.identity;
+      }
       return Quaternion.Inverse(Quaternion.LookRotation(modelFingerPointing, -modelPalmFacing));
     }
+
     public override void UpdateHand() {
       if (palm != null) {
         if (ModelPalmAtLeapWrist) {


### PR DESCRIPTION
Happens when e.g. serialization gets messed up and the Rigged Hand gets zero vectors for reference "pointing directions."

Arguably the inspector should show some sort of helpful error when Rigged Hands are not correct, but this error (not even an error, just an inspector log) is unhelpful anyway, it's just console spam.