### PR TITLE
multi-grasp behaviour on first release

### DIFF
--- a/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionBehaviour.cs
+++ b/Assets/LeapMotion/Modules/InteractionEngine/Scripts/InteractionBehaviour.cs
@@ -1278,10 +1278,14 @@ namespace Leap.Unity.Interaction {
 
         // Fire interaction callback.
         OnPerControllerGraspEnd(controller);
+      }
 
-        if (moveObjectWhenGrasped) {
-          // Remove each hand from the pose solver.
-          graspedPoseHandler.RemoveController(controller);
+      // This re-initializes the graspedPoseHandler for multi-grasp.
+      if (moveObjectWhenGrasped) {
+        graspedPoseHandler.ClearControllers();
+
+        foreach (var item in _graspingControllers) {
+          graspedPoseHandler.AddController(item);
         }
       }
 


### PR DESCRIPTION
Hey!

So a while ago we found that there is a weird behaviour, when multi-grasp is enabled on an object:
If you grasp an `InteractionBehaviour` object with both hands, rotate it around and release one of your hands, the grasped object always 'jumps' so that its position and rotation is correct relative to the still grasping hand, as if you never grasped with your second hand.
This means that it is nearly impossible to move an object with both hands and release it at that position because the release of both hands has to happen in the very same frame.
Our adjustment makes sure that the object won't move or rotate if one hand released its grasp.

I'm not quiet sure whether the former behaviour was purposely designed that way, for I can see some use-cases where it could be the desired behaviour.

Now some explanation to the changes we made:
Instead of removing an `InteractionController` from the `graspedPoseHandler` in `InteractionBehaviour.EndGrasp(...)` method, we clear all controllers in the pose handler and add again all controllers that are still grasping the object. This way the pose handler uses the current hand pose for the movement calculations.

This is a simple fix for this behaviour, maybe it would be better to change the behaviour in the `KabschSolver` class.