### PR TITLE
Fix incorrect calling convention for Allocate/Deallocate

### DIFF
--- a/Assets/LeapMotion/Core/Plugins/LeapCSharp/LeapC.cs
+++ b/Assets/LeapMotion/Core/Plugins/LeapCSharp/LeapC.cs
@@ -490,7 +490,9 @@ namespace LeapInternal {
 
   [StructLayout(LayoutKind.Sequential, Pack = 1)]
   public struct LEAP_ALLOCATOR {
+    [MarshalAs(UnmanagedType.FunctionPtr)]
     public Allocate allocate;
+    [MarshalAs(UnmanagedType.FunctionPtr)]
     public Deallocate deallocate;
     public IntPtr state;
   }


### PR DESCRIPTION
This PR fixes the crash happening when using the image api when targeting 32bit.  The major fix was telling C# to marshal the allocate and deallocate callbacks using the Cdecl calling convention rather than the default Stdcall convention.  Also added in a bit of safety, making sure to tag them to be marshaled as function pointers, and actually getting the signature of the functions to match LeapC (even though the void* state is not used).  Finally made sure to log errors instead of just swallowing them.

To test:
 - [ ] Make sure that images still come through when using 64bit
 - [ ] Make sure that images come through when using 32bit