### PR TITLE
[FEAT] Build Documentation with Github Actions

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -6,7 +6,7 @@ on:
 # Switch to this when ready to merge into master
 #  push:
 #    branches:
-#      - master
+#      - main
 #    paths:
 #      - docs/**
 
@@ -25,14 +25,14 @@ jobs:
       # Debug
       - name: Debug Print Current Directory
         run: |
-          ls
+          ls -l
         working-directory: .
 
       # Install Doxygen and Graphvis from Brew
       - name: Install doxygen and graphviz
         run: |
-          brew install doxygen
-          brew install graphviz
+          apt-get install doxygen=1.8.11
+          apt-get install graphviz
         working-directory: ./docs
 
       # Build the Doxygen Documentation
@@ -44,7 +44,7 @@ jobs:
       # Debug view the files in the html directory
       - name: Debug Print Built Files
         run: |
-          ls -R
+          ls -lR
         working-directory: ./docs/html
 
       # Upload the files in the html directory

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,0 +1,65 @@
+name: UnityModules - Build Docs
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+# Switch to this when ready to merge into master
+#  push:
+#    branches:
+#      - master
+#    paths:
+#      - docs/**
+
+jobs:
+  build:
+    name: Build Docs
+    runs-on: ubuntu-latest
+    steps:
+    
+      # Checkout
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          lfs: true
+
+      # Debug
+      - name: Debug Print Current Directory
+        run: |
+          ls
+        working-directory: .
+
+      # Install Doxygen and Graphvis from Brew
+      - name: Install doxygen and graphviz
+        run: |
+          brew install doxygen
+          brew install graphviz
+        working-directory: ./docs
+
+      # Build the Doxygen Documentation
+      - name: Build Documentation
+        run: |
+          doxygen
+        working-directory: ./docs
+
+      # Debug view the files in the html directory
+      - name: Debug Print Built Files
+        run: |
+          ls -R
+        working-directory: ./docs/html
+
+      # Upload the files in the html directory
+      - name: Debug Upload Documentation Artifacts
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }} # Even if the build exits with a failure code
+        with:
+          name: Documentation Build Artifacts
+          path: ./docs/html
+
+      ## Push the contents of the html directory to the gh-pages branch 
+      #- name: Deploy 🚀
+      #  uses: JamesIves/github-pages-deploy-action@3.6.1
+      #  with:
+      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is set by github, do not change.
+      #    BRANCH: gh-pages # The branch the action should deploy to.
+      #    FOLDER: .docs/html # The folder the action should deploy.
+      #    CLEAN: true # Automatically remove deleted files from the deploy branch

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -31,8 +31,8 @@ jobs:
       # Install Doxygen and Graphvis from Brew
       - name: Install doxygen and graphviz
         run: |
-          apt-get install doxygen=1.8.11
-          apt-get install graphviz
+          sudo apt-get install doxygen=1.8.11
+          sudo apt-get install graphviz
         working-directory: ./docs
 
       # Build the Doxygen Documentation

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -61,5 +61,5 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is set by github, do not change.
           BRANCH: gh-pages-temp # The branch the action should deploy to.
-          FOLDER: .docs/html # The folder the action should deploy.
+          FOLDER: ./docs/html # The folder the action should deploy.
           CLEAN: true # Automatically remove deleted files from the deploy branch

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -15,40 +15,42 @@ jobs:
     name: Build Docs
     runs-on: ubuntu-latest
     steps:
-    
-      # Checkout
-      - name: Checkout repository
+      - name: Checkout UnityModules
         uses: actions/checkout@v2
         with:
           lfs: true
 
-      # Debug
       - name: Debug Print Current Directory
         run: |
-          ls -l
+          ls
         working-directory: .
 
-      # Install Doxygen and Graphvis from Brew
-      - name: Install doxygen and graphviz
+      - name: Checkout Doxygen 1.8.11
         run: |
-          sudo apt-get install doxygen=1.8.13-10
+          git clone https://github.com/nickjbenson/doxygen-clone-1-8-11 --branch doxygen-1.8.11 doxygen
+        working-directory: .
+
+      - name: Build Doxygen 1.8.11
+        run: |
+          cmake .
+          make
+        working-directory: ./doxygen
+
+      - name: Install graphviz
+        run: |
           sudo apt-get install graphviz
+
+      - name: Run Doxygen 1.8.11 in docs folder
+        run: |
+          ../doxygen/bin/doxygen
         working-directory: ./docs
 
