### PR TITLE
Reorder stop and join attempts when stopping connection

### DIFF
--- a/Assets/LeapMotion/Core/Plugins/LeapCSharp/Connection.cs
+++ b/Assets/LeapMotion/Core/Plugins/LeapCSharp/Connection.cs
@@ -179,8 +179,18 @@ namespace LeapInternal {
         return;
 
       _isRunning = false;
-      _polster.Join();
+
+      //Very important to close the connection before we try to join the
+      //worker thread!  The call to PollConnection can sometimes block,
+      //despite the timeout, causing an attempt to join the thread waiting
+      //forever and preventing the connection from stopping.
+      //
+      //It seems that closing the connection causes PollConnection to 
+      //unblock in these cases, so just make sure to close the connection
+      //before trying to join the worker thread.
       LeapC.CloseConnection(_leapConnection);
+
+      _polster.Join();
     }
 
     //Run in Polster thread, fills in object queues


### PR DESCRIPTION
The LeapC.PollConnection can block under certain circumstances (like when the device is unplugged) despite the timeout argument.  This may or may not be a bug, but either way, the fact that calling CloseConnection unblocks the call to PollConnection means that we have an effective workaround to the freeze issue.  When attempting to stop a connection, we simply need to stop the connection _before_ attempting to join the worker thread.

To test:
 - [x] Make sure that when unplugging the device during an application, you are still able to stop the application (or exit playmode)