### PR TITLE
Connection stores an incorrect IntPtr to the Device

### DIFF
--- a/Assets/Plugins/LeapMotion/Core/Plugins/LeapCSharp/Connection.cs
+++ b/Assets/Plugins/LeapMotion/Core/Plugins/LeapCSharp/Connection.cs
@@ -453,7 +453,7 @@ namespace LeapInternal {
       result = LeapC.GetDeviceInfo(device, ref deviceInfo); //Query the serial
 
       if (result == eLeapRS.eLeapRS_Success) {
-        Device apiDevice = new Device(deviceHandle,
+        Device apiDevice = new Device(device,
                                deviceInfo.h_fov, //radians
                                deviceInfo.v_fov, //radians
                                deviceInfo.range / 1000.0f, //to mm


### PR DESCRIPTION
In Connection.cs, the IntPtr that get's stored in the Device class is incorrect, resulting in future GetDeviceInfo calls from within that class to have incorrect references.

Quick example:
Call LeapC.GetDeviceInfo(Handle, ref deviceInfo); from within Device.cs, it will always return a status code of 0.