### PR TITLE
Remove erroneous smoothed tracking latency

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/LeapXRServiceProvider.cs
+++ b/Assets/LeapMotion/Core/Scripts/LeapXRServiceProvider.cs
@@ -364,8 +364,7 @@ namespace Leap.Unity {
         transformHistory.SampleTransform(timestamp
                                          - (long)(warpingAdjustment * 1000f)
                                          - (_temporalWarpingMode ==
-                                         TemporalWarpingMode.Images ? -20000 :
-                                         (long)(_smoothedTrackingLatency.value)),
+                                         TemporalWarpingMode.Images ? -20000 : 0),
                                          out warpedPosition, out warpedRotation);
       }
 


### PR DESCRIPTION
The way this was written double counts the smoothedTrackingLatency; see `master` for the original implementation.