### PR TITLE
Delete annoying "No LeapProvider" warning

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/Utils/HandUtils.cs
+++ b/Assets/LeapMotion/Core/Scripts/Utils/HandUtils.cs
@@ -71,9 +71,6 @@ namespace Leap.Unity {
       get {
         if (s_provider == null) {
           InitStatic();
-          if (s_provider == null) {
-            Debug.LogWarning("No LeapProvider found in the scene.");
-          }
         }
         return s_provider;
       }

--- a/Assets/LeapMotion/Core/Scripts/Utils/HandUtils.cs
+++ b/Assets/LeapMotion/Core/Scripts/Utils/HandUtils.cs
@@ -56,16 +56,22 @@ namespace Leap.Unity {
       get {
         if (s_leapRig == null) {
           InitStatic();
-          if (s_leapRig == null) {
-            Debug.LogWarning("Camera has no parent; Rig will return null.");
-          }
         }
         return s_leapRig;
       }
     }
 
     /// <summary>
-    /// Static convenience accessor for the LeapProvider.
+    /// Static convenience accessor for a LeapProvider in the scene. Preference is given
+    /// to a LeapServiceProvider if there is one.
+    /// 
+    /// If static memory currently has no reference for the provider (or if it was
+    /// destroyed), this call will search the scene for a LeapProvider and cache it to be
+    /// returned next time.
+    /// 
+    /// If there is no LeapProvider in your scene, this getter
+    /// will return null. Be warned that calling this regularly can be expensive if
+    /// LeapProviders often don't exist in your scene or are frequently destroyed.
     /// </summary>
     public static LeapProvider Provider {
       get {


### PR DESCRIPTION
I have found this little set of lines to be incredibly annoying.

Overall motivation: Often, a project only *sometimes* supports Leap, and sometimes just doesn't have a static Provider available. I think this should just be fine, and static accessors can search the scene and return null, and errbody will be fine because null reference exceptions are a normal part of life.

Alternative:
- Have the error message print by default, but allow a LeapPreferences checkbox for disabling it. I'm not sure this is worth the extra effort.

Thoughts?