### PR TITLE
removed obsolete enum SelectionMode.OnlyUserModifiable from Hotkeys.cs

### DIFF
--- a/Assets/Plugins/LeapMotion/Core/Editor/Hotkeys.cs
+++ b/Assets/Plugins/LeapMotion/Core/Editor/Hotkeys.cs
@@ -21,7 +21,7 @@ namespace Leap.Unity {
         return;
       }
 
-      GameObject[] objs = Selection.GetFiltered<GameObject>(SelectionMode.ExcludePrefab | SelectionMode.OnlyUserModifiable | SelectionMode.Editable);
+      GameObject[] objs = Selection.GetFiltered<GameObject>(SelectionMode.ExcludePrefab | SelectionMode.Editable);
       if (objs.Length == 0) {
         return;
       }
@@ -103,7 +103,7 @@ namespace Leap.Unity {
         return;
       }
 
-      GameObject[] objs = Selection.GetFiltered<GameObject>(SelectionMode.ExcludePrefab | SelectionMode.OnlyUserModifiable | SelectionMode.Editable);
+      GameObject[] objs = Selection.GetFiltered<GameObject>(SelectionMode.ExcludePrefab | SelectionMode.Editable);
       foreach (var obj in objs) {
         Undo.RecordObject(obj.transform, "Cleared transform for " + obj.name + ".");
         obj.transform.localPosition = Vector3.zero;
@@ -118,7 +118,7 @@ namespace Leap.Unity {
         return;
       }
 
-      GameObject[] objs = Selection.GetFiltered<GameObject>(SelectionMode.ExcludePrefab | SelectionMode.OnlyUserModifiable | SelectionMode.Editable);
+      GameObject[] objs = Selection.GetFiltered<GameObject>(SelectionMode.ExcludePrefab | SelectionMode.Editable);
       foreach (var obj in objs) {
         Undo.RecordObject(obj.transform, "Cleared local position and rotation for " + obj.name + ".");
         obj.transform.localPosition = Vector3.zero;


### PR DESCRIPTION
Hi,
reason for this PR is that importing Core modules into Unity version 2021.1.9f1 causes script compilation errors due to obsolete enum "SelectionMode.OnlyUserModifiable". I found out that it has been made obsolete at least since 2011 [source](https://forum.unity.com/threads/the-value-of-selectionmode-onlyusermodifiable-can-not-find-the-reference.113964/)