### PR TITLE
Tweaked worker thread profiling text

### DIFF
--- a/Assets/LeapMotion/Core/Editor/LeapServiceProviderEditor.cs
+++ b/Assets/LeapMotion/Core/Editor/LeapServiceProviderEditor.cs
@@ -39,7 +39,7 @@ namespace Leap.Unity {
                                 (int)LeapServiceProvider.PhysicsExtrapolationMode.Manual,
                                 "_physicsExtrapolationTime");
 
-      deferProperty("_enableDllProfiling");
+      deferProperty("_workerThreadProfiling");
     }
 
     private void frameOptimizationWarning(SerializedProperty property) {

--- a/Assets/LeapMotion/Core/Scripts/LeapServiceProvider.cs
+++ b/Assets/LeapMotion/Core/Scripts/LeapServiceProvider.cs
@@ -66,10 +66,10 @@ namespace Leap.Unity {
     [SerializeField]
     protected float _physicsExtrapolationTime = 1.0f / 90.0f;
 
-    [Tooltip("When checked, profiling data from the LeapCSharp dll will be used to populate the UnityProfiler.")]
+    [Tooltip("When checked, profiling data from the LeapCSharp worker thread will be used to populate the UnityProfiler.")]
     [EditTimeOnly]
     [SerializeField]
-    protected bool _enableDllProfiling = false;
+    protected bool _workerThreadProfiling = false;
 
     #endregion
 
@@ -243,7 +243,7 @@ namespace Leap.Unity {
     }
 
     protected virtual void Update() {
-      if (_enableDllProfiling) {
+      if (_workerThreadProfiling) {
         LeapProfiling.Update();
       }
 
@@ -441,7 +441,7 @@ namespace Leap.Unity {
         _leapController.Device += onHandControllerConnect;
       }
 
-      if (_enableDllProfiling) {
+      if (_workerThreadProfiling) {
         //A controller will report profiling statistics for the duration of it's lifetime
         //so these events will never be unsubscribed from.
         _leapController.EndProfilingBlock += LeapProfiling.EndProfilingBlock;


### PR DESCRIPTION
No more dll, so switch the text to call out the profiling of the _worker thread_ instead.  Even though all the logic has been moved into Unity, we can't easily simplify the worker thread profiling logic because of the simple fact that we need to construct CustomSampler objects on the main thread, so all the existing back and forth still needs to be performed.

To test: 
 - [x] Make sure ServiceProvider and XRServiceProvider both look correct in the inspector and have good tooltips.