### PR TITLE
Fix deprecation of 2018.1 hierarchyWindowChanged

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/EditorTools/Editor/LeapRigUpgrader.cs
+++ b/Assets/LeapMotion/Core/Scripts/EditorTools/Editor/LeapRigUpgrader.cs
@@ -43,8 +43,13 @@ namespace Leap.Unity {
       EditorSceneManager.sceneOpened -= onSceneOpened;
       EditorSceneManager.sceneOpened += onSceneOpened;
 
-      EditorApplication.hierarchyWindowChanged -= onHierarchyWindowChanged;
-      EditorApplication.hierarchyWindowChanged += onHierarchyWindowChanged;
+      #if UNITY_2018_1_OR_NEWER
+      EditorApplication.hierarchyChanged -= onHierarchyChanged;
+      EditorApplication.hierarchyChanged += onHierarchyChanged;
+      #else
+      EditorApplication.hierarchyWindowChanged -= onHierarchyChanged;
+      EditorApplication.hierarchyWindowChanged += onHierarchyChanged;
+      #endif
 
       _currentSceneScanStatus = SceneScanStatus.NotScanned;
     }
@@ -53,7 +58,7 @@ namespace Leap.Unity {
       _currentSceneScanStatus = SceneScanStatus.NotScanned;
       ClearScanData();
     }
-    private static void onHierarchyWindowChanged() {
+    private static void onHierarchyChanged() {
       _currentSceneScanStatus = SceneScanStatus.NotScanned;
       ClearScanData();
     }


### PR DESCRIPTION
- [x] Fixes compilation warning on 2018.1
- [x] Make sure the Rig Upgrader still asks you to re-scan your scene if you change the scene hierarchy