### PR TITLE
Feature: Periodic Controller Polling

### DIFF
--- a/Assets/LeapMotion/Modules/InteractionEngine/Examples/5. Anchors/Anchors.unity
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Examples/5. Anchors/Anchors.unity
@@ -7544,6 +7544,11 @@ Prefab:
   m_Modification:
     m_TransformParent: {fileID: 892104472}
     m_Modifications:
+    - target: {fileID: 114205148317838364, guid: 40e809833d307ef4983e1e71fe56e23b,
+        type: 2}
+      propertyPath: _enableObjectsOnlyWhenTracked.Array.size
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 4829828358790816, guid: 40e809833d307ef4983e1e71fe56e23b, type: 2}
       propertyPath: m_LocalPosition.x
       value: -0.0801
@@ -7580,6 +7585,16 @@ Prefab:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 114205148317838364, guid: 40e809833d307ef4983e1e71fe56e23b,
+        type: 2}
+      propertyPath: _enableObjectsOnlyWhenTracked.Array.data[2]
+      value: 
+      objectReference: {fileID: 1424211469}
+    - target: {fileID: 114205148317838364, guid: 40e809833d307ef4983e1e71fe56e23b,
+        type: 2}
+      propertyPath: _enableObjectsOnlyWhenTracked.Array.data[3]
+      value: 
+      objectReference: {fileID: 1424211469}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 40e809833d307ef4983e1e71fe56e23b, type: 2}
   m_IsPrefabParent: 0
@@ -9032,6 +9047,11 @@ Prefab:
   m_Modification:
     m_TransformParent: {fileID: 892104472}
     m_Modifications:
+    - target: {fileID: 114252805458954098, guid: 9361ab6d13ee87644bc370bccb524144,
+        type: 2}
+      propertyPath: _enableObjectsOnlyWhenTracked.Array.size
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 4911511504652324, guid: 9361ab6d13ee87644bc370bccb524144, type: 2}
       propertyPath: m_LocalPosition.x
       value: 0.0801
@@ -9068,6 +9088,11 @@ Prefab:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 114252805458954098, guid: 9361ab6d13ee87644bc370bccb524144,
+        type: 2}
+      propertyPath: _enableObjectsOnlyWhenTracked.Array.data[2]
+      value: 
+      objectReference: {fileID: 695586575}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 9361ab6d13ee87644bc370bccb524144, type: 2}
   m_IsPrefabParent: 0
@@ -9082,6 +9107,11 @@ MonoBehaviour:
     type: 2}
   m_PrefabInternal: {fileID: 695586572}
   m_Script: {fileID: 11500000, guid: e55d3703de8ab5d418cb97104179cb49, type: 3}
+--- !u!1 &695586575 stripped
+GameObject:
+  m_PrefabParentObject: {fileID: 1042150412978782, guid: 9361ab6d13ee87644bc370bccb524144,
+    type: 2}
+  m_PrefabInternal: {fileID: 695586572}
 --- !u!1 &704737755
 GameObject:
   m_ObjectHideFlags: 0
@@ -16448,6 +16478,11 @@ Prefab:
   m_Modification:
     m_TransformParent: {fileID: 892104472}
     m_Modifications:
+    - target: {fileID: 114446365300099102, guid: 72368278d054cda4bb18e5aa08ce971d,
+        type: 2}
+      propertyPath: _enableObjectsOnlyWhenTracked.Array.size
+      value: 2
+      objectReference: {fileID: 0}
     - target: {fileID: 4527397571117942, guid: 72368278d054cda4bb18e5aa08ce971d, type: 2}
       propertyPath: m_LocalPosition.x
       value: 0.0801
@@ -16484,6 +16519,11 @@ Prefab:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 114446365300099102, guid: 72368278d054cda4bb18e5aa08ce971d,
+        type: 2}
+      propertyPath: _enableObjectsOnlyWhenTracked.Array.data[2]
+      value: 
+      objectReference: {fileID: 1281910587}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 72368278d054cda4bb18e5aa08ce971d, type: 2}
   m_IsPrefabParent: 0
