### PR TITLE
Add attempts to reconnect to the service when not connected

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/LeapServiceProvider.cs
+++ b/Assets/LeapMotion/Core/Scripts/LeapServiceProvider.cs
@@ -37,6 +37,12 @@ namespace Leap.Unity {
     /// </summary>
     protected const string HAND_ARRAY_GLOBAL_NAME = "_LeapHandTransforms";
 
+    /// <summary>
+    /// The maximum number of times the provider will 
+    /// attempt to reconnect to the service before giving up.
+    /// </summary>
+    protected const int MAX_RECONNECTION_ATTEMPTS = 3;
+
     #endregion
 
     #region Inspector
@@ -252,6 +258,8 @@ namespace Leap.Unity {
       if (_workerThreadProfiling) {
         LeapProfiling.Update();
       }
+
+      if (!checkConnectionIntegrity()) { return; }
 
 #if UNITY_EDITOR
       if (UnityEditor.EditorApplication.isCompiling) {
@@ -485,6 +493,33 @@ namespace Leap.Unity {
         _leapController.StopConnection();
         _leapController = null;
       }
+    }
+
+    private float _timeSinceServiceConnectionChecked = 0f;
+    private int _numberOfReconnectionAttempts = 0;
+    /// <summary>
+    /// Checks whether this provider is connected to a service;
+    /// If it is not, attempt to reconnect at regular intervals
+    /// for MAX_RECONNECTION_ATTEMPTS
+    /// </summary>
+    protected bool checkConnectionIntegrity() {
+      if (_leapController.IsServiceConnected) {
+        _timeSinceServiceConnectionChecked = 0f;
+        return true;
+      } else if (_numberOfReconnectionAttempts < MAX_RECONNECTION_ATTEMPTS) {
+        _timeSinceServiceConnectionChecked += Time.unscaledDeltaTime;
+
+        if (_timeSinceServiceConnectionChecked > 2f) {
+          _timeSinceServiceConnectionChecked = 0f;
+          _numberOfReconnectionAttempts++;
+
+          Debug.LogWarning("Leap Service not connected; attempting to reconnect for try " +
+                            _numberOfReconnectionAttempts+"/"+MAX_RECONNECTION_ATTEMPTS+"...", this);
+          destroyController();
+          createController();
+        }
+      }
+      return false;
     }
 
     protected void onHandControllerConnect(object sender, LeapEventArgs args) {


### PR DESCRIPTION
This PR attempts to solve the sporadic issue that sometimes occurs where users will client applications will spuriously not receive hands; we suspect it's caused by the service not acknowledging the connection attempt by the app the first time, so we attempt to simulate an "app restart" by destroying and recreating the controller object.

You can easily test whether doing this could break working apps by adding ` && !Input.GetKey(KeyCode.Space)` to the service connection check on line 506 and holding down Space for several seconds (to artificially induce a "Destroy/Create" cycle).