### PR TITLE
Detatch on destroy if we are at runtime

### DIFF
--- a/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/LeapGraphic.cs
+++ b/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/LeapGraphic.cs
@@ -366,6 +366,12 @@ namespace Leap.Unity.GraphicalRenderer {
       patchReferences();
     }
 
+    protected virtual void OnDestroy() {
+      if (Application.isPlaying && isAttachedToGroup) {
+        TryDetach();
+      }
+    }
+
     protected virtual void OnDrawGizmos() {
 #if UNITY_EDITOR
       editor.OnDrawGizmos();


### PR DESCRIPTION
Simple fix that allows graphics to be destroyed at runtime (if they can be detached at runtime!)