@@ -16498,6 +16538,11 @@ MonoBehaviour:
     type: 2}
   m_PrefabInternal: {fileID: 1281910584}
   m_Script: {fileID: 11500000, guid: e55d3703de8ab5d418cb97104179cb49, type: 3}
+--- !u!1 &1281910587 stripped
+GameObject:
+  m_PrefabParentObject: {fileID: 1087039652897348, guid: 72368278d054cda4bb18e5aa08ce971d,
+    type: 2}
+  m_PrefabInternal: {fileID: 1281910584}
 --- !u!1 &1287936020
 GameObject:
   m_ObjectHideFlags: 0
@@ -25156,6 +25201,11 @@ Prefab:
   m_Modification:
     m_TransformParent: {fileID: 892104472}
     m_Modifications:
+    - target: {fileID: 114384944290433142, guid: 80e9754fad44e784f97f6c76a2c7255b,
+        type: 2}
+      propertyPath: _enableObjectsOnlyWhenTracked.Array.size
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 4360080876800316, guid: 80e9754fad44e784f97f6c76a2c7255b, type: 2}
       propertyPath: m_LocalPosition.x
       value: -0.0801
@@ -25192,6 +25242,16 @@ Prefab:
       propertyPath: m_IsActive
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 114384944290433142, guid: 80e9754fad44e784f97f6c76a2c7255b,
+        type: 2}
+      propertyPath: _enableObjectsOnlyWhenTracked.Array.data[2]
+      value: 
+      objectReference: {fileID: 1382730427}
+    - target: {fileID: 114384944290433142, guid: 80e9754fad44e784f97f6c76a2c7255b,
+        type: 2}
+      propertyPath: _enableObjectsOnlyWhenTracked.Array.data[3]
+      value: 
+      objectReference: {fileID: 1382730427}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: 80e9754fad44e784f97f6c76a2c7255b, type: 2}
   m_IsPrefabParent: 0

--- a/Assets/LeapMotion/Modules/InteractionEngine/Prefabs/Interaction Controllers/VR Oculus-style Controller (Left).prefab
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Prefabs/Interaction Controllers/VR Oculus-style Controller (Left).prefab
@@ -312,7 +312,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1135166102121244}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.0801, y: 0, z: 0}
+  m_LocalPosition: {x: -1.4307879, y: -1.570349e-17, z: 0.7072223}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4867000564616732}
@@ -449,6 +449,8 @@ MonoBehaviour:
   _trackingProviderType: Leap.Unity.Interaction.DefaultXRNodeTrackingProvider
   _deviceJoystickTokens: oculus touch left
   _chirality: 0
+  _pollConnection: 1
+  pollConnectionInterval: 2
   _hoverPoint: {fileID: 4560782703005532}
   primaryHoverPoints:
   - {fileID: 4518730954856196}
@@ -457,6 +459,9 @@ MonoBehaviour:
   maxGraspDistance: 0.06
   graspButtonAxis: LeftVRTriggerAxis
   graspTimingSlop: 0.1
+  _enableObjectsOnlyWhenTracked:
+  - {fileID: 1509814725961646}
+  - {fileID: 1917669154522462}
 --- !u!114 &114868041951073566
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/LeapMotion/Modules/InteractionEngine/Prefabs/Interaction Controllers/VR Oculus-style Controller (Right).prefab
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Prefabs/Interaction Controllers/VR Oculus-style Controller (Right).prefab
@@ -312,7 +312,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1180994678239160}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.0801, y: 0, z: 0}
+  m_LocalPosition: {x: -0.84071773, y: -1.57867e-17, z: 0.7109698}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4945636674666266}
@@ -453,6 +453,8 @@ MonoBehaviour:
   _trackingProviderType: Leap.Unity.Interaction.DefaultXRNodeTrackingProvider
   _deviceJoystickTokens: oculus touch right
   _chirality: 1
