### PR TITLE
[FEAT] Github Actions for Unit Testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: Test UnityModules 😎
 
 on:
   pull_request: {}
-  push: { branches: [feat-gh-actions] }
+  push: { branches: [develop] }
 
 env:
   UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
@@ -17,7 +17,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
-          ref: feat-gh-actions
+          ref: develop
           lfs: true
     
       # Cache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,7 @@ jobs:
           unityVersion: 2019.2.11f1
 
       - uses: actions/upload-artifact@v2
+        if: ${{ always() }}
         with:
           name: Test results
           path: artifacts

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,50 @@
+name: Test UnityModules 😎
+
+on:
+  pull_request: {}
+  push: { branches: [feat-gh-actions] }
+
+env:
+  UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+
+jobs:
+  build:
+    name: Test UnityModules ✨
+    runs-on: ubuntu-latest
+    steps:
+    
+      # Checkout
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          lfs: true
+    
+      # Cache
+      - uses: actions/cache@v1.1.0
+        with:
+          path: Library
+          key: Library
+
+      # Test
+      - name: Run tests
+        uses: webbertakken/unity-test-runner@v1.3
+        with:
+          unityVersion: 2019.2.11f1
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Test results
+          path: artifacts
+
+      # Build
+      #- name: Build project
+      #  uses: webbertakken/unity-builder@v0.10
+      #  with:
+      #    unityVersion: 2019.2.11f1
+      #    targetPlatform: Windows 
+
+      ## Output 
+      #- uses: actions/upload-artifact@v1
+      #  with:
+      #    name: Build
+      #    path: build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,6 +28,10 @@ jobs:
       # Test
       - name: Run tests
         uses: webbertakken/unity-test-runner@v1.3
+        env:
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+          UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
         with:
           unityVersion: 2019.2.11f1
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
+          ref: feat-gh-actions
           lfs: true
     
       # Cache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Test UnityModules 😎
+name: UnityModules: Run Unit Tests on develop
 
 on:
   pull_request: {}
@@ -9,7 +9,7 @@ env:
 
 jobs:
   build:
-    name: Test UnityModules ✨
+    name: Run Unit Tests on develop
     runs-on: ubuntu-latest
     steps:
     
@@ -41,16 +41,3 @@ jobs:
         with:
           name: Test results
           path: artifacts
-
-      # Build
-      #- name: Build project
-      #  uses: webbertakken/unity-builder@v0.10
-      #  with:
-      #    unityVersion: 2019.2.11f1
-      #    targetPlatform: Windows 
-
-      ## Output 
-      #- uses: actions/upload-artifact@v1
-      #  with:
-      #    name: Build
-      #    path: build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,7 +2,7 @@ name: UnityModules - Run Unit Tests on develop
 
 on:
   pull_request: {}
-  push: { branches: [develop] }
+  push: {}
 
 env:
   UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
@@ -17,7 +17,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
         with:
-          ref: develop
           lfs: true
     
       # Cache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,15 +1,15 @@
-name: UnityModules - Run Unit Tests on develop
+name: UnityModules - Run Unit Tests
 
 on:
-  pull_request: {}
-  push: {}
+  pull_request:
+    types: [opened, synchronize]
 
 env:
   UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
 
 jobs:
   build:
-    name: Run Unit Tests on develop
+    name: Run Unit Tests
     runs-on: ubuntu-latest
     steps:
     

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: UnityModules: Run Unit Tests on develop
+name: UnityModules - Run Unit Tests on develop
 
 on:
   pull_request: {}

--- a/Assets/Plugins/LeapMotion/Core/Tests/Editor/DeviceTests.cs
+++ b/Assets/Plugins/LeapMotion/Core/Tests/Editor/DeviceTests.cs
@@ -7,6 +7,8 @@
  * between Ultraleap and you, your company or other organization.             *
  ******************************************************************************/
 
+#if !UNITY_EDITOR_LINUX
+
 using NUnit.Framework;
 using System;
 
@@ -59,4 +61,5 @@ namespace Leap.LeapCSharp.Tests {
     }
   }
 }
-
+ 
+#endif

--- a/Assets/Plugins/LeapMotion/Core/Tests/Editor/FrameValidator.cs
+++ b/Assets/Plugins/LeapMotion/Core/Tests/Editor/FrameValidator.cs
@@ -36,7 +36,7 @@ namespace Leap.Unity.Tests {
       _frame = createFrame();
     }
 
-    [SetUp]
+    [TearDown]
     public virtual void Teardown() {
       _frame = null;
     }

--- a/Assets/Plugins/LeapMotion/Core/Tests/Editor/LeapCStressTests.cs
+++ b/Assets/Plugins/LeapMotion/Core/Tests/Editor/LeapCStressTests.cs
@@ -7,6 +7,8 @@
  * between Ultraleap and you, your company or other organization.             *
  ******************************************************************************/
 
+#if !UNITY_EDITOR_LINUX
+
 using System;
 using NUnit.Framework;
 using LeapInternal;
@@ -41,3 +43,5 @@ namespace Leap.LeapCSharp.Tests {
     }
   }
 }
+
+#endif

--- a/Assets/Plugins/LeapMotion/Core/Tests/Editor/LeapCTests.cs
+++ b/Assets/Plugins/LeapMotion/Core/Tests/Editor/LeapCTests.cs
@@ -7,6 +7,8 @@
  * between Ultraleap and you, your company or other organization.             *
  ******************************************************************************/
 
+#if !UNITY_EDITOR_LINUX
+
 using System;
 using System.Threading;
 using System.Runtime.InteropServices;
@@ -1006,3 +1008,5 @@ namespace Leap.LeapCSharp.Tests {
 
   }
 }
+
+#endif


### PR DESCRIPTION
This PR queues a Github Action that runs UnityModules' Unit Tests upon each commit to PR branch.

Upon each push to a PR branch, this action will pull that branch, open it in Unity `2019.2.11f1`, and run all of the unit tests that are unrelated to LeapC (which, as of this moment, does not have a Linux implementation).  After the tests are run, the results will be uploaded to that action's log (and an icon will appear next to the commit).

This PR also fixes a bug in the Unit Tests (both the Setup and Teardown functions in `FrameValidator` had `[SetUp]` attributes).