-      # Build the Doxygen Documentation
-      - name: Build Documentation
+      - name: (Debug) Print html build artifacts
         run: |
-          doxygen
-        working-directory: ./docs
-
-      # Debug view the files in the html directory
-      - name: Debug Print Built Files
-        run: |
-          ls -lR
+          ls -R
         working-directory: ./docs/html
 
-      # Upload the files in the html directory
-      - name: Debug Upload Documentation Artifacts
+      - name: (Debug) Upload html build artifacts
         uses: actions/upload-artifact@v2
         if: ${{ always() }} # Even if the build exits with a failure code
         with:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -31,7 +31,7 @@ jobs:
       # Install Doxygen and Graphvis from Brew
       - name: Install doxygen and graphviz
         run: |
-          sudo apt-get install doxygen=1.8.11
+          sudo apt-get install doxygen=1.8.13-10
           sudo apt-get install graphviz
         working-directory: ./docs
 

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -1,14 +1,9 @@
 name: UnityModules - Build Docs
 
 on:
-  pull_request:
-    types: [opened, synchronize]
-  # Switch to this when ready to merge into master
-  # push:
-  #   branches:
-  #     - main
-  #   paths:
-  #     - docs/**
+  push:
+    branches:
+      - main
 
 jobs:
   build:
@@ -62,6 +57,6 @@ jobs:
         uses: JamesIves/github-pages-deploy-action@3.6.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is set by github, do not change.
-          BRANCH: gh-pages-temp # The branch the action should deploy to.
+          BRANCH: gh-pages # The branch the action should deploy to.
           FOLDER: docs/html # The folder the action should deploy.
           CLEAN: true # Automatically remove deleted files from the deploy branch

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -55,11 +55,11 @@ jobs:
           name: Documentation Build Artifacts
           path: ./docs/html
 
-      ## Push the contents of the html directory to the gh-pages branch 
+      # Push the contents of the html directory to the gh-pages branch 
       - name: Deploy 🚀 - TEMP BRANCH
-       uses: JamesIves/github-pages-deploy-action@3.6.1
-       with:
-         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is set by github, do not change.
-         BRANCH: gh-pages-temp # The branch the action should deploy to.
-         FOLDER: .docs/html # The folder the action should deploy.
-         CLEAN: true # Automatically remove deleted files from the deploy branch
+        uses: JamesIves/github-pages-deploy-action@3.6.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is set by github, do not change.
+          BRANCH: gh-pages-temp # The branch the action should deploy to.
+          FOLDER: .docs/html # The folder the action should deploy.
+          CLEAN: true # Automatically remove deleted files from the deploy branch

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -61,5 +61,5 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is set by github, do not change.
           BRANCH: gh-pages-temp # The branch the action should deploy to.
-          FOLDER: ./docs/html # The folder the action should deploy.
+          FOLDER: docs/html # The folder the action should deploy.
           CLEAN: true # Automatically remove deleted files from the deploy branch

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -3,12 +3,12 @@ name: UnityModules - Build Docs
 on:
   pull_request:
     types: [opened, synchronize]
-# Switch to this when ready to merge into master
-#  push:
-#    branches:
-#      - main
-#    paths:
-#      - docs/**
+  # Switch to this when ready to merge into master
+  # push:
+  #   branches:
+  #     - main
+  #   paths:
+  #     - docs/**
 
 jobs:
   build:
@@ -56,10 +56,10 @@ jobs:
           path: ./docs/html
 
       ## Push the contents of the html directory to the gh-pages branch 
-      #- name: Deploy 🚀
-      #  uses: JamesIves/github-pages-deploy-action@3.6.1
-      #  with:
-      #    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is set by github, do not change.
-      #    BRANCH: gh-pages # The branch the action should deploy to.
-      #    FOLDER: .docs/html # The folder the action should deploy.
-      #    CLEAN: true # Automatically remove deleted files from the deploy branch
+      - name: Deploy 🚀 - TEMP BRANCH
+       uses: JamesIves/github-pages-deploy-action@3.6.1
+       with:
+         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This is set by github, do not change.
+         BRANCH: gh-pages-temp # The branch the action should deploy to.
+         FOLDER: .docs/html # The folder the action should deploy.
+         CLEAN: true # Automatically remove deleted files from the deploy branch


### PR DESCRIPTION
This PR will allow the UnityModules documentation to build automatically with each push to `main`'s docs folder.

(when ready to switch to prod, in theory just switch the section at the beginning, and uncomment the end).