+  _pollConnection: 1
+  pollConnectionInterval: 2
   _hoverPoint: {fileID: 4806976238791452}
   primaryHoverPoints:
   - {fileID: 4886390705553262}
@@ -461,6 +463,9 @@ MonoBehaviour:
   maxGraspDistance: 0.06
   graspButtonAxis: RightVRTriggerAxis
   graspTimingSlop: 0.1
+  _enableObjectsOnlyWhenTracked:
+  - {fileID: 1549893461946908}
+  - {fileID: 1042150412978782}
 --- !u!114 &114624724585167906
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/LeapMotion/Modules/InteractionEngine/Prefabs/Interaction Controllers/VR Vive-style Controller (Left).prefab
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Prefabs/Interaction Controllers/VR Vive-style Controller (Left).prefab
@@ -262,7 +262,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1393620680427892}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.0801, y: 0, z: 0}
+  m_LocalPosition: {x: -1.2390416, y: -1.1210103e-17, z: 0.50485814}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4296772287723422}
@@ -438,6 +438,8 @@ MonoBehaviour:
   _trackingProviderType: Leap.Unity.Interaction.DefaultXRNodeTrackingProvider
   _deviceJoystickTokens: openvr controller left
   _chirality: 0
+  _pollConnection: 1
+  pollConnectionInterval: 2
   _hoverPoint: {fileID: 4815831099454246}
   primaryHoverPoints:
   - {fileID: 4198793855848632}
@@ -446,6 +448,9 @@ MonoBehaviour:
   maxGraspDistance: 0.06
   graspButtonAxis: LeftVRTriggerAxis
   graspTimingSlop: 0.1
+  _enableObjectsOnlyWhenTracked:
+  - {fileID: 1397249577376870}
+  - {fileID: 1545272327151176}
 --- !u!114 &114439833622174436
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/LeapMotion/Modules/InteractionEngine/Prefabs/Interaction Controllers/VR Vive-style Controller (Right).prefab
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Prefabs/Interaction Controllers/VR Vive-style Controller (Right).prefab
@@ -260,7 +260,7 @@ Transform:
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1257637052428748}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.0801, y: 0, z: 0}
+  m_LocalPosition: {x: -1.0057702, y: -2.0849268e-17, z: 0.9389675}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 4802836220905650}
@@ -438,6 +438,8 @@ MonoBehaviour:
   _trackingProviderType: Leap.Unity.Interaction.DefaultXRNodeTrackingProvider
   _deviceJoystickTokens: openvr controller right
   _chirality: 1
+  _pollConnection: 1
+  pollConnectionInterval: 2
   _hoverPoint: {fileID: 4981927146387146}
   primaryHoverPoints:
   - {fileID: 4734948962374662}
@@ -446,6 +448,9 @@ MonoBehaviour:
   maxGraspDistance: 0.06
   graspButtonAxis: RightVRTriggerAxis
   graspTimingSlop: 0.1
+  _enableObjectsOnlyWhenTracked:
+  - {fileID: 1155848361077982}
+  - {fileID: 1087039652897348}
 --- !u!114 &114459101824845844
 MonoBehaviour:
   m_ObjectHideFlags: 1

