### PR TITLE
Add null checks to various components of rig upgrader

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/EditorTools/Editor/LeapRigUpgrader.cs
+++ b/Assets/LeapMotion/Core/Scripts/EditorTools/Editor/LeapRigUpgrader.cs
@@ -972,12 +972,14 @@ namespace Leap.Unity {
       }
       else {
         var enableDepthBufferScript = this.cameraData.enableDepthBuffer;
-        if (options.camera_removeEnableDepthBufferScript) {
+        if (options.camera_removeEnableDepthBufferScript
+            && enableDepthBufferScript != null) {
           Undo.DestroyObjectImmediate(enableDepthBufferScript);
         }
 
         var eyeDislocator = this.cameraData.leapEyeDislocator;
-        if (options.camera_removeLeapEyeDislocator) {
+        if (options.camera_removeLeapEyeDislocator
+            && eyeDislocator != null) {
           Undo.DestroyObjectImmediate(eyeDislocator);
         }
         
@@ -985,7 +987,8 @@ namespace Leap.Unity {
           var rightEyeCamData = this.imageRigData.rightEyeCamData;
           if (rightEyeCamData != null) {
             var rightEyeTransform = rightEyeCamData.cameraTransform;
-            if (options.camera_removeRightEyeCamera) {
+            if (options.camera_removeRightEyeCamera
+                && rightEyeTransform != null) {
               Undo.DestroyObjectImmediate(rightEyeTransform.gameObject);
             }
           }
@@ -1003,8 +1006,9 @@ namespace Leap.Unity {
         }
         else {
           var leapSpaceExtraChildren = leapSpaceData.nonLHCChildTransforms;
-          if (options.leapSpace_mergeExtraChildrenUpward) {
-            foreach (var extraChild in leapSpaceExtraChildren) {
+          if (options.leapSpace_mergeExtraChildrenUpward
+              && leapSpaceExtraChildren != null) {
+            foreach (var extraChild in leapSpaceExtraChildren.Query().Where(t => t != null)) {
               Undo.SetTransformParent(extraChild, cameraTransform,
                 "Move LeapSpace child to Camera");
             }
@@ -1018,8 +1022,9 @@ namespace Leap.Unity {
           }
           else {
             var lhcExtraChildren = lhcData.extraChildTransforms;
-            if (options.lhc_mergeExtraChildrenUpward) {
-              foreach (var extraChild in lhcExtraChildren) {
+            if (options.lhc_mergeExtraChildrenUpward
+                && lhcExtraChildren != null) {
+              foreach (var extraChild in lhcExtraChildren.Query().Where(t => t != null)) {
                 Undo.SetTransformParent(extraChild, cameraTransform,
                   "Move LHC child to Camera");
               }
@@ -1059,7 +1064,7 @@ namespace Leap.Unity {
             // Migrate any extra components on the LHC to the camera.
             var extraComponents = lhcData.extraComponents;
             if (extraComponents != null && extraComponents.Count > 0) {
-              foreach (var component in extraComponents) {
+              foreach (var component in extraComponents.Query().Where(c => c != null)) {
                 var newComponent
                   = cameraTransform.gameObject.AddComponent(component.GetType());
 


### PR DESCRIPTION
This PR resolves at least one issue found in the wild when EnableDepthBuffer didn't actually exist on a camera to be upgraded; for safety, I added null checks for the other non-camera components that are identified in a rig.