### PR TITLE
Bump version, set quality defaults, quick-fix buttons

### DIFF
--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/UI/InteractionButton.cs.meta
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/UI/InteractionButton.cs.meta
@@ -6,7 +6,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 0
+  executionOrder: -200
   icon: {instanceID: 0}
   userData: 
   assetBundleName: 

--- a/ProjectSettings/ProjectVersion.txt
+++ b/ProjectSettings/ProjectVersion.txt
@@ -1,1 +1,1 @@
-m_EditorVersion: 2017.4.1f1
+m_EditorVersion: 2017.4.2f2

--- a/ProjectSettings/QualitySettings.asset
+++ b/ProjectSettings/QualitySettings.asset
@@ -4,7 +4,7 @@
 QualitySettings:
   m_ObjectHideFlags: 0
   serializedVersion: 5
-  m_CurrentQuality: 0
+  m_CurrentQuality: 1
   m_QualitySettings:
   - serializedVersion: 2
     name: Mobile
@@ -49,7 +49,7 @@ QualitySettings:
     blendWeights: 4
     textureQuality: 0
     anisotropicTextures: 2
-    antiAliasing: 2
+    antiAliasing: 8
     softParticles: 1
     softVegetation: 1
     realtimeReflectionProbes: 1
@@ -62,4 +62,6 @@ QualitySettings:
     asyncUploadBufferSize: 4
     resolutionScalingFixedDPIFactor: 1
     excludedTargetPlatforms: []
-  m_PerPlatformDefaultQuality: {}
+  m_PerPlatformDefaultQuality:
+    Android: 0
+    Standalone: 0


### PR DESCRIPTION
DAT 8x msaa tho

This fix for buttons is just setting them to -200 Execution Order so that they run before Default Time. FWIW, this is the same thing that fixed spurious terribleness with Particles, so I'm confident that it's a fix, even though I really don't like relying on execution order at all.