### PR TITLE
Fix some Unity 6.3 deprecation warnings

### DIFF
--- a/Packages/Tracking/Core/Runtime/Scripts/Utils/XRSupportUtil.cs
+++ b/Packages/Tracking/Core/Runtime/Scripts/Utils/XRSupportUtil.cs
@@ -186,9 +186,27 @@ namespace Leap
 
         public static float GetGPUTime()
         {
+#if UNITY_6000_3_OR_NEWER
+            var displaySubsystems = new List<XRDisplaySubsystem>();
+            SubsystemManager.GetSubsystems(displaySubsystems);
+
+            foreach (XRDisplaySubsystem displaySubsystem in displaySubsystems)
+            {
+                if (displaySubsystem != null &&
+                    displaySubsystem.running &&
+                    displaySubsystem.TryGetAppGPUTimeLastFrame(
+                        out float gpuTime))
+                {
+                    return gpuTime;
+                }
+            }
+
+            return 0f;
+#else
             float gpuTime = 0f;
             XRStats.TryGetGPUTimeLastFrame(out gpuTime);
             return gpuTime;
+#endif
         }
 
         public static string GetLoadedDeviceName()

--- a/Packages/Tracking/Physical Hands/Runtime/Scripts/Misc/GrabBall.cs
+++ b/Packages/Tracking/Physical Hands/Runtime/Scripts/Misc/GrabBall.cs
@@ -84,6 +84,9 @@ namespace Leap.PhysicalHands
 
         private void Start()
         {
+#if !UNITY_6000_3_OR_NEWER
+            // This was deprecated in Unity 6, but only warns on our usage of it
+            // in version 6.3+.
             if (Physics.autoSyncTransforms)
             {
                 Debug.LogWarning(
@@ -92,6 +95,7 @@ namespace Leap.PhysicalHands
                 + "move a parent transform. You can modify this setting in "
                 + "Edit->Project Settings->Physics.");
             }
+#endif
 
             _head = Camera.main.transform;
 


### PR DESCRIPTION
This fixes some deprecation warnings around `Physics.autoSyncTransforms` and `XRStats.TryGetGPUTimeLastFrame`.