### PR TITLE
Fix OnGraspStay() running all the time

### DIFF
--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionController.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionController.cs
@@ -2004,7 +2004,7 @@ namespace Leap.Unity.Interaction {
     /// </summary>
     bool IInternalInteractionController.CheckGraspHold(out IInteractionBehaviour graspedObject) {
       graspedObject = _graspedObject;
-      OnGraspStay();
+      if (graspedObject != null) OnGraspStay();
       return graspedObject != null;
     }
 


### PR DESCRIPTION
OnGraspStay() always runs no matter you grasp or not. This will fix it.