### PR TITLE
Add ifdefs to support 2018.2 compile in GR

### DIFF
--- a/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/Utility/AtlasBuilder.cs
+++ b/Assets/LeapMotion/Modules/GraphicRenderer/Scripts/Utility/AtlasBuilder.cs
@@ -381,7 +381,13 @@ namespace Leap.Unity.GraphicalRenderer {
         }
       }
 
-      packedTexture = new Texture2D(1, 1, TextureFormat.ARGB32, mipmap: false, linear: true);
+      #if UNITY_2018_2_OR_NEWER
+      packedTexture = new Texture2D(1, 1, TextureFormat.ARGB32, mipChain: false,
+        linear: true);
+      #else
+      packedTexture = new Texture2D(1, 1, TextureFormat.ARGB32, mipmap: false,
+        linear: true);
+      #endif
       packedTexture.filterMode = _filterMode;
     }
 
@@ -442,7 +448,13 @@ namespace Leap.Unity.GraphicalRenderer {
     private Texture2D getDefaultTexture(Color color) {
       Texture2D texture;
       if (!_cachedDefaultTextures.TryGetValue(color, out texture)) {
+        
+        #if UNITY_2018_2_OR_NEWER
+        texture = new Texture2D(3, 3, TextureFormat.ARGB32, mipChain: false);
+        #else
         texture = new Texture2D(3, 3, TextureFormat.ARGB32, mipmap: false);
+        #endif
+
         texture.SetPixels(new Color[3 * 3].Fill(color));
         _cachedDefaultTextures[color] = texture;
       }


### PR DESCRIPTION
This PR:

- [ ] Fixes GR compilation for Unity 2018.2
- [ ] Should still allow GR compilation for previous versions of Unity

To test:
- [x] Validate Graphic Renderer test scenes run in-editor in 2018.2 and 2018.1
- [x] Validate Graphic Renderer modules don't break builds in 2018.2 and 2018.1

