### PR TITLE
Fix visualizer policy and images

### DIFF
--- a/Assets/LeapMotion/Core/Plugins/LeapCSharp/Connection.cs
+++ b/Assets/LeapMotion/Core/Plugins/LeapCSharp/Connection.cs
@@ -666,7 +666,7 @@ namespace LeapInternal {
     public void ClearPolicy(Controller.PolicyFlag policy) {
       UInt64 clearFlags = (ulong)flagForPolicy(policy);
       _requestedPolicies = _requestedPolicies & ~clearFlags;
-      eLeapRS result = LeapC.SetPolicyFlags(_leapConnection, 0, clearFlags);
+      eLeapRS result = LeapC.SetPolicyFlags(_leapConnection, _requestedPolicies, ~_requestedPolicies);
       reportAbnormalResults("LeapC SetPolicyFlags call was ", result);
     }
 

--- a/Assets/LeapMotion/Internal/VRVisualizer/ScenesResources/Scripts/VisualizerManager.cs
+++ b/Assets/LeapMotion/Internal/VRVisualizer/ScenesResources/Scripts/VisualizerManager.cs
@@ -19,7 +19,6 @@ namespace Leap.Unity.VRVisualizer{
     public UnityEngine.UI.Text m_trackingText;
     public UnityEngine.UI.Text m_frameRateText;
     public UnityEngine.UI.Text m_dataFrameRateText;
-
     public KeyCode keyToToggleHMD = KeyCode.V;
   
     private Controller m_controller = null;
@@ -61,14 +60,13 @@ namespace Leap.Unity.VRVisualizer{
       if (m_controller != null)
         m_leapConnected = m_controller.IsConnected;
 
+      Screen.SetResolution(Screen.currentResolution.width, Screen.currentResolution.height, false);
       if (XRSupportUtil.IsXRDevicePresent())
       {
-        Screen.SetResolution(640, 480, false);
         goVR();    
       }
       else
       {
-        Screen.SetResolution(Screen.currentResolution.width, Screen.currentResolution.height, false);
         goDesktop();
       }
 

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -67,7 +67,7 @@ PlayerSettings:
   defaultIsFullScreen: 0
   defaultIsNativeResolution: 1
   macRetinaSupport: 1
-  runInBackground: 0
+  runInBackground: 1
   captureSingleScreen: 0
   muteOtherAudioSources: 0
   Prepare IOS For Recording: 0


### PR DESCRIPTION
 - Setting or Resetting a policy flag _always_ updates every policy, so that we can make sure the connection keeps every policy flag that has been set previously.
 - VRVisualizer will now always maximize to fullscreen windowed when it opens
 - Now set to to always run in background.