--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionController.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionController.cs
@@ -166,8 +166,8 @@ namespace Leap.Unity.Interaction {
     public abstract InteractionHand intHand { get; }
 
     /// <summary>
-    /// Contact requires knowledge of the controller's scale.
-    /// TODO: Warn if the controller is scaled non-uniformly.
+    /// Contact requires knowledge of the controller's scale. Non-uniformly scaled
+    /// controllers are NOT supported.
     /// </summary>
     public float scale { get { return this.transform.lossyScale.x; } }
 
@@ -1313,10 +1313,13 @@ namespace Leap.Unity.Interaction {
           if (_delayedDisableSoftContactCoroutine != null) {
             manager.StopCoroutine(_delayedDisableSoftContactCoroutine);
           }
-          for (int i = 0; i < contactBones.Length; i++) {
-            if (contactBones[i].collider == null) continue;
 
-            disableContactBoneCollision();
+          if (contactBones != null) {
+            for (int i = 0; i < contactBones.Length; i++) {
+              if (contactBones[i].collider == null) continue;
+
+              disableContactBoneCollision();
+            }
           }
         }
       }

--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionHand.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionHand.cs
@@ -548,6 +548,10 @@ namespace Leap.Unity.Interaction {
 
     /// <summary> Reconnects and resets all the joints in the hand. </summary>
     private void resetContactBoneJoints() {
+      // If contact bones array is null, there's nothing to reset. This can happen if
+      // the controller is disabled before it had a chance to initialize contact.
+      if (_contactBones == null) return;
+
       // If the palm contact bone is null, we can't reset bone joints.
       if (_contactBones[NUM_FINGERS * BONES_PER_FINGER] == null) return;
 

--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionXRController.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionXRController.cs
@@ -563,6 +563,8 @@ namespace Leap.Unity.Interaction {
         includeInactiveObjects: true);
 
       foreach (var collider in _colliderBuffer) {
+        if (collider.isTrigger) continue; // Contact Bones are for "contacting" colliders.
+
         ContactBone contactBone = collider.gameObject.AddComponent<ContactBone>();
         Rigidbody body = collider.gameObject.GetComponent<Rigidbody>();
         if (body == null) {

--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionXRController.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionXRController.cs
@@ -238,12 +238,7 @@ namespace Leap.Unity.Interaction {
                                  .Any(joystick => controllerSupportTokens.Query()
                                                  .All(token => joystick.Contains(token)));
 
-        if (matchesController) {
-          _isJoystickDetected = true;
-        }
-        else {
-          _isJoystickDetected = false;
-        }
+        _isJoystickDetected = matchesController;
       }
     }
 


### PR DESCRIPTION
This PR addresses #1021 by making some important changes to InteractionXRController.

- [ ] Fundamentally, the active/inactive state of InteractionXRControllers should determine whether or not it _tries_ to have tracking, not whether it _has_ tracking. Disabling the InteractionXRController's gameObject or Component should prevent updates but not reflect the fact that the joystick wasn't detected.
- [ ] `pollConnection` is now an option, plus `pollConnectionInterval`. This option, enabled by default, allows the controller to call Input.GetJoystickNames(), which unfortunately allocates garbage. To minimize allocation, `pollConnection` only checks joystick names if the script is active and enabled but hasn't seen the joystick yet in the device list. Once it has seen the joystick, you must manually call `RefreshControllerConnection` to find out if the device list has removed the joystick.
- [ ] `isTracking` now requires both the joystick tokens to have matched a device in the device list AND that XR tracking data is available from the XRNode tracking provider. The joystick token test is skipped if the tokens string is empty or null.
- [ ] Adds a convenience List to the InteractionXRController inspector allowing the user to specify GameObjects to keep active IFF the controller `isTracking`.
- [ ] Some null checks were added to the Interaction Engine to avoid accessing `contactBones` if the array is null, solving reference errors happening when OnDisable occurred before contact bones were initialized.
- [ ] Converted even **inactive** colliders beneath InteractionXRControllers into ContactBones to prevent an issue where contact bones were not initializing when controllers were not immediately detected as active joysticks. Trigger colliders beneath InteractionXRControllers are also no longer converted to ContactBones so they can't apply forces to objects.

To test:
- [ ] Make sure `pollConnection = false` prevents the controller from allocating garbage.
- [ ] Make sure that the example scenes function with InteractionXRControllers, and that even if you create a build with the splash screen disabled or your controllers aren't connected on application startup that you can still get controller data to the application once they wake up.
- [ ] Make sure the feature changes make sense
- [ ] Make sure the code changes make sense