### PR TITLE
2020.1 Support

### DIFF
--- a/Assets/Plugins/LeapMotion/Core/Scripts/LeapXRServiceProvider.cs
+++ b/Assets/Plugins/LeapMotion/Core/Scripts/LeapXRServiceProvider.cs
@@ -236,6 +236,12 @@ namespace Leap.Unity {
         preCullCamera = GetComponent<Camera>();
       }
 
+      #if UNITY_2020_1_OR_NEWER
+      if (GetComponent<UnityEngine.SpatialTracking.TrackedPoseDriver>() == null) {
+        gameObject.AddComponent<UnityEngine.SpatialTracking.TrackedPoseDriver>().UseRelativeTransform = true;
+      }
+      #endif
+
       #if UNITY_2019_1_OR_NEWER
       if (GraphicsSettings.renderPipelineAsset != null) {
         RenderPipelineManager.beginCameraRendering -= onBeginRendering;

--- a/Assets/Plugins/LeapMotion/Core/Scripts/XR/XRHeightOffset.cs
+++ b/Assets/Plugins/LeapMotion/Core/Scripts/XR/XRHeightOffset.cs
@@ -118,7 +118,7 @@ namespace Leap.Unity {
             }
           }
 
-          if (recenterOnUserPresence && !XRSupportUtil.IsRoomScale()) {
+          if (recenterOnUserPresence && !XRSupportUtil.IsLargePlayspace()) {
             var userPresence = XRSupportUtil.IsUserPresent();
 
             if (_lastUserPresence != userPresence) {

--- a/Assets/Plugins/LeapMotion/Modules/GraphicRenderer/Scripts/RenderingMethods/LeapMesherBase.cs
+++ b/Assets/Plugins/LeapMotion/Modules/GraphicRenderer/Scripts/RenderingMethods/LeapMesherBase.cs
@@ -221,9 +221,11 @@ namespace Leap.Unity.GraphicalRenderer {
       SupportUtil.OnlySupportFirstFeature<LeapSpriteFeature>(info);
 
 #if UNITY_EDITOR
+      #if !UNITY_2020_1_OR_NEWER
       if (!Application.isPlaying) {
         Packer.RebuildAtlasCacheIfNeeded(EditorUserBuildSettings.activeBuildTarget);
       }
+      #endif
 
       for (int i = 0; i < features.Count; i++) {
         var feature = features[i];
@@ -375,7 +377,7 @@ namespace Leap.Unity.GraphicalRenderer {
         }
 
         if (_spriteFeatures.Count != 0) {
-#if UNITY_EDITOR
+#if UNITY_EDITOR && !UNITY_2020_1_OR_NEWER
           Packer.RebuildAtlasCacheIfNeeded(EditorUserBuildSettings.activeBuildTarget);
 #endif
           extractSpriteRects();


### PR DESCRIPTION
These code changes bring the UnityModules _package_ to full 2020.1 compatibility.

However there's a catch: the 2020.1 Oculus XR Package is not backwards compatible with the UnityModules _project_.

To ensure _project_ compatibility with prior versions of Unity, users of 2020.1 will need to install the OculusXR plugin manually via the package manager.