### PR TITLE
Remove unsafe code

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/Utils/BitConverterNonAlloc.cs
+++ b/Assets/LeapMotion/Core/Scripts/Utils/BitConverterNonAlloc.cs
@@ -8,313 +8,337 @@
  ******************************************************************************/
 
 using System;
+using System.Runtime.InteropServices;
 
 namespace Leap.Unity {
 
-  public class BitConverterNonAlloc {
+  public static class BitConverterNonAlloc {
+    private static ConversionStruct _c = new ConversionStruct();
+
 
     public static UInt16 ToUInt16(byte[] bytes, int offset = 0) {
-      unsafe {
-        fixed (byte* ptr = &bytes[offset]) {
-          UInt16* primitivePtr = (UInt16*)ptr;
-          return *primitivePtr;
-        }
-      }
-    }
-
-    public static UInt16 ToUInt16(byte[] bytes, ref int offset) {
-      unsafe {
-        fixed (byte* ptr = &bytes[offset]) {
-          offset += sizeof(UInt16);
-          UInt16* primitivePtr = (UInt16*)ptr;
-          return *primitivePtr;
-        }
-      }
-    }
-
-    public static void GetBytes(UInt16 primitive, byte[] bytes, int offset = 0) {
-      unsafe {
-        fixed (byte* ptr = &bytes[offset]) {
-          UInt16* primitivePtr = (UInt16*)ptr;
-          *primitivePtr = primitive;
-        }
-      }
-    }
-
-    public static void GetBytes(UInt16 primitive, byte[] bytes, ref int offset) {
-      unsafe {
-        fixed (byte* ptr = &bytes[offset]) {
-          offset += sizeof(UInt16);
-          UInt16* primitivePtr = (UInt16*)ptr;
-          *primitivePtr = primitive;
-        }
-      }
+      _c.Byte0 = bytes[offset++];
+      _c.Byte1 = bytes[offset++];
+      return _c.UInt16;
     }
 
     public static Int16 ToInt16(byte[] bytes, int offset = 0) {
-      unsafe {
-        fixed (byte* ptr = &bytes[offset]) {
-          Int16* primitivePtr = (Int16*)ptr;
-          return *primitivePtr;
-        }
-      }
-    }
-
-    public static Int16 ToInt16(byte[] bytes, ref int offset) {
-      unsafe {
-        fixed (byte* ptr = &bytes[offset]) {
-          offset += sizeof(Int16);
-          Int16* primitivePtr = (Int16*)ptr;
-          return *primitivePtr;
-        }
-      }
-    }
-
-    public static void GetBytes(Int16 primitive, byte[] bytes, int offset = 0) {
-      unsafe {
-        fixed (byte* ptr = &bytes[offset]) {
-          Int16* primitivePtr = (Int16*)ptr;
-          *primitivePtr = primitive;
-        }
-      }
-    }
-
-    public static void GetBytes(Int16 primitive, byte[] bytes, ref int offset) {
-      unsafe {
-        fixed (byte* ptr = &bytes[offset]) {
-          offset += sizeof(Int16);
-          Int16* primitivePtr = (Int16*)ptr;
-          *primitivePtr = primitive;
-        }
-      }
+      _c.Byte0 = bytes[offset++];
+      _c.Byte1 = bytes[offset++];
+      return _c.Int16;
     }
 
     public static UInt32 ToUInt32(byte[] bytes, int offset = 0) {
-      unsafe {
-        fixed (byte* ptr = &bytes[offset]) {
-          UInt32* primitivePtr = (UInt32*)ptr;
-          return *primitivePtr;
-        }
-      }
-    }
-
-    public static UInt32 ToUInt32(byte[] bytes, ref int offset) {
-      unsafe {
-        fixed (byte* ptr = &bytes[offset]) {
-          offset += sizeof(UInt32);
-          UInt32* primitivePtr = (UInt32*)ptr;
-          return *primitivePtr;
-        }
-      }
-    }
-
-    public static void GetBytes(UInt32 primitive, byte[] bytes, int offset = 0) {
-      unsafe {
-        fixed (byte* ptr = &bytes[offset]) {
-          UInt32* primitivePtr = (UInt32*)ptr;
-          *primitivePtr = primitive;
-        }
-      }
-    }
-
-    public static void GetBytes(UInt32 primitive, byte[] bytes, ref int offset) {
-      unsafe {
-        fixed (byte* ptr = &bytes[offset]) {
-          offset += sizeof(UInt32);
-          UInt32* primitivePtr = (UInt32*)ptr;
-          *primitivePtr = primitive;
-        }
-      }
+      _c.Byte0 = bytes[offset++];
+      _c.Byte1 = bytes[offset++];
+      _c.Byte2 = bytes[offset++];
+      _c.Byte3 = bytes[offset++];
+      return _c.UInt32;
     }
 
     public static Int32 ToInt32(byte[] bytes, int offset = 0) {
-      unsafe {
-        fixed (byte* ptr = &bytes[offset]) {
-          Int32* primitivePtr = (Int32*)ptr;
-          return *primitivePtr;
-        }
-      }
-    }
-
-    public static Int32 ToInt32(byte[] bytes, ref int offset) {
-      unsafe {
-        fixed (byte* ptr = &bytes[offset]) {
-          offset += sizeof(Int32);
-          Int32* primitivePtr = (Int32*)ptr;
-          return *primitivePtr;
-        }
-      }
-    }
-
-    public static void GetBytes(Int32 primitive, byte[] bytes, int offset = 0) {
-      unsafe {
-        fixed (byte* ptr = &bytes[offset]) {
-          Int32* primitivePtr = (Int32*)ptr;
-          *primitivePtr = primitive;
-        }
-      }
-    }
-
-    public static void GetBytes(Int32 primitive, byte[] bytes, ref int offset) {
-      unsafe {
-        fixed (byte* ptr = &bytes[offset]) {
-          offset += sizeof(Int32);
-          Int32* primitivePtr = (Int32*)ptr;
-          *primitivePtr = primitive;
-        }
-      }
+      _c.Byte0 = bytes[offset++];
+      _c.Byte1 = bytes[offset++];
+      _c.Byte2 = bytes[offset++];
+      _c.Byte3 = bytes[offset++];
+      return _c.Int32;
     }
 
     public static UInt64 ToUInt64(byte[] bytes, int offset = 0) {
-      unsafe {
-        fixed (byte* ptr = &bytes[offset]) {
-          UInt64* primitivePtr = (UInt64*)ptr;
-          return *primitivePtr;
-        }
-      }
-    }
-
-    public static UInt64 ToUInt64(byte[] bytes, ref int offset) {
-      unsafe {
-        fixed (byte* ptr = &bytes[offset]) {
-          offset += sizeof(UInt64);
-          UInt64* primitivePtr = (UInt64*)ptr;
-          return *primitivePtr;
-        }
-      }
-    }
-
-    public static void GetBytes(UInt64 primitive, byte[] bytes, int offset = 0) {
-      unsafe {
-        fixed (byte* ptr = &bytes[offset]) {
-          UInt64* primitivePtr = (UInt64*)ptr;
-          *primitivePtr = primitive;
-        }
-      }
-    }
-
-    public static void GetBytes(UInt64 primitive, byte[] bytes, ref int offset) {
-      unsafe {
-        fixed (byte* ptr = &bytes[offset]) {
-          offset += sizeof(UInt64);
-          UInt64* primitivePtr = (UInt64*)ptr;
-          *primitivePtr = primitive;
-        }
-      }
+      _c.Byte0 = bytes[offset++];
+      _c.Byte1 = bytes[offset++];
+      _c.Byte2 = bytes[offset++];
+      _c.Byte3 = bytes[offset++];
+      _c.Byte4 = bytes[offset++];
+      _c.Byte5 = bytes[offset++];
+      _c.Byte6 = bytes[offset++];
+      _c.Byte7 = bytes[offset++];
+      return _c.UInt64;
     }
 
     public static Int64 ToInt64(byte[] bytes, int offset = 0) {
-      unsafe {
-        fixed (byte* ptr = &bytes[offset]) {
-          Int64* primitivePtr = (Int64*)ptr;
-          return *primitivePtr;
-        }
-      }
-    }
-
-    public static Int64 ToInt64(byte[] bytes, ref int offset) {
-      unsafe {
-        fixed (byte* ptr = &bytes[offset]) {
-          offset += sizeof(Int64);
-          Int64* primitivePtr = (Int64*)ptr;
-          return *primitivePtr;
-        }
-      }
-    }
-
-    public static void GetBytes(Int64 primitive, byte[] bytes, int offset = 0) {
-      unsafe {
-        fixed (byte* ptr = &bytes[offset]) {
-          Int64* primitivePtr = (Int64*)ptr;
-          *primitivePtr = primitive;
-        }
-      }
-    }
-
-    public static void GetBytes(Int64 primitive, byte[] bytes, ref int offset) {
-      unsafe {
-        fixed (byte* ptr = &bytes[offset]) {
-          offset += sizeof(Int64);
-          Int64* primitivePtr = (Int64*)ptr;
-          *primitivePtr = primitive;
-        }
-      }
+      _c.Byte0 = bytes[offset++];
+      _c.Byte1 = bytes[offset++];
+      _c.Byte2 = bytes[offset++];
+      _c.Byte3 = bytes[offset++];
+      _c.Byte4 = bytes[offset++];
+      _c.Byte5 = bytes[offset++];
+      _c.Byte6 = bytes[offset++];
+      _c.Byte7 = bytes[offset++];
+      return _c.Int64;
     }
 
     public static Single ToSingle(byte[] bytes, int offset = 0) {
-      unsafe {
-        fixed (byte* ptr = &bytes[offset]) {
-          Single* primitivePtr = (Single*)ptr;
-          return *primitivePtr;
-        }
-      }
-    }
-
-    public static Single ToSingle(byte[] bytes, ref int offset) {
-      unsafe {
-        fixed (byte* ptr = &bytes[offset]) {
-          offset += sizeof(Single);
-          Single* primitivePtr = (Single*)ptr;
-          return *primitivePtr;
-        }
-      }
-    }
-
-    public static void GetBytes(Single primitive, byte[] bytes, int offset = 0) {
-      unsafe {
-        fixed (byte* ptr = &bytes[offset]) {
-          Single* primitivePtr = (Single*)ptr;
-          *primitivePtr = primitive;
-        }
-      }
-    }
-
-    public static void GetBytes(Single primitive, byte[] bytes, ref int offset) {
-      unsafe {
-        fixed (byte* ptr = &bytes[offset]) {
-          offset += sizeof(Single);
-          Single* primitivePtr = (Single*)ptr;
-          *primitivePtr = primitive;
-        }
-      }
+      _c.Byte0 = bytes[offset++];
+      _c.Byte1 = bytes[offset++];
+      _c.Byte2 = bytes[offset++];
+      _c.Byte3 = bytes[offset++];
+      return _c.Single;
     }
 
     public static Double ToDouble(byte[] bytes, int offset = 0) {
-      unsafe {
-        fixed (byte* ptr = &bytes[offset]) {
-          Double* primitivePtr = (Double*)ptr;
-          return *primitivePtr;
-        }
-      }
+      _c.Byte0 = bytes[offset++];
+      _c.Byte1 = bytes[offset++];
+      _c.Byte2 = bytes[offset++];
+      _c.Byte3 = bytes[offset++];
+      _c.Byte4 = bytes[offset++];
+      _c.Byte5 = bytes[offset++];
+      _c.Byte6 = bytes[offset++];
+      _c.Byte7 = bytes[offset++];
+      return _c.Double;
+    }
+
+    public static UInt16 ToUInt16(byte[] bytes, ref int offset) {
+      _c.Byte0 = bytes[offset++];
+      _c.Byte1 = bytes[offset++];
+      return _c.UInt16;
+    }
+
+    public static Int16 ToInt16(byte[] bytes, ref int offset) {
+      _c.Byte0 = bytes[offset++];
+      _c.Byte1 = bytes[offset++];
+      return _c.Int16;
+    }
+
+    public static UInt32 ToUInt32(byte[] bytes, ref int offset) {
+      _c.Byte0 = bytes[offset++];
+      _c.Byte1 = bytes[offset++];
+      _c.Byte2 = bytes[offset++];
+      _c.Byte3 = bytes[offset++];
+      return _c.UInt32;
+    }
+
+    public static Int32 ToInt32(byte[] bytes, ref int offset) {
+      _c.Byte0 = bytes[offset++];
+      _c.Byte1 = bytes[offset++];
+      _c.Byte2 = bytes[offset++];
+      _c.Byte3 = bytes[offset++];
+      return _c.Int32;
+    }
+
+    public static UInt64 ToUInt64(byte[] bytes, ref int offset) {
+      _c.Byte0 = bytes[offset++];
+      _c.Byte1 = bytes[offset++];
+      _c.Byte2 = bytes[offset++];
+      _c.Byte3 = bytes[offset++];
+      _c.Byte4 = bytes[offset++];
+      _c.Byte5 = bytes[offset++];
+      _c.Byte6 = bytes[offset++];
+      _c.Byte7 = bytes[offset++];
+      return _c.UInt64;
+    }
+
+    public static Int64 ToInt64(byte[] bytes, ref int offset) {
+      _c.Byte0 = bytes[offset++];
+      _c.Byte1 = bytes[offset++];
+      _c.Byte2 = bytes[offset++];
+      _c.Byte3 = bytes[offset++];
+      _c.Byte4 = bytes[offset++];
+      _c.Byte5 = bytes[offset++];
+      _c.Byte6 = bytes[offset++];
+      _c.Byte7 = bytes[offset++];
+      return _c.Int64;
+    }
+
+    public static Single ToSingle(byte[] bytes, ref int offset) {
+      _c.Byte0 = bytes[offset++];
+      _c.Byte1 = bytes[offset++];
+      _c.Byte2 = bytes[offset++];
+      _c.Byte3 = bytes[offset++];
+      return _c.Single;
     }
 
     public static Double ToDouble(byte[] bytes, ref int offset) {
-      unsafe {
-        fixed (byte* ptr = &bytes[offset]) {
-          offset += sizeof(Double);
-          Double* primitivePtr = (Double*)ptr;
-          return *primitivePtr;
-        }
-      }
+      _c.Byte0 = bytes[offset++];
+      _c.Byte1 = bytes[offset++];
+      _c.Byte2 = bytes[offset++];
+      _c.Byte3 = bytes[offset++];
+      _c.Byte4 = bytes[offset++];
+      _c.Byte5 = bytes[offset++];
+      _c.Byte6 = bytes[offset++];
+      _c.Byte7 = bytes[offset++];
+      return _c.Double;
     }
 
-    public static void GetBytes(Double primitive, byte[] bytes, int offset = 0) {
-      unsafe {
-        fixed (byte* ptr = &bytes[offset]) {
-          Double* primitivePtr = (Double*)ptr;
-          *primitivePtr = primitive;
-        }
-      }
+    public static void GetBytes(UInt16 value, byte[] bytes, int offset = 0) {
+      _c.UInt16 = value;
+      bytes[offset++] = _c.Byte0;
+      bytes[offset++] = _c.Byte1;
     }
 
-    public static void GetBytes(Double primitive, byte[] bytes, ref int offset) {
-      unsafe {
-        fixed (byte* ptr = &bytes[offset]) {
-          offset += sizeof(Double);
-          Double* primitivePtr = (Double*)ptr;
-          *primitivePtr = primitive;
-        }
-      }
+    public static void GetBytes(Int16 value, byte[] bytes, int offset = 0) {
+      _c.Int16 = value;
+      bytes[offset++] = _c.Byte0;
+      bytes[offset++] = _c.Byte1;
+    }
+
+    public static void GetBytes(UInt32 value, byte[] bytes, int offset = 0) {
+      _c.UInt32 = value;
+      bytes[offset++] = _c.Byte0;
+      bytes[offset++] = _c.Byte1;
+      bytes[offset++] = _c.Byte2;
+      bytes[offset++] = _c.Byte3;
+    }
+
+    public static void GetBytes(Int32 value, byte[] bytes, int offset = 0) {
+      _c.Int32 = value;
+      bytes[offset++] = _c.Byte0;
+      bytes[offset++] = _c.Byte1;
+      bytes[offset++] = _c.Byte2;
+      bytes[offset++] = _c.Byte3;
+    }
+
+    public static void GetBytes(UInt64 value, byte[] bytes, int offset = 0) {
+      _c.UInt64 = value;
+      bytes[offset++] = _c.Byte0;
+      bytes[offset++] = _c.Byte1;
+      bytes[offset++] = _c.Byte2;
+      bytes[offset++] = _c.Byte3;
+      bytes[offset++] = _c.Byte4;
+      bytes[offset++] = _c.Byte5;
+      bytes[offset++] = _c.Byte6;
+      bytes[offset++] = _c.Byte7;
+    }
+
+    public static void GetBytes(Int64 value, byte[] bytes, int offset = 0) {
+      _c.Int64 = value;
+      bytes[offset++] = _c.Byte0;
+      bytes[offset++] = _c.Byte1;
+      bytes[offset++] = _c.Byte2;
+      bytes[offset++] = _c.Byte3;
+      bytes[offset++] = _c.Byte4;
+      bytes[offset++] = _c.Byte5;
+      bytes[offset++] = _c.Byte6;
+      bytes[offset++] = _c.Byte7;
+    }
+
+    public static void GetBytes(Single value, byte[] bytes, int offset = 0) {
+      _c.Single = value;
+      bytes[offset++] = _c.Byte0;
+      bytes[offset++] = _c.Byte1;
+      bytes[offset++] = _c.Byte2;
+      bytes[offset++] = _c.Byte3;
+    }
+
+    public static void GetBytes(Double value, byte[] bytes, int offset = 0) {
+      _c.Double = value;
+      bytes[offset++] = _c.Byte0;
+      bytes[offset++] = _c.Byte1;
+      bytes[offset++] = _c.Byte2;
+      bytes[offset++] = _c.Byte3;
+      bytes[offset++] = _c.Byte4;
+      bytes[offset++] = _c.Byte5;
+      bytes[offset++] = _c.Byte6;
+      bytes[offset++] = _c.Byte7;
+    }
+
+    public static void GetBytes(UInt16 value, byte[] bytes, ref int offset) {
+      _c.UInt16 = value;
+      bytes[offset++] = _c.Byte0;
+      bytes[offset++] = _c.Byte1;
+    }
+
+    public static void GetBytes(Int16 value, byte[] bytes, ref int offset) {
+      _c.Int16 = value;
+      bytes[offset++] = _c.Byte0;
+      bytes[offset++] = _c.Byte1;
+    }
+
+    public static void GetBytes(UInt32 value, byte[] bytes, ref int offset) {
+      _c.UInt32 = value;
+      bytes[offset++] = _c.Byte0;
+      bytes[offset++] = _c.Byte1;
+      bytes[offset++] = _c.Byte2;
+      bytes[offset++] = _c.Byte3;
+    }
+
+    public static void GetBytes(Int32 value, byte[] bytes, ref int offset) {
+      _c.Int32 = value;
+      bytes[offset++] = _c.Byte0;
+      bytes[offset++] = _c.Byte1;
+      bytes[offset++] = _c.Byte2;
+      bytes[offset++] = _c.Byte3;
+    }
+
+    public static void GetBytes(UInt64 value, byte[] bytes, ref int offset) {
+      _c.UInt64 = value;
+      bytes[offset++] = _c.Byte0;
+      bytes[offset++] = _c.Byte1;
+      bytes[offset++] = _c.Byte2;
+      bytes[offset++] = _c.Byte3;
+      bytes[offset++] = _c.Byte4;
+      bytes[offset++] = _c.Byte5;
+      bytes[offset++] = _c.Byte6;
+      bytes[offset++] = _c.Byte7;
+    }
+
+    public static void GetBytes(Int64 value, byte[] bytes, ref int offset) {
+      _c.Int64 = value;
+      bytes[offset++] = _c.Byte0;
+      bytes[offset++] = _c.Byte1;
+      bytes[offset++] = _c.Byte2;
+      bytes[offset++] = _c.Byte3;
+      bytes[offset++] = _c.Byte4;
+      bytes[offset++] = _c.Byte5;
+      bytes[offset++] = _c.Byte6;
+      bytes[offset++] = _c.Byte7;
+    }
+
+    public static void GetBytes(Single value, byte[] bytes, ref int offset) {
+      _c.Single = value;
+      bytes[offset++] = _c.Byte0;
+      bytes[offset++] = _c.Byte1;
+      bytes[offset++] = _c.Byte2;
+      bytes[offset++] = _c.Byte3;
+    }
+
+    public static void GetBytes(Double value, byte[] bytes, ref int offset) {
+      _c.Double = value;
+      bytes[offset++] = _c.Byte0;
+      bytes[offset++] = _c.Byte1;
+      bytes[offset++] = _c.Byte2;
+      bytes[offset++] = _c.Byte3;
+      bytes[offset++] = _c.Byte4;
+      bytes[offset++] = _c.Byte5;
+      bytes[offset++] = _c.Byte6;
+      bytes[offset++] = _c.Byte7;
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    private struct ConversionStruct {
+      [FieldOffset(0)]
+      public byte Byte0;
+      [FieldOffset(1)]
+      public byte Byte1;
+      [FieldOffset(2)]
+      public byte Byte2;
+      [FieldOffset(3)]
+      public byte Byte3;
+      [FieldOffset(4)]
+      public byte Byte4;
+      [FieldOffset(5)]
+      public byte Byte5;
+      [FieldOffset(6)]
+      public byte Byte6;
+      [FieldOffset(7)]
+      public byte Byte7;
+
+      [FieldOffset(0)]
+      public UInt16 UInt16;
+      [FieldOffset(0)]
+      public Int16 Int16;
+      [FieldOffset(0)]
+      public UInt32 UInt32;
+      [FieldOffset(0)]
+      public Int32 Int32;
+      [FieldOffset(0)]
+      public UInt64 UInt64;
+      [FieldOffset(0)]
+      public Int64 Int64;
+      [FieldOffset(0)]
+      public Single Single;
+      [FieldOffset(0)]
+      public Double Double;
     }
   }
 }

--- a/Assets/LeapMotion/Internal/Generation/BitConverter/BitConverterTemplate.cs
+++ b/Assets/LeapMotion/Internal/Generation/BitConverter/BitConverterTemplate.cs
@@ -31,15 +31,15 @@ namespace Leap.Unity.Generation {
     //END
     //BEGIN GET
 
-    public static void GetBytes(Single single, byte[] bytes, int offset = 0) {
-      _c.Single = single;
+    public static void GetBytes(Single value, byte[] bytes, int offset = 0) {
+      _c.Single = value;
       //FILL BYTES
     }
     //END
     //BEGIN GET
 
-    public static void GetBytes(Single single, byte[] bytes, ref int offset) {
-      _c.Single = single;
+    public static void GetBytes(Single value, byte[] bytes, ref int offset) {
+      _c.Single = value;
       //FILL BYTES
     }
     //END

--- a/Assets/LeapMotion/Internal/Generation/BitConverter/BitConverterTemplate.cs
+++ b/Assets/LeapMotion/Internal/Generation/BitConverter/BitConverterTemplate.cs
@@ -8,49 +8,77 @@
  ******************************************************************************/
 
 using System;
+using System.Runtime.InteropServices;
 
 namespace Leap.Unity.Generation {
 
-  public class BitConverterNonAlloc_Template_ {
-    //BEGIN
+  public static class BitConverterNonAlloc_Template_ {
+    private static ConversionStruct _c = new ConversionStruct();
 
-    public static _Primitive_ To_Primitive_(byte[] bytes, int offset = 0) {
-      unsafe {
-        fixed (byte* ptr = &bytes[offset]) {
-          _Primitive_* primitivePtr = (_Primitive_*)ptr;
-          return *primitivePtr;
-        }
-      }
-    }
+    //BEGIN TO
 
-    public static _Primitive_ To_Primitive_(byte[] bytes, ref int offset) {
-      unsafe {
-        fixed (byte* ptr = &bytes[offset]) {
-          offset += sizeof(_Primitive_);
-          _Primitive_* primitivePtr = (_Primitive_*)ptr;
-          return *primitivePtr;
-        }
-      }
-    }
-
-    public static void GetBytes(_Primitive_ primitive, byte[] bytes, int offset = 0) {
-      unsafe {
-        fixed (byte* ptr = &bytes[offset]) {
-          _Primitive_* primitivePtr = (_Primitive_*)ptr;
-          *primitivePtr = primitive;
-        }
-      }
-    }
-
-    public static void GetBytes(_Primitive_ primitive, byte[] bytes, ref int offset) {
-      unsafe {
-        fixed (byte* ptr = &bytes[offset]) {
-          offset += sizeof(_Primitive_);
-          _Primitive_* primitivePtr = (_Primitive_*)ptr;
-          *primitivePtr = primitive;
-        }
-      }
+    public static Single ToSingle(byte[] bytes, int offset = 0) {
+      //FILL BYTES
+      return _c.Single;
     }
     //END
+    //BEGIN TO
+
+    public static Single ToSingle(byte[] bytes, ref int offset) {
+      //FILL BYTES
+      return _c.Single;
+    }
+    //END
+    //BEGIN GET
+
+    public static void GetBytes(Single single, byte[] bytes, int offset = 0) {
+      _c.Single = single;
+      //FILL BYTES
+    }
+    //END
+    //BEGIN GET
+
+    public static void GetBytes(Single single, byte[] bytes, ref int offset) {
+      _c.Single = single;
+      //FILL BYTES
+    }
+    //END
+
+    [StructLayout(LayoutKind.Explicit)]
+    private struct ConversionStruct {
+      [FieldOffset(0)]
+      public byte Byte0;
+      [FieldOffset(1)]
+      public byte Byte1;
+      [FieldOffset(2)]
+      public byte Byte2;
+      [FieldOffset(3)]
+      public byte Byte3;
+      [FieldOffset(4)]
+      public byte Byte4;
+      [FieldOffset(5)]
+      public byte Byte5;
+      [FieldOffset(6)]
+      public byte Byte6;
+      [FieldOffset(7)]
+      public byte Byte7;
+
+      [FieldOffset(0)]
+      public UInt16 UInt16;
+      [FieldOffset(0)]
+      public Int16 Int16;
+      [FieldOffset(0)]
+      public UInt32 UInt32;
+      [FieldOffset(0)]
+      public Int32 Int32;
+      [FieldOffset(0)]
+      public UInt64 UInt64;
+      [FieldOffset(0)]
+      public Int64 Int64;
+      [FieldOffset(0)]
+      public Single Single;
+      [FieldOffset(0)]
+      public Double Double;
+    }
   }
 }


### PR DESCRIPTION
Removed the one instance where we were using unsafe code, in the BitConverterNoAlloc.  This is replaced with the original union based code that behaves the same way, but is slightly less efficient.

To test:
 - [ ] Make sure tests pass
 - [ ] Make sure new code looks good