### PR TITLE
Fix null when spoofing Combinable Properties (AppModules)

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/Attributes/Editor/CombinablePropertyDrawer.cs
+++ b/Assets/LeapMotion/Core/Scripts/Attributes/Editor/CombinablePropertyDrawer.cs
@@ -79,7 +79,9 @@ namespace Leap.Unity.Attributes {
 
       IFullPropertyDrawer fullPropertyDrawer = null;
       foreach (var a in attributes) {
-        a.Init(fieldInfo, property.serializedObject.targetObjects);
+        if (fieldInfo != null) {
+          a.Init(fieldInfo, property.serializedObject.targetObjects);
+        }
 
         if (a is IBeforeLabelAdditiveDrawer) {
           EditorGUIUtility.labelWidth -= (a as IBeforeLabelAdditiveDrawer).GetWidth();


### PR DESCRIPTION
Why would you want to spoof Combinable Property attributes, you ask?

AppModules does this in the `Streams` library because it needs to use Reflection to figure out what interface actually needs to be satisfied at runtime in the Editor. Attributes don't support generic types because they have to be resolved at compile-time, so to utilize the ImplementsInterface combinable property attribute, I can construct it in the custom editor and call CombinablePropertyDrawer's OnGUI() manually to do the appropriate checks DRYly.

Long story short this works great, we just need to not RE-initialize the attribute's fieldInfo with a bad fieldInfo when OnGUI is used in this way (with `null` for fieldInfo, to account for the fact that the attributes are already initialized with the appropriate fieldInfo).