### PR TITLE
Add query method to (class-based) indexables

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/DataStructures/IIndexable.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/IIndexable.cs
@@ -30,6 +30,14 @@ namespace Leap.Unity {
     public static IndexableEnumerator<T> GetEnumerator<T>(this IIndexable<T> indexable) {
       return new IndexableEnumerator<T>(indexable);
     }
+
+    public static Query<T> Query<T>(this IIndexable<T> indexable) {
+      var arr = ArrayPool<T>.Spawn(indexable.Count);
+      for (int i = 0; i < indexable.Count; i++) {
+        arr[i] = indexable[i];
+      }
+      return new Query<T>(arr, indexable.Count);
+    }
   }
 
   public struct IndexableEnumerator<Element> {


### PR DESCRIPTION
This PR adds a Query() function back to (class-based) Indexables.

This does it pretty naively, copying the data to an array for querying. We can probably do better? @Amarcolina 

I had to do this in AppExperiments to get it to compile since a lot of the older code uses Querying a lot on IIndexables. In that case I think it's happening on structs :( but better garbage than non-functionality. Here it's less of an issue I think because IIndexable clearly recommends the use of the interface for classes only.