### PR TITLE
[FEAT] Implement Server Namespaces

### DIFF
--- a/Assets/MultipleServiceExample.unity
+++ b/Assets/MultipleServiceExample.unity
@@ -1,0 +1,549 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 0
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 10304, guid: 0000000000000000f000000000000000, type: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 11
+  m_GIWorkflowMode: 0
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 1
+    m_EnableRealtimeLightmaps: 1
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 0
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 1024
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 1
+    m_BakeBackend: 0
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 500
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 500
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 2
+    m_PVRDenoiserTypeDirect: 0
+    m_PVRDenoiserTypeIndirect: 0
+    m_PVRDenoiserTypeAO: 0
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 0
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+  m_LightingDataAsset: {fileID: 0}
+  m_UseShadowmask: 0
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1001 &14685545
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1671192356237494, guid: dae2e2be31c98324eac460f702db97e9, type: 3}
+      propertyPath: m_Name
+      value: V4 Hand Models
+      objectReference: {fileID: 0}
+    - target: {fileID: 4050235663507654, guid: dae2e2be31c98324eac460f702db97e9, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4050235663507654, guid: dae2e2be31c98324eac460f702db97e9, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 1.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 4050235663507654, guid: dae2e2be31c98324eac460f702db97e9, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4050235663507654, guid: dae2e2be31c98324eac460f702db97e9, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4050235663507654, guid: dae2e2be31c98324eac460f702db97e9, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4050235663507654, guid: dae2e2be31c98324eac460f702db97e9, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4050235663507654, guid: dae2e2be31c98324eac460f702db97e9, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4050235663507654, guid: dae2e2be31c98324eac460f702db97e9, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114121827862505544, guid: dae2e2be31c98324eac460f702db97e9,
+        type: 3}
+      propertyPath: recenterOnKey
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 114292754717913548, guid: dae2e2be31c98324eac460f702db97e9,
+        type: 3}
+      propertyPath: _preCullCamera
+      value: 
+      objectReference: {fileID: 315929244}
+    - target: {fileID: 114292754717913548, guid: dae2e2be31c98324eac460f702db97e9,
+        type: 3}
+      propertyPath: serverNameSpace
+      value: v4
+      objectReference: {fileID: 0}
+    - target: {fileID: 114292754717913548, guid: dae2e2be31c98324eac460f702db97e9,
+        type: 3}
+      propertyPath: _serverNameSpace
+      value: v4
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: dae2e2be31c98324eac460f702db97e9, type: 3}
+--- !u!1 &315929242 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 1339460489974520, guid: dae2e2be31c98324eac460f702db97e9,
+    type: 3}
+  m_PrefabInstance: {fileID: 14685545}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &315929243
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 315929242}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: abb0e8dd6c809854f8fea5e0976884f8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  editTimePose: 0
+  _frameOptimization: 0
+  _physicsExtrapolation: 1
+  _physicsExtrapolationTime: 0.011111111
+  _workerThreadProfiling: 0
+  _serverNameSpace: v5
+  _deviceOffsetMode: 0
+  _deviceOffsetYAxis: 0
+  _deviceOffsetZAxis: 0.12
+  _deviceTiltXAxis: 5
+  _deviceOrigin: {fileID: 0}
+  _preCullCamera: {fileID: 315929244}
+  _temporalWarpingMode: 0
+  _customWarpAdjustment: 17
+  _updateHandInPrecull: 0
+--- !u!20 &315929244 stripped
+Camera:
+  m_CorrespondingSourceObject: {fileID: 20862101930491778, guid: dae2e2be31c98324eac460f702db97e9,
+    type: 3}
+  m_PrefabInstance: {fileID: 14685545}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &475644817
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 4337218684828712, guid: d927f226198a4c041848215cdda6fd4d, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4337218684828712, guid: d927f226198a4c041848215cdda6fd4d, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.05
+      objectReference: {fileID: 0}
+    - target: {fileID: 4337218684828712, guid: d927f226198a4c041848215cdda6fd4d, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4337218684828712, guid: d927f226198a4c041848215cdda6fd4d, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4337218684828712, guid: d927f226198a4c041848215cdda6fd4d, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4337218684828712, guid: d927f226198a4c041848215cdda6fd4d, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4337218684828712, guid: d927f226198a4c041848215cdda6fd4d, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4337218684828712, guid: d927f226198a4c041848215cdda6fd4d, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: d927f226198a4c041848215cdda6fd4d, type: 3}
+--- !u!1 &577337496
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 577337497}
+  - component: {fileID: 577337498}
+  m_Layer: 0
+  m_Name: V5 Hand Models
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &577337497
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 577337496}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1231913618}
+  - {fileID: 988406617}
+  m_Father: {fileID: 1736029492}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &577337498
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 577337496}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: c592f16851a620743868a31232613370, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _leapProvider: {fileID: 315929243}
+  ModelPool:
+  - GroupName: Capsule Hands
+    _handModelManager: {fileID: 0}
+    LeftModel: {fileID: 1231913620}
+    IsLeftToBeSpawned: 0
+    RightModel: {fileID: 988406619}
+    IsRightToBeSpawned: 0
+    IsEnabled: 1
+    CanDuplicate: 0
+--- !u!1 &988406616
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 988406617}
+  - component: {fileID: 988406619}
+  - component: {fileID: 988406618}
+  m_Layer: 0
+  m_Name: Capsule Hand Right
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &988406617
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 988406616}
+  m_LocalRotation: {x: 0.000000115202326, y: -0.7071067, z: -0.7071068, w: -0.00000011520231}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 577337497}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: -89.980194, y: 180, z: 0}
+--- !u!114 &988406618
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 988406616}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8bcd03e00992e084c8be61565d44b8bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &988406619
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 988406616}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a04122797dd84ca43a07055f12d91e0f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  handedness: 1
+  _showArm: 1
+  _castShadows: 1
+  _material: {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  _sphereMesh: {fileID: 4300002, guid: 2f496b1b1bec86743b418551f859020c, type: 3}
+  _cylinderResolution: 12
+  _jointRadius: 0.008
+  _cylinderRadius: 0.006
+  _palmRadius: 0.015
+--- !u!1 &1231913617
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1231913618}
+  - component: {fileID: 1231913620}
+  - component: {fileID: 1231913619}
+  m_Layer: 0
+  m_Name: Capsule Hand Left
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1231913618
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1231913617}
+  m_LocalRotation: {x: 0.000000115202326, y: -0.7071067, z: -0.7071068, w: -0.00000011520231}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 577337497}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: -89.980194, y: 180, z: 0}
+--- !u!114 &1231913619
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1231913617}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8bcd03e00992e084c8be61565d44b8bd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1231913620
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1231913617}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a04122797dd84ca43a07055f12d91e0f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  handedness: 0
+  _showArm: 1
+  _castShadows: 1
+  _material: {fileID: 10303, guid: 0000000000000000f000000000000000, type: 0}
+  _sphereMesh: {fileID: 4300002, guid: 2f496b1b1bec86743b418551f859020c, type: 3}
+  _cylinderResolution: 12
+  _jointRadius: 0.008
+  _cylinderRadius: 0.006
+  _palmRadius: 0.015
+--- !u!4 &1736029492 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 4050235663507654, guid: dae2e2be31c98324eac460f702db97e9,
+    type: 3}
+  m_PrefabInstance: {fileID: 14685545}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1966885502
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1966885504}
+  - component: {fileID: 1966885503}
+  m_Layer: 0
+  m_Name: Directional Light
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!108 &1966885503
+Light:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1966885502}
+  m_Enabled: 1
+  serializedVersion: 9
+  m_Type: 1
+  m_Color: {r: 1, g: 0.95686275, b: 0.8392157, a: 1}
+  m_Intensity: 1
+  m_Range: 10
+  m_SpotAngle: 30
+  m_InnerSpotAngle: 21.80208
+  m_CookieSize: 10
+  m_Shadows:
+    m_Type: 2
+    m_Resolution: -1
+    m_CustomResolution: -1
+    m_Strength: 1
+    m_Bias: 0.05
+    m_NormalBias: 0.4
+    m_NearPlane: 0.2
+    m_CullingMatrixOverride:
+      e00: 1
+      e01: 0
+      e02: 0
+      e03: 0
+      e10: 0
+      e11: 1
+      e12: 0
+      e13: 0
+      e20: 0
+      e21: 0
+      e22: 1
+      e23: 0
+      e30: 0
+      e31: 0
+      e32: 0
+      e33: 1
+    m_UseCullingMatrixOverride: 0
+  m_Cookie: {fileID: 0}
+  m_DrawHalo: 0
+  m_Flare: {fileID: 0}
+  m_RenderMode: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingLayerMask: 1
+  m_Lightmapping: 4
+  m_LightShadowCasterMode: 0
+  m_AreaSize: {x: 1, y: 1}
+  m_BounceIntensity: 1
+  m_ColorTemperature: 6570
+  m_UseColorTemperature: 0
+  m_BoundingSphereOverride: {x: 0, y: 0, z: 0, w: 0}
+  m_UseBoundingSphereOverride: 0
+  m_ShadowRadius: 0
+  m_ShadowAngle: 0
+--- !u!4 &1966885504
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1966885502}
+  m_LocalRotation: {x: 0.40821794, y: -0.23456973, z: 0.109381676, w: 0.87542605}
+  m_LocalPosition: {x: 0, y: 3, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/MultipleServiceExample.unity.meta
+++ b/Assets/MultipleServiceExample.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 53deade3b54a61944a658f04d6187992
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/LeapMotion/Core/Editor/CustomEditorBase.cs
+++ b/Assets/Plugins/LeapMotion/Core/Editor/CustomEditorBase.cs
@@ -31,14 +31,17 @@ namespace Leap.Unity {
   }
 
   public class CustomEditorBase : Editor {
-    protected Dictionary<string, Action<SerializedProperty>> _specifiedDrawers;
+    protected Dictionary<string,      Action<SerializedProperty >> _specifiedDrawers;
     protected Dictionary<string, List<Action<SerializedProperty>>> _specifiedDecorators;
     protected Dictionary<string, List<Action<SerializedProperty>>> _specifiedPostDecorators;
-    protected Dictionary<string, List<Func<bool>>> _conditionalProperties;
-    protected List<string> _deferredProperties;
+    protected Dictionary<string,                 List<Func<bool>>> _conditionalProperties;
+    protected Dictionary<string,                     List<string>> _foldoutProperties;
+    protected Dictionary<string,                             bool> _foldoutStates;
+    protected List      <string                                  > _deferredProperties;
     protected bool _showScriptField = true;
 
     private bool _canCallSpecifyFunctions = false;
+    private GUIStyle _boldFoldoutStyle;
 
     protected List<SerializedProperty> _modifiedProperties = new List<SerializedProperty>();
 
@@ -181,6 +184,37 @@ namespace Leap.Unity {
       _deferredProperties.Insert(0, propertyName);
     }
 
+    /// <summary>
+    /// Condition the drawing of a property based on the status of a foldout drop-down.
+    /// </summary>
+    protected void addPropertyToFoldout(string propertyName, string foldoutName, bool foldoutStartOpen = false) {
+      throwIfNotInOnEnable("addPropertyToFoldout");
+
+      if (!validateProperty(propertyName)) { return; }
+
+      List<string> list;
+      if (!_foldoutProperties.TryGetValue(foldoutName, out list)) {
+        list = new List<string>();
+        _foldoutProperties[foldoutName] = list;
+      }
+      _foldoutProperties[foldoutName].Add(propertyName);
+      _foldoutStates    [foldoutName] = foldoutStartOpen;
+    }
+
+    /// <summary>
+    /// Check whether a property is inside of a foldout drop-down.
+    /// </summary>
+    protected bool isInFoldout(string propertyName) {
+      bool isInFoldout = false;
+      foreach (var foldout in _foldoutProperties) {
+        foreach (string property in foldout.Value) {
+          if (property.Equals(propertyName)) { isInFoldout = true; break; }
+        }
+        if (isInFoldout) { break; }
+      }
+      return isInFoldout;
+    }
+
     protected void drawScriptField(bool disable = true) {
       var scriptProp = serializedObject.FindProperty("m_Script");
       EditorGUI.BeginDisabledGroup(disable);
@@ -196,11 +230,13 @@ namespace Leap.Unity {
         throw new Exception("Cleaning up an editor of type " + GetType() + ".  Make sure to always destroy your editors when you are done with them!");
       }
 
-      _specifiedDrawers = new Dictionary<string, Action<SerializedProperty>>();
-      _specifiedDecorators = new Dictionary<string, List<Action<SerializedProperty>>>();
+      _specifiedDrawers        = new Dictionary<string, Action<SerializedProperty>>();
+      _specifiedDecorators     = new Dictionary<string, List<Action<SerializedProperty>>>();
       _specifiedPostDecorators = new Dictionary<string, List<Action<SerializedProperty>>>();
-      _conditionalProperties = new Dictionary<string, List<Func<bool>>>();
-      _deferredProperties = new List<string>();
+      _conditionalProperties   = new Dictionary<string, List<Func<bool>>>();
+      _foldoutProperties       = new Dictionary<string, List<string>>();
+      _foldoutStates           = new Dictionary<string, bool>();
+      _deferredProperties      = new List<string>();
       _canCallSpecifyFunctions = true;
     }
 
@@ -217,6 +253,12 @@ namespace Leap.Unity {
      * Individual properties can be specified to have custom drawers.
      */
     public override void OnInspectorGUI() {
+      // OnInspectorGUI is the first time "EditorStyles" can be accessed
+      if (_boldFoldoutStyle == null) {
+        _boldFoldoutStyle = new GUIStyle(EditorStyles.foldout);
+        _boldFoldoutStyle.fontStyle = FontStyle.Bold;
+      }
+
       _canCallSpecifyFunctions = false;
 
       _modifiedProperties.Clear();
@@ -229,7 +271,8 @@ namespace Leap.Unity {
           continue;
         }
 
-        if (_deferredProperties.Contains(iterator.name)) {
+        if (_deferredProperties.Contains(iterator.name) || 
+            isInFoldout(iterator.name)) {
           continue;
         }
 
@@ -241,7 +284,28 @@ namespace Leap.Unity {
       }
 
       foreach (var deferredProperty in _deferredProperties) {
-        drawProperty(serializedObject.FindProperty(deferredProperty));
+        if (!isInFoldout(deferredProperty)) {
+          drawProperty(serializedObject.FindProperty(deferredProperty));
+        }
+      }
+
+      foreach (var foldout in _foldoutProperties) {
+        _foldoutStates[foldout.Key] = 
+          EditorGUILayout.Foldout(_foldoutStates[foldout.Key], foldout.Key, _boldFoldoutStyle);
+        if (_foldoutStates[foldout.Key]) {
+          // Draw normal priority properties first
+          foreach (var property in foldout.Value) {
+            if (!_deferredProperties.Contains(property)) {
+              drawProperty(serializedObject.FindProperty(property));
+            }
+          }
+          // Draw deferred properties second
+          foreach (var property in foldout.Value) {
+            if (_deferredProperties.Contains(property)) {
+              drawProperty(serializedObject.FindProperty(property));
+            }
+          }
+        }
       }
 
       serializedObject.ApplyModifiedProperties();

--- a/Assets/Plugins/LeapMotion/Core/Editor/LeapServiceProviderEditor.cs
+++ b/Assets/Plugins/LeapMotion/Core/Editor/LeapServiceProviderEditor.cs
@@ -38,6 +38,7 @@ namespace Leap.Unity {
                                 (int)LeapServiceProvider.PhysicsExtrapolationMode.Manual,
                                 "_physicsExtrapolationTime");
 
+      deferProperty("_serverNameSpace");
       deferProperty("_workerThreadProfiling");
     }
 

--- a/Assets/Plugins/LeapMotion/Core/Editor/LeapServiceProviderEditor.cs
+++ b/Assets/Plugins/LeapMotion/Core/Editor/LeapServiceProviderEditor.cs
@@ -40,6 +40,9 @@ namespace Leap.Unity {
 
       deferProperty("_serverNameSpace");
       deferProperty("_workerThreadProfiling");
+
+      addPropertyToFoldout("_workerThreadProfiling", "Advanced Options");
+      addPropertyToFoldout("_serverNameSpace"      , "Advanced Options");
     }
 
     private void frameOptimizationWarning(SerializedProperty property) {

--- a/Assets/Plugins/LeapMotion/Core/Editor/LeapXRServiceProviderEditor.cs
+++ b/Assets/Plugins/LeapMotion/Core/Editor/LeapXRServiceProviderEditor.cs
@@ -35,6 +35,16 @@ namespace Leap.Unity {
                                                  .FindProperty("_deviceOffsetMode")
                                                    .enumValueIndex == 2; },
                                 "_deviceOrigin");
+
+      addPropertyToFoldout("_deviceOffsetMode"    , "Advanced Options");
+      addPropertyToFoldout("_temporalWarpingMode" , "Advanced Options");
+      addPropertyToFoldout("_customWarpAdjustment", "Advanced Options");
+      addPropertyToFoldout("_deviceOffsetYAxis"   , "Advanced Options");
+      addPropertyToFoldout("_deviceOffsetZAxis"   , "Advanced Options");
+      addPropertyToFoldout("_deviceTiltXAxis"     , "Advanced Options");
+      addPropertyToFoldout("_deviceOrigin"        , "Advanced Options");
+      addPropertyToFoldout("_preCullCamera"       , "Advanced Options");
+      addPropertyToFoldout("_updateHandInPrecull" , "Advanced Options");
     }
 
     private void decorateAllowManualTimeAlignment(SerializedProperty property) {

--- a/Assets/Plugins/LeapMotion/Core/Plugins/LeapCSharp/Config.cs
+++ b/Assets/Plugins/LeapMotion/Core/Plugins/LeapCSharp/Config.cs
@@ -28,11 +28,12 @@ namespace Leap {
     /// Note that the Controller.Config provides a properly initialized Config object already.
     /// @since 3.0
     /// </summary>
-    public Config(int connectionKey) {
+    public Config(Connection.Key connectionKey) {
       _connection = Connection.GetConnection(connectionKey);
       _connection.LeapConfigChange += handleConfigChange;
       _connection.LeapConfigResponse += handleConfigResponse;
     }
+    public Config(int connectionId) : this(new Connection.Key(connectionId)) { }
 
     private void handleConfigChange(object sender, ConfigChangeEventArgs eventArgs) {
       object actionDelegate;

--- a/Assets/Plugins/LeapMotion/Core/Plugins/LeapCSharp/Connection.cs
+++ b/Assets/Plugins/LeapMotion/Core/Plugins/LeapCSharp/Connection.cs
@@ -16,7 +16,30 @@ namespace LeapInternal {
   using Leap;
 
   public class Connection {
-    private static Dictionary<int, Connection> connectionDictionary = new Dictionary<int, Connection>();
+    public struct Key {
+      public readonly int connectionId;
+      public readonly string serverNamespace;
+
+      public Key(int connectionId, string serverNamespace = null) {
+        this.connectionId = connectionId;
+        this.serverNamespace = serverNamespace;
+      }
+    }
+
+    private static Dictionary<Key, Connection> connectionDictionary = new Dictionary<Key, Connection>();
+
+    public static Connection GetConnection(int connectionId = 0) {
+      return GetConnection(new Key(connectionId));
+    }
+
+    public static Connection GetConnection(Key connectionKey) {
+      Connection conn;
+      if (!Connection.connectionDictionary.TryGetValue(connectionKey, out conn)) {
+        conn = new Connection(connectionKey);
+        connectionDictionary.Add(connectionKey, conn);
+      }
+      return conn;
+    }
 
     //Left-right precalculated offsets
     private static long _handIdOffset;
@@ -31,16 +54,7 @@ namespace LeapInternal {
       _handOrientationOffset = Marshal.OffsetOf(typeof(LEAP_PALM), "orientation").ToInt64() + palmOffset;
     }
 
-    public static Connection GetConnection(int connectionKey = 0) {
-      Connection conn;
-      if (!connectionDictionary.TryGetValue(connectionKey, out conn)) {
-        conn = new Connection(connectionKey);
-        connectionDictionary.Add(connectionKey, conn);
-      }
-      return conn;
-    }
-
-    public int ConnectionKey { get; private set; }
+    public Key ConnectionKey { get; private set; }
     public CircularObjectBuffer<LEAP_TRACKING_EVENT> Frames { get; set; }
 
     private DeviceList _devices = new DeviceList();
@@ -130,7 +144,7 @@ namespace LeapInternal {
       Dispose(false);
     }
 
-    private Connection(int connectionKey) {
+    private Connection(Key connectionKey) {
       ConnectionKey = connectionKey;
       _leapConnection = IntPtr.Zero;
 
@@ -145,7 +159,17 @@ namespace LeapInternal {
 
       eLeapRS result;
       if (_leapConnection == IntPtr.Zero) {
-        result = LeapC.CreateConnection(out _leapConnection);
+        if (ConnectionKey.serverNamespace == null) {
+          result = LeapC.CreateConnection(out _leapConnection);
+        } else {
+          LEAP_CONNECTION_CONFIG config = new LEAP_CONNECTION_CONFIG();
+          config.size = (uint)Marshal.SizeOf(config);
+          config.flags = 0;
+          config.server_namespace = Marshal.StringToHGlobalAnsi(ConnectionKey.serverNamespace);
+          result = LeapC.CreateConnection(ref config, out _leapConnection);
+          Marshal.FreeHGlobal(config.server_namespace);
+        }
+
         if (result != eLeapRS.eLeapRS_Success || _leapConnection == IntPtr.Zero) {
           reportAbnormalResults("LeapC CreateConnection call was ", result);
           return;

--- a/Assets/Plugins/LeapMotion/Core/Plugins/LeapCSharp/Controller.cs
+++ b/Assets/Plugins/LeapMotion/Core/Plugins/LeapCSharp/Controller.cs
@@ -361,7 +361,7 @@ namespace Leap {
     /// 
     /// @since 1.0
     /// </summary>
-    public Controller() : this(0) { }
+    public Controller() : this(0, null) { }
 
     /// <summary>
     /// Constructs a Controller object using the specified connection key.
@@ -375,8 +375,8 @@ namespace Leap {
     /// Otherwise, a new connection is created.
     /// @since 3.0
     /// </summary>
-    public Controller(int connectionKey) {
-      _connection = Connection.GetConnection(connectionKey);
+    public Controller(int connectionKey, string serverNamespace = null) {
+      _connection = Connection.GetConnection(new Connection.Key(connectionKey, serverNamespace));
       _connection.EventContext = SynchronizationContext.Current;
 
       _connection.LeapInit += OnInit;

--- a/Assets/Plugins/LeapMotion/Core/Scripts/LeapServiceProvider.cs
+++ b/Assets/Plugins/LeapMotion/Core/Scripts/LeapServiceProvider.cs
@@ -88,6 +88,11 @@ namespace Leap.Unity {
     [SerializeField]
     protected bool _workerThreadProfiling = false;
 
+    [Tooltip("Which Leap Service API Endpoint to connect to.  This is configured on the service with the 'api_namespace' argument.")]
+    [SerializeField]
+    [EditTimeOnly]
+    protected string _serverNameSpace = "Leap Service";
+
     #endregion
 
     #region Internal Settings & Memory
@@ -463,7 +468,7 @@ namespace Leap.Unity {
         return;
       }
 
-      _leapController = new Controller();
+      _leapController = new Controller(0, _serverNameSpace);
       _leapController.Device += (s, e) => {
         if (_onDeviceSafe != null) {
           _onDeviceSafe(e.Device);

--- a/Assets/Plugins/LeapMotion/Core/Scripts/LeapXRServiceProvider.cs
+++ b/Assets/Plugins/LeapMotion/Core/Scripts/LeapXRServiceProvider.cs
@@ -39,8 +39,6 @@ namespace Leap.Unity {
       Transform
     }
 
-    [Header("Advanced")]
-
     [Tooltip("Allow manual adjustment of the Leap device's virtual offset and tilt. These "
            + "settings can be used to match the physical position and orientation of the "
            + "Leap Motion sensor on a tracked device it is mounted on (such as a VR "


### PR DESCRIPTION
This PR implements an internal feature which allows different versions of the service to be run and streamed into Unity simultaneously.

Once that's done, you can run the MultipleServiceExample in the root Unity directory.  It has two LeapXRServiceProviders preconfigured to stream data from the `v4` and `v5` server namespaces simultaneously.

Once we're ready to merge, I'll remove the example scene.