### PR TITLE
Fixed streaming assets and folders when in packages

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/DataStructures/AssetFolder.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/AssetFolder.cs
@@ -10,6 +10,7 @@
 using System;
 using UnityEngine;
 using UnityObject = UnityEngine.Object;
+using UnityEngine.Serialization;
 #if UNITY_EDITOR
 using UnityEditor;
 #endif
@@ -27,7 +28,8 @@ namespace Leap.Unity {
   public class AssetFolder {
 
     [SerializeField]
-    protected UnityObject _assetFolder;
+    [FormerlySerializedAs("_assetFolder")]
+    protected UnityObject _assetReference;
 
     public AssetFolder() { }
 
@@ -44,8 +46,8 @@ namespace Leap.Unity {
     public virtual string Path {
       get {
 #if UNITY_EDITOR
-        if (_assetFolder != null) {
-          return AssetDatabase.GetAssetPath(_assetFolder);
+        if (_assetReference != null) {
+          return AssetDatabase.GetAssetPath(_assetReference);
         } else {
           return null;
         }
@@ -55,7 +57,7 @@ namespace Leap.Unity {
       }
       set {
 #if UNITY_EDITOR
-        _assetFolder = AssetDatabase.LoadAssetAtPath<DefaultAsset>(value);
+        _assetReference = AssetDatabase.LoadAssetAtPath<DefaultAsset>(value);
 #else
         throw new InvalidOperationException("Cannot set the Path of an Asset Folder in a build.");
 #endif

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/Editor/AssetFolderPropertyDrawer.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/Editor/AssetFolderPropertyDrawer.cs
@@ -26,11 +26,11 @@ namespace Leap.Unity {
       Object folderAsset = null;
       string folderPath = "";
 
-      SerializedProperty folderProp = property.FindPropertyRelative("_assetFolder");
-      if (folderProp.hasMultipleDifferentValues) {
+      SerializedProperty assetProp = property.FindPropertyRelative("_assetReference");
+      if (assetProp.hasMultipleDifferentValues) {
         EditorGUI.showMixedValue = true;
       } else {
-        folderAsset = folderProp.objectReferenceValue;
+        folderAsset = assetProp.objectReferenceValue;
         if (folderAsset != null) {
           folderPath = AssetDatabase.GetAssetPath(folderAsset);
         }
@@ -50,7 +50,7 @@ namespace Leap.Unity {
           if (!ValidatePath(resultPath, relativePath, out errorMessage)) {
             EditorUtility.DisplayDialog("Invalid selection.", errorMessage, "OK");
           } else {
-            folderProp.objectReferenceValue = asset;
+            assetProp.objectReferenceValue = asset;
           }
         }
       }
@@ -72,7 +72,7 @@ namespace Leap.Unity {
             case EventType.DragPerform:
               if (ValidateObject(draggedObject, out errorMessage)) {
                 DragAndDrop.AcceptDrag();
-                folderProp.objectReferenceValue = draggedObject;
+                assetProp.objectReferenceValue = draggedObject;
               }
               break;
           }
@@ -85,6 +85,9 @@ namespace Leap.Unity {
     }
 
     protected virtual string PromptUserForPath(string currentPath) {
+      if (string.IsNullOrEmpty(currentPath)) {
+        currentPath = "Assets";
+      }
       return EditorUtility.OpenFolderPanel("Select Folder", currentPath, "");
     }
 

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/Editor/StreamingAssetPropertyDrawer.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/Editor/StreamingAssetPropertyDrawer.cs
@@ -16,6 +16,9 @@ namespace Leap.Unity {
   public class StreamingAssetPropertyDrawer : StreamingFolderPropertyDrawer {
 
     protected override string PromptUserForPath(string currentPath) {
+      if (string.IsNullOrEmpty(currentPath)) {
+        currentPath = "Assets";
+      }
       return EditorUtility.OpenFilePanel("Select File", currentPath, "");
     }
 

--- a/Assets/LeapMotion/Core/Scripts/DataStructures/StreamingFolder.cs
+++ b/Assets/LeapMotion/Core/Scripts/DataStructures/StreamingFolder.cs
@@ -20,7 +20,7 @@ namespace Leap.Unity {
   public class StreamingFolder : AssetFolder, ISerializationCallbackReceiver {
 
     [SerializeField]
-    private string _relativePath;
+    protected string _relativePath;
 
     /// <summary>
     /// Gets the full path to the streaming folder.  This operation is safe to be
@@ -41,7 +41,18 @@ namespace Leap.Unity {
 
     public void OnBeforeSerialize() {
 #if UNITY_EDITOR
-      string assetPath = AssetDatabase.GetAssetPath(_assetFolder);
+      if (_assetReference == null && !string.IsNullOrEmpty(_relativePath)) {
+        //If the asset folder is null, we first see if the current relative path points to a valid
+        //folder.  This can happen during deserialization of a unitypackage.
+
+        //We hardcode Assets/StreamingAssets since this can only occur within the editor
+        //and unity doesn't let us call Application.streamingAssetsPath from within the
+        //OnBeforeSerialize callback
+        string path = System.IO.Path.Combine("Assets/StreamingAssets", _relativePath);
+        _assetReference = AssetDatabase.LoadAssetAtPath<DefaultAsset>(path);
+      }
+
+      string assetPath = AssetDatabase.GetAssetPath(_assetReference);
       if (string.IsNullOrEmpty(assetPath)) {
         _relativePath = null;
       } else {


### PR DESCRIPTION
When a unity package loads a streaming asset or folder, the relative path is correct, but the asset reference will be null since packages don't bring folder references across.  This causes the folder to overwrite itself with an incorrect null value.  This PR makes a change so that when serializing, if it sees that the reference is null, but the path is not, it will try to see if there is a valid folder and uses that one instead of nulling out the path.