### PR TITLE
[FIX] Fix Script Compatibility with Unity 2017.4

### DIFF
--- a/Assets/Plugins/LeapMotion/Core/Editor/LeapServiceProviderEditor.cs
+++ b/Assets/Plugins/LeapMotion/Core/Editor/LeapServiceProviderEditor.cs
@@ -202,10 +202,11 @@ namespace Leap.Unity {
       Handles.color = interactionZoneColor;
 
       Vector3 origin = target.transform.TransformPoint(controllerOffset);
-      getLocalGlobalPoint(-1, 1, 1, box_width, box_depth, box_radius, out Vector3 local_top_left, out Vector3 top_left);
-      getLocalGlobalPoint(1, 1, 1, box_width, box_depth, box_radius, out Vector3 local_top_right, out Vector3 top_right);
-      getLocalGlobalPoint(-1, 1, -1, box_width, box_depth, box_radius, out Vector3 local_bottom_left, out Vector3 bottom_left);
-      getLocalGlobalPoint(1, 1, -1, box_width, box_depth, box_radius, out Vector3 local_bottom_right, out Vector3 bottom_right);
+      Vector3 local_top_left, top_left, local_top_right, top_right, local_bottom_left, bottom_left, local_bottom_right, bottom_right;
+      getLocalGlobalPoint(-1, 1,  1, box_width, box_depth, box_radius, out local_top_left    , out top_left);
+      getLocalGlobalPoint( 1, 1,  1, box_width, box_depth, box_radius, out local_top_right   , out top_right);
+      getLocalGlobalPoint(-1, 1, -1, box_width, box_depth, box_radius, out local_bottom_left , out bottom_left);
+      getLocalGlobalPoint( 1, 1, -1, box_width, box_depth, box_radius, out local_bottom_right, out bottom_right);
 
       Handles.DrawAAPolyLine(origin, top_left);
       Handles.DrawAAPolyLine(origin, top_right);

--- a/Assets/Plugins/LeapMotion/Core/Plugins/LeapCSharp/Device.cs
+++ b/Assets/Plugins/LeapMotion/Core/Plugins/LeapCSharp/Device.cs
@@ -8,8 +8,7 @@
 
 namespace Leap {
   using System;
-    using System.Data;
-    using LeapInternal;
+  using LeapInternal;
 
   /// <summary>
   /// The Device class represents a physically connected device.

--- a/Assets/Plugins/LeapMotion/Core/Scripts/Geometry/Shapes/Box.cs
+++ b/Assets/Plugins/LeapMotion/Core/Scripts/Geometry/Shapes/Box.cs
@@ -118,20 +118,20 @@ namespace Leap.Unity.Geometry {
       divisions = Mathf.Max(1, divisions);
       var frac = 1f / divisions;
 
-      drawDividedLines(draw: drawLineFunc, step: frac, corner000, corner100);
-      drawDividedLines(draw: drawLineFunc, step: frac, corner000, corner010);
-      drawDividedLines(draw: drawLineFunc, step: frac, corner110, corner100);
-      drawDividedLines(draw: drawLineFunc, step: frac, corner110, corner010);
+      drawDividedLines(draw: drawLineFunc, step: frac, a: corner000, b: corner100);
+      drawDividedLines(draw: drawLineFunc, step: frac, a: corner000, b: corner010);
+      drawDividedLines(draw: drawLineFunc, step: frac, a: corner110, b: corner100);
+      drawDividedLines(draw: drawLineFunc, step: frac, a: corner110, b: corner010);
 
-      drawDividedLines(draw: drawLineFunc, step: frac, corner000, corner001);
-      drawDividedLines(draw: drawLineFunc, step: frac, corner100, corner101);
-      drawDividedLines(draw: drawLineFunc, step: frac, corner010, corner011);
-      drawDividedLines(draw: drawLineFunc, step: frac, corner110, corner111);
+      drawDividedLines(draw: drawLineFunc, step: frac, a: corner000, b: corner001);
+      drawDividedLines(draw: drawLineFunc, step: frac, a: corner100, b: corner101);
+      drawDividedLines(draw: drawLineFunc, step: frac, a: corner010, b: corner011);
+      drawDividedLines(draw: drawLineFunc, step: frac, a: corner110, b: corner111);
 
-      drawDividedLines(draw: drawLineFunc, step: frac, corner001, corner101);
-      drawDividedLines(draw: drawLineFunc, step: frac, corner001, corner011);
-      drawDividedLines(draw: drawLineFunc, step: frac, corner111, corner101);
-      drawDividedLines(draw: drawLineFunc, step: frac, corner111, corner011);
+      drawDividedLines(draw: drawLineFunc, step: frac, a: corner001, b: corner101);
+      drawDividedLines(draw: drawLineFunc, step: frac, a: corner001, b: corner011);
+      drawDividedLines(draw: drawLineFunc, step: frac, a: corner111, b: corner101);
+      drawDividedLines(draw: drawLineFunc, step: frac, a: corner111, b: corner011);
     }
 
     private void drawDividedLines(System.Action<Vector3, Vector3> draw,

--- a/Assets/Plugins/LeapMotion/Core/Scripts/Geometry/Shapes/Rect.cs
+++ b/Assets/Plugins/LeapMotion/Core/Scripts/Geometry/Shapes/Rect.cs
@@ -271,10 +271,10 @@ namespace Leap.Unity.Geometry {
       divisions = Mathf.Max(1, divisions);
       if (divisions > 1) {
         var frac = 1 / divisions;
-        drawDividedLines(drawLineFunc, step: frac, a, b);
-        drawDividedLines(drawLineFunc, step: frac, b, c);
-        drawDividedLines(drawLineFunc, step: frac, c, d);
-        drawDividedLines(drawLineFunc, step: frac, d, a);
+        drawDividedLines(drawLineFunc, step: frac, a: a, b: b);
+        drawDividedLines(drawLineFunc, step: frac, a: b, b: c);
+        drawDividedLines(drawLineFunc, step: frac, a: c, b: d);
+        drawDividedLines(drawLineFunc, step: frac, a: d, b: a);
       }
       else {
         drawLineFunc(a, b);
@@ -315,10 +315,10 @@ namespace Leap.Unity.Geometry {
       int numRectLines = 8;
       for (int i = 0; i < numRectLines; i++) {
         var shrinkMul = (Vector2.one - shrink.CompMul(invRadii) * i);
-        drawer.DrawLine(a * shrinkMul, b * shrinkMul);
-        drawer.DrawLine(b * shrinkMul, c * shrinkMul);
-        drawer.DrawLine(c * shrinkMul, d * shrinkMul);
-        drawer.DrawLine(d * shrinkMul, a * shrinkMul);
+        drawer.DrawLine(shrinkMul.CompMul(a), shrinkMul.CompMul(b));
+        drawer.DrawLine(shrinkMul.CompMul(b), shrinkMul.CompMul(c));
+        drawer.DrawLine(shrinkMul.CompMul(c), shrinkMul.CompMul(d));
+        drawer.DrawLine(shrinkMul.CompMul(d), shrinkMul.CompMul(a));
       }
 
       drawer.DrawLine(a, c);

--- a/Assets/Plugins/LeapMotion/Core/Scripts/LeapServiceProvider.cs
+++ b/Assets/Plugins/LeapMotion/Core/Scripts/LeapServiceProvider.cs
@@ -176,7 +176,8 @@ namespace Leap.Unity {
       = new Dictionary<TestHandFactory.TestHandPose, Hand>();
     private Hand _editTimeLeftHand {
       get {
-        if (_cachedLeftHands.TryGetValue(editTimePose, out Hand cachedHand)) {
+        Hand cachedHand = null;
+        if (_cachedLeftHands.TryGetValue(editTimePose, out cachedHand)) {
           return cachedHand;
         }
         else {
@@ -191,7 +192,8 @@ namespace Leap.Unity {
       = new Dictionary<TestHandFactory.TestHandPose, Hand>();
     private Hand _editTimeRightHand {
       get {
-        if (_cachedRightHands.TryGetValue(editTimePose, out Hand cachedHand)) {
+        Hand cachedHand = null;
+        if (_cachedRightHands.TryGetValue(editTimePose, out cachedHand)) {
           return cachedHand;
         }
         else {

--- a/Assets/Plugins/LeapMotion/Core/Scripts/Utils/DisconnectionNotice.cs
+++ b/Assets/Plugins/LeapMotion/Core/Scripts/Utils/DisconnectionNotice.cs
@@ -34,14 +34,16 @@ namespace Leap.Unity{
     private Controller leap_controller_;
     private float fadedIn = 0.0f;
     private int frames_disconnected_ = 0;
+    private UnityEngine.UI.Image _image;
   
     void Start() {
       leap_controller_ = new Controller();
+      if (_image == null) { _image = GetComponent<UnityEngine.UI.Image>(); }
       SetAlpha(0.0f);
     }
   
     void SetAlpha(float alpha) {
-      GetComponent<UnityEngine.UI.Image>().color = Color.Lerp(Color.clear, onColor, alpha);
+      if (_image != null) { _image.color = Color.Lerp(Color.clear, onColor, alpha); }
     }
   
     /** The connection state of the controller. */

--- a/Assets/Plugins/LeapMotion/Core/Scripts/Utils/Drawer.cs
+++ b/Assets/Plugins/LeapMotion/Core/Scripts/Utils/Drawer.cs
@@ -122,7 +122,8 @@ namespace Leap.Unity {
         #if UNITY_EDITOR
         var origM = UnityEditor.Handles.matrix;
         var origColor = UnityEditor.Handles.color;
-        Color.RGBToHSV(origColor, out float h, out float s, out float v);
+        float h, s, v;
+        Color.RGBToHSV(origColor, out h, out s, out v);
         UnityEditor.Handles.color = origColor.WithHSV(h, s * 1f, v * 3f);
         UnityEditor.Handles.matrix = m;
         // UnityEditor.Handles.SphereHandleCap

--- a/Assets/Plugins/LeapMotion/Core/Scripts/Utils/Utils.cs
+++ b/Assets/Plugins/LeapMotion/Core/Scripts/Utils/Utils.cs
@@ -350,7 +350,7 @@ namespace Leap.Unity {
     public static List<T> RequireLen<T>(ref List<T> list, int length) {
       list = Require(ref list);
       list.Clear();
-      while (list.Count < length) { list.Add(default); }
+      while (list.Count < length) { list.Add(default(T)); }
       return list;
     }
 
@@ -1035,7 +1035,7 @@ namespace Leap.Unity {
         UnityEditor.PrefabUtility.GetPrefabInstanceStatus(obj) == UnityEditor.PrefabInstanceStatus.NotAPrefab;
       #else
       // Before 2018.3, use GetPrefabType.
-      return PrefabUtility.GetPrefabType(obj) == PrefabType.Prefab;
+      return UnityEditor.PrefabUtility.GetPrefabType(obj) == UnityEditor.PrefabType.Prefab;
       #endif
       #else
       return false;

--- a/Assets/Plugins/LeapMotion/Internal/Package/BuildDefinition.cs
+++ b/Assets/Plugins/LeapMotion/Internal/Package/BuildDefinition.cs
@@ -52,7 +52,9 @@ namespace Leap.Unity.Packaging {
 
     [System.Serializable]
     public struct BuildPlayerSettings {
+      #if UNITY_2018_3_OR_NEWER
       public FullScreenMode fullScreenMode;
+      #endif
       public int defaultScreenWidth;
       public int defaultScreenHeight;
       public bool resizableWindow;
@@ -61,7 +63,9 @@ namespace Leap.Unity.Packaging {
       #endif
       public static BuildPlayerSettings Default() {
         return new BuildPlayerSettings() {
+          #if UNITY_2018_3_OR_NEWER
           fullScreenMode = FullScreenMode.Windowed,
+          #endif
           defaultScreenWidth = 800,
           defaultScreenHeight = 500,
           resizableWindow = true,
@@ -166,7 +170,9 @@ namespace Leap.Unity.Packaging {
           getFileSuffix(target);
         
         if (_useSpecificPlayerSettings) {
+          #if UNITY_2018_3_OR_NEWER
           var origFullscreenMode = PlayerSettings.fullScreenMode;
+          #endif
           var origDefaultWidth = PlayerSettings.defaultScreenWidth;
           var origDefaultHeight = PlayerSettings.defaultScreenHeight;
           var origResizableWindow = PlayerSettings.resizableWindow;
@@ -174,7 +180,9 @@ namespace Leap.Unity.Packaging {
           var origResDialogSetting = PlayerSettings.displayResolutionDialog;
           #endif
           try {
+            #if UNITY_2018_3_OR_NEWER
             PlayerSettings.fullScreenMode = _playerSettings.fullScreenMode;
+            #endif
             PlayerSettings.defaultScreenWidth = _playerSettings.defaultScreenWidth;
             PlayerSettings.defaultScreenHeight =
             _playerSettings.defaultScreenHeight;
@@ -189,7 +197,9 @@ namespace Leap.Unity.Packaging {
             callPostBuildExtensions(fullBuildPath, crashWithCodeOnFail);
           }
           finally {
+            #if UNITY_2018_3_OR_NEWER
             PlayerSettings.fullScreenMode = origFullscreenMode;
+            #endif
             PlayerSettings.defaultScreenWidth = origDefaultWidth;
             PlayerSettings.defaultScreenHeight = origDefaultHeight;
             PlayerSettings.resizableWindow = origResizableWindow;

--- a/Assets/Plugins/LeapMotion/Legacy/GraphicRenderer/Scripts/LeapGraphicGroup.cs
+++ b/Assets/Plugins/LeapMotion/Legacy/GraphicRenderer/Scripts/LeapGraphicGroup.cs
@@ -24,7 +24,7 @@ namespace Leap.Unity.GraphicalRenderer {
 
     #region INSPECTOR FIELDS
     [SerializeField]
-    private string _groupName = default;
+    private string _groupName = default(string);
 
     [SerializeField]
     private RenderingMethodReference _renderingMethod = new RenderingMethodReference();
@@ -44,7 +44,7 @@ namespace Leap.Unity.GraphicalRenderer {
     private List<SupportInfo> _supportInfo = new List<SupportInfo>();
 
     [SerializeField, HideInInspector]
-    private bool _addRemoveSupported = default;
+    private bool _addRemoveSupported = default(bool);
 
     private HashSet<LeapGraphic> _toAttach = new HashSet<LeapGraphic>();
     private HashSet<LeapGraphic> _toDetach = new HashSet<LeapGraphic>();

--- a/Assets/Plugins/LeapMotion/Legacy/GraphicRenderer/Scripts/RenderingMethods/LeapMesherBase.cs
+++ b/Assets/Plugins/LeapMotion/Legacy/GraphicRenderer/Scripts/RenderingMethods/LeapMesherBase.cs
@@ -135,7 +135,7 @@ namespace Leap.Unity.GraphicalRenderer {
 
     //#### Sprite/Texture Remapping ####
     [SerializeField]
-    private AtlasUvs _atlasUvs = default;
+    private AtlasUvs _atlasUvs = default(AtlasUvs);
     [NonSerialized]
     protected MaterialPropertyBlock _spriteTextureBlock;
 

--- a/Assets/Plugins/LeapMotion/Legacy/GraphicRenderer/Scripts/RenderingMethods/LeapTextRenderer.cs
+++ b/Assets/Plugins/LeapMotion/Legacy/GraphicRenderer/Scripts/RenderingMethods/LeapTextRenderer.cs
@@ -26,7 +26,7 @@ namespace Leap.Unity.GraphicalRenderer {
     public const float SCALE_CONSTANT = 0.001f;
 
     [EditTimeOnly, SerializeField]
-    private Font _font = default;
+    private Font _font = default(Font);
 
     [EditTimeOnly, SerializeField]
     private float _dynamicPixelsPerUnit = 1.0f;
@@ -39,7 +39,7 @@ namespace Leap.Unity.GraphicalRenderer {
 
     [Header("Rendering Settings")]
     [EditTimeOnly, SerializeField]
-    private Shader _shader = default;
+    private Shader _shader = default(Shader);
 
     [EditTimeOnly, SerializeField]
     private float _scale = 1f;


### PR DESCRIPTION
The Unity Visualizer is built in Jenkins with Unity 2017.4; this PR fixes the Script-based incompatibilities with Unity 2017.4 (and presumably the versions of 2018.x in-between).

This PR does not attempt to address the Prefab and Scene Serialization issues with 2017.4 (which may still cause problems when building the Unity Visualizer).   To properly deal with these, we will probably need to update the version of Unity used in Jenkins (to 2019.2 or so).