### PR TITLE
[DEPRECATE] Graphic Renderer in the Documentation

### DIFF
--- a/docs/content/000-Getting-Started.md
+++ b/docs/content/000-Getting-Started.md
@@ -27,8 +27,6 @@ For more details on upgrading modules, or if your project already contains older
   
 [Blocks]: https://www.youtube.com/watch?v=oZ_53T2jBGg "Leap Motion Blocks Demo"
 
-- With the @ref graphic-renderer, you can **render an entire curved, 3D, dynamic interface in 1-3 draw calls**. The Graphic Renderer can be used in tandem with the Interaction Engine; see @ref gr-plus-ie for details and a link to an example project.
-
 - The @ref hands-module provides the tools you need to rig your 3D hand assets to work with Leap hands, including the powerful @ref #hands-auto-rigging-tool.
 
 # Troubleshooting {#troubleshooting}

--- a/docs/content/600-Deprecated-Modules.md
+++ b/docs/content/600-Deprecated-Modules.md
@@ -30,4 +30,4 @@ These modules are **still compatible** as of Core 4.3.0, but may become unsuppor
 
   The Graphic Renderer was deprecated in 4.6.0 because its primary function (drawcall batching) is not necessary on desktop-class GPUs (our primary supported platform), and Unity updates since its initial release have incrementally subsumed or broken underlying functionality.
 
-[graphic-renderer]: https://leapmotion.github.io/UnityModules/graphic-renderer.html "(Deprecated) Graphic Renderer"
+[graphic-renderer]: https://developer.leapmotion.com/releases/graphic-renderer-013 "(Deprecated) Graphic Renderer"

--- a/docs/content/600-Deprecated-Modules.md
+++ b/docs/content/600-Deprecated-Modules.md
@@ -28,6 +28,6 @@ These modules are **still compatible** as of Core 4.3.0, but may become unsuppor
 
 - [Graphic Renderer 0.1.3][graphic-renderer]
 
-  The Graphic Renderer was deprecated in 4.6.0 because its primary function (drawcall batching) is not necessary on desktop-class GPUs (our primary supported platform), and Unity updates since its initial release have incrementally subsumed or broken underlying functionality.
+  The Graphic Renderer was deprecated in 4.6.0 because its primary function (draw-call batching) is not necessary on desktop-class GPUs, which is currently our primary supported platform. Additionally, other tools for mobile UI optimization have matured since its inception, and Unity updates since its initial release have incrementally subsumed or broken its underlying functionality.
 
 [graphic-renderer]: https://developer.leapmotion.com/releases/graphic-renderer-013 "(Deprecated) Graphic Renderer"

--- a/docs/content/600-Deprecated-Modules.md
+++ b/docs/content/600-Deprecated-Modules.md
@@ -25,3 +25,9 @@ These modules are **still compatible** as of Core 4.3.0, but may become unsuppor
   The examples in this module demonstrate scripts in Core that have been deprecated and removed in a future Core release, since most of their functionalities have been superseded by more recent Modules or Core features.
 
 [detection-utilities]: https://developer.leapmotion.com/releases/detection-examples-104 "(Deprecated) Detection Utilities"
+
+- [Graphic Renderer 0.1.3][graphic-renderer]
+
+  The Graphic Renderer was deprecated in 4.6.0 because its primary function (drawcall batching) is not necessary on desktop-class GPUs (our primary supported platform), and Unity updates since its initial release have incrementally subsumed or broken underlying functionality.
+
+[graphic-renderer]: https://leapmotion.github.io/UnityModules/graphic-renderer.html "(Deprecated) Graphic Renderer"

--- a/docs/content/650-Graphic-Renderer.md
+++ b/docs/content/650-Graphic-Renderer.md
@@ -1,5 +1,9 @@
 # (Deprecated) Graphic Renderer {#graphic-renderer}
 
+Deprecation Notice
+-------
+<ins><b>This module is deprecated as of October 6th, 2020. It should still function with Core version 4.4.0 and Unity 2019 versions but future support may degrade.</b></ins>
+
 Introduction
 -------
 

--- a/docs/content/650-Graphic-Renderer.md
+++ b/docs/content/650-Graphic-Renderer.md
@@ -1,4 +1,4 @@
-# Graphic Renderer {#graphic-renderer}
+# (Deprecated) Graphic Renderer {#graphic-renderer}
 
 Introduction
 -------


### PR DESCRIPTION
At the request of Chris Burgess, this PR moves the Graphic Renderer's Documentation sub-heading beneath the Deprecated Modules subheading, and adds a short blurb about why the Graphic Renderer was deprecated at the request.

![image](https://user-images.githubusercontent.com/174475/108791736-a90eca00-7534-11eb-917d-8beadf75f795.png)
