### PR TITLE
Add timeout on thread join on shutdown and suppress ThreadAbortException

### DIFF
--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 [docs-website]: https://docs.ultraleap.com/unity-api/ "Ultraleap Docs"
 
+## NEXT
+
+### Fixed
+- Fixed an issue with ThreadAbortExceptions being raised during normal shutdown.
+
 ## [7.3.0] - 25/02/2026
 
 ### Added

--- a/Packages/Tracking/CHANGELOG.md
+++ b/Packages/Tracking/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed an issue with ThreadAbortExceptions being raised during normal shutdown.
+- Fixed some deprecated API usage of `Physics.autoSyncTransforms` and `XRStats.TryGetGPUTimeLastFrame` in Unity 6.3+.
 
 ## [7.3.0] - 25/02/2026
 

--- a/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/Connection.cs
+++ b/Packages/Tracking/Core/Runtime/Plugins/LeapCSharp/Connection.cs
@@ -17,6 +17,8 @@ namespace LeapInternal
 
     public class Connection
     {
+        private const uint DEFAULT_TIMEOUT_MILLISECONDS = 150;
+
         public struct Key
         {
             public readonly int connectionId;
@@ -272,7 +274,9 @@ namespace LeapInternal
             //before trying to join the worker thread.
             LeapC.CloseConnection(_leapConnection);
 
-            _polster.Join();
+            //Using a timeout for Join() to prevent the application from hanging
+            //if the worker thread does not exit quickly during shutdown.
+            _polster.Join((int)DEFAULT_TIMEOUT_MILLISECONDS);
         }
 
         /// <summary>
@@ -308,9 +312,7 @@ namespace LeapInternal
                     }
 
                     LEAP_CONNECTION_MESSAGE _msg = new LEAP_CONNECTION_MESSAGE();
-                    uint timeout = 150;
-
-                    result = LeapC.PollConnection(_leapConnection, timeout, ref _msg);
+                    result = LeapC.PollConnection(_leapConnection, DEFAULT_TIMEOUT_MILLISECONDS, ref _msg);
 
                     if (result != eLeapRS.eLeapRS_Success)
                     {
@@ -406,6 +408,11 @@ namespace LeapInternal
                         LeapEndProfilingBlock(new EndProfilingBlockArgs(HANDLE_EVENT_PROFILER_BLOCK));
                     }
                 } //while running
+            }
+            catch (ThreadAbortException)
+            {
+                // Handle thread abort gracefully without logging as this can occur under normal circumstances.
+                _isRunning = false;
             }
             catch (Exception e)
             {
@@ -1031,12 +1038,11 @@ namespace LeapInternal
             }
 
             LEAP_CONNECTION_MESSAGE _msg = new LEAP_CONNECTION_MESSAGE();
-            uint timeout = 150;
-            result = LeapC.PollConnection(tempConnection, timeout, ref _msg);
+            LeapC.PollConnection(tempConnection, DEFAULT_TIMEOUT_MILLISECONDS, ref _msg);
 
             LEAP_CONNECTION_INFO pInfo = new LEAP_CONNECTION_INFO();
             pInfo.size = (uint)Marshal.SizeOf(pInfo);
-            result = LeapC.GetConnectionInfo(tempConnection, ref pInfo);
+            LeapC.GetConnectionInfo(tempConnection, ref pInfo);
 
             if (pInfo.status == eLeapConnectionStatus.eLeapConnectionStatus_Connected)
             {


### PR DESCRIPTION
## Summary

The timeout on the thread join matches the maximum amount of time that should be spent on a PollConnection anyway, before the thread is aborted. ThreadAbortExceptions are now explicity caught and suppressed without logging to avoid erroneous log messages in normal operation.

## Contributor Tasks

- [x] Add a CHANGELOG entry for this change.
- [x] Ensure documentation requirements are met e.g., public API is commented.
- [x] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.

## Reviewer Tasks

- [ ] Code reviewed.
- [ ] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] All tests must be ran and cover all scenarios (If not, add new tests to the cycle and run them).
- [ ] Documentation has been reviewed.
- [ ] Approve with a comment of any additional tests run or any observations.

## Related Issues

This should hopefully resolve https://github.com/ultraleap/UnityPlugin/issues/1708

