### PR TITLE
null check for LeapController only happened in Editor, not Player.

### DIFF
--- a/Assets/LeapMotion/Core/Scripts/LeapServiceProvider.cs
+++ b/Assets/LeapMotion/Core/Scripts/LeapServiceProvider.cs
@@ -421,12 +421,10 @@ namespace Leap.Unity {
     /// Returns the Leap Controller instance.
     /// </summary>
     public Controller GetLeapController() {
-      #if UNITY_EDITOR
       // Null check to deal with hot reloading.
       if (!_isDestroyed && _leapController == null) {
         createController();
       }
-      #endif
       return _leapController;
     }
 


### PR DESCRIPTION
This was causing errors in Built Unity Applications, that needed multi-